### PR TITLE
Fix HTTP Links to HTTPS

### DIFF
--- a/PureBasicDebugger/DebugOutput.pb
+++ b/PureBasicDebugger/DebugOutput.pb
@@ -91,8 +91,8 @@ Procedure DebugWindowEvents(*Debugger.DebuggerData, EventID)
   
   If EventID = #PB_Event_ActivateWindow
     CompilerIf #CompileWindows
-      ; to 'fix' a weird bug: http://www.purebasic.fr/english/viewtopic.php?f=4&t=66634
-      ; NOTE: doesn't work as it breaks the IDE: http://www.purebasic.fr/english/viewtopic.php?f=4&t=69031
+      ; to 'fix' a weird bug: https://www.purebasic.fr/english/viewtopic.php?f=4&t=66634
+      ; NOTE: doesn't work as it breaks the IDE: https://www.purebasic.fr/english/viewtopic.php?f=4&t=69031
       ; SetActiveGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Debug_List])
     CompilerEndIf
     
@@ -340,7 +340,7 @@ Procedure UpdateDebugOutputWindow(*Debugger.DebuggerData)
     
     CompilerIf #CompileMac
       ; Scroll the editor gadget to the bottom
-      ; This function is very very slow, that's why we defer it (http://www.purebasic.fr/english/viewtopic.php?f=24&t=55924)
+      ; This function is very very slow, that's why we defer it (https://www.purebasic.fr/english/viewtopic.php?f=24&t=55924)
       Range.NSRange\location = CocoaMessage(0, CocoaMessage(0, GadgetID(Gadget), "string"), "length") - 1
       Range\length = 1
       CocoaMessage(0, GadgetID(Gadget), "scrollRangeToVisible:@", @Range);

--- a/PureBasicDebugger/PureBasic.asm
+++ b/PureBasicDebugger/PureBasic.asm
@@ -752,7 +752,7 @@ PureBasicStart:
 ; 
 ; CompilerIf #SpiderBasic
 ; #ProductName$ = "PureBasic"
-; #ProductWebSite$ = "http://www.purebasic.com"
+; #ProductWebSite$ = "https://www.purebasic.com"
 ; 
 ; #SourceFileExtension  = ".pb"
 ; #IncludeFileExtension = ".pbi"

--- a/PureBasicDebugger/Standalone_ScintillaStuff.pb
+++ b/PureBasicDebugger/Standalone_ScintillaStuff.pb
@@ -57,7 +57,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
           EndIf
         Until *Cursor = 0
         
-        ; Another special case: *#CONSTANT (http://www.purebasic.fr/english/viewtopic.php?f=4&t=40104)
+        ; Another special case: *#CONSTANT (https://www.purebasic.fr/english/viewtopic.php?f=4&t=40104)
         *NextCharacter.Character = *WordStart+#CharSize
         If *WordStart\c = '*' And *NextCharacter\c = '#'
           *WordStart+1

--- a/PureBasicDebugger/VariableDebug.pb
+++ b/PureBasicDebugger/VariableDebug.pb
@@ -960,7 +960,7 @@ Procedure OpenVariableWindow(*Debugger.DebuggerData)
       VariableWindowEvents(*Debugger, #PB_Event_SizeWindow)
       
       CompilerIf #CompileLinux
-        FlushEvents() ; Flush the events to finish window creation/resize or SetGadgetState() could fail on linux: http://www.purebasic.fr/english/viewtopic.php?f=23&t=48589
+        FlushEvents() ; Flush the events to finish window creation/resize or SetGadgetState() could fail on linux: https://www.purebasic.fr/english/viewtopic.php?f=23&t=48589
       CompilerEndIf
       
       Height = GetPanelHeight(*Debugger\Gadgets[#DEBUGGER_GADGET_Variable_Panel])

--- a/PureBasicIDE/CompilerFlags.pb
+++ b/PureBasicIDE/CompilerFlags.pb
@@ -51,7 +51,7 @@ CompilerEndIf
 
 CompilerIf #SpiderBasic
   #ProductName$ = "SpiderBasic"
-  #ProductWebSite$ = "http://www.spiderbasic.com"
+  #ProductWebSite$ = "https://www.spiderbasic.com"
   
   #SourceFileExtension  = ".sb"
   #IncludeFileExtension = ".sbi"
@@ -61,7 +61,7 @@ CompilerIf #SpiderBasic
   #CatalogFileIDE = "SB_IDE"
 CompilerElse
   #ProductName$ = "PureBasic"
-  #ProductWebSite$ = "http://www.purebasic.com"
+  #ProductWebSite$ = "https://www.purebasic.com"
   
   #SourceFileExtension  = ".pb"
   #IncludeFileExtension = ".pbi"
@@ -284,7 +284,7 @@ CompilerSelect #PB_Compiler_OS
     #DEFAULT_FunctionFile       = "pbfunctions.txt"  ; related to Temp$ path
     #DEFAULT_ApiFile            = "compilers/apifunctions.txt" ; related to PB path
     
-    #DEFAULT_NewLineType        = 1 ; lf (on OS X, the norm is now lf, no more 'cr' http://www.purebasic.fr/english/viewtopic.php?f=24&t=55391)
+    #DEFAULT_NewLineType        = 1 ; lf (on OS X, the norm is now lf, no more 'cr' https://www.purebasic.fr/english/viewtopic.php?f=24&t=55391)
     #DEFAULT_DLLExtension       = "so"
     
     #DEFAULT_ImageBorder        = 0 ; for colorpicker

--- a/PureBasicIDE/CompilerInterface.pb
+++ b/PureBasicIDE/CompilerInterface.pb
@@ -1607,7 +1607,7 @@ Procedure CompilerCleanup()
       EndIf
     CompilerEndIf
     
-    ; Do custom constants. All constants are written in UTF-8 format to preserve complex string value (http://www.purebasic.fr/english/viewtopic.php?f=4&t=63159&sid=0f541e4670f96083c28f005df6f8d2b7)
+    ; Do custom constants. All constants are written in UTF-8 format to preserve complex string value (https://www.purebasic.fr/english/viewtopic.php?f=4&t=63159&sid=0f541e4670f96083c28f005df6f8d2b7)
     ;
     For i = 0 To *Target\NbConstants-1
       If *Target\ConstantEnabled[i]
@@ -1638,7 +1638,7 @@ Procedure CompilerCleanup()
         ;
         equal = FindString(Constant$, "=", 1)
         If equal > 0
-          Constant$ = Trim(RemoveString(Left(Constant$, equal-1), "#")) + "=" + Trim(LTrim(Right(Constant$, Len(Constant$)-equal)), #DQUOTE$) ; Also remove the "" around, as expected by the compiler (http://www.purebasic.fr/english/viewtopic.php?f=4&t=59430)
+          Constant$ = Trim(RemoveString(Left(Constant$, equal-1), "#")) + "=" + Trim(LTrim(Right(Constant$, Len(Constant$)-equal)), #DQUOTE$) ; Also remove the "" around, as expected by the compiler (https://www.purebasic.fr/english/viewtopic.php?f=4&t=59430)
           
           CompilerWrite("CONSTANT"+Chr(9)+Constant$, #PB_UTF8)
         EndIf
@@ -1890,7 +1890,7 @@ Procedure CompilerCleanup()
             ; Vista admin tools must run in the standalone debugger
             ;
             CompilerIf #CompileWindows
-              If *Target\RunEnableAdmin And OSVersion() >= #PB_OS_Windows_Vista And IsAdmin() = 0 ; Fallback only if we are not admin (http://www.purebasic.fr/english/viewtopic.php?f=4&t=50571&p=385348#p385348)
+              If *Target\RunEnableAdmin And OSVersion() >= #PB_OS_Windows_Vista And IsAdmin() = 0 ; Fallback only if we are not admin (https://www.purebasic.fr/english/viewtopic.php?f=4&t=50571&p=385348#p385348)
                 ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
                 ProcedureReturn
               EndIf

--- a/PureBasicIDE/CompilerWindow.pb
+++ b/PureBasicIDE/CompilerWindow.pb
@@ -1217,7 +1217,7 @@ Procedure CreateExecutable()
             File$+Extension$
           EndIf
           
-          ; If the name of the exe has changed, we need to re-save the file (http://www.purebasic.fr/english/viewtopic.php?f=4&t=59806)
+          ; If the name of the exe has changed, we need to re-save the file (https://www.purebasic.fr/english/viewtopic.php?f=4&t=59806)
           ;
           If *ActiveSource\ExecutableName$ <> File$
             *ActiveSource\ExecutableName$ = File$

--- a/PureBasicIDE/EditHistory.pb
+++ b/PureBasicIDE/EditHistory.pb
@@ -1623,7 +1623,7 @@ CompilerIf #CompileWindows
                 EditHistoryDialog\Close()
               EndIf
               
-              EditHistoryDialog = 0 ; Important on OS X to put back the pointer to null after closing, as it can be called in the resize callback (http://www.purebasic.fr/english/viewtopic.php?f=24&t=59703&start=60)
+              EditHistoryDialog = 0 ; Important on OS X to put back the pointer to null after closing, as it can be called in the resize callback (https://www.purebasic.fr/english/viewtopic.php?f=24&t=59703&start=60)
               
               ; clear the display cache
               ForEach EventSourceCache()

--- a/PureBasicIDE/Explorer.pb
+++ b/PureBasicIDE/Explorer.pb
@@ -127,7 +127,7 @@ Procedure InsertFavorite(Position, Entry$)
   If Right(Entry$, 1) = #Separator
     ImageID = OptionalImageID(#IMAGE_Explorer_Directory)
     Name$ = GetFilePart(Left(Entry$, Len(Entry$)-1))
-    If Name$ = "" ; It's root drive (C:\) (http://www.purebasic.fr/english/viewtopic.php?f=4&t=53810)
+    If Name$ = "" ; It's root drive (C:\) (https://www.purebasic.fr/english/viewtopic.php?f=4&t=53810)
       Name$ = Left(Entry$, Len(Entry$)-1)
     EndIf
   Else
@@ -283,7 +283,7 @@ Procedure.s NextExplorerEntry()
         Directory$ = GetGadgetText(#GADGET_Explorer)
         
         If GetGadgetItemState(#GADGET_Explorer, Explorer_CurrentItem) & #PB_Explorer_File
-          Result$ = ResolveRelativePath(CurrentDirectory$, Directory$ + Entry$) ; Ensure we really have a full path (use the initial current directory if not: http://www.purebasic.fr/english/viewtopic.php?f=4&t=55801)
+          Result$ = ResolveRelativePath(CurrentDirectory$, Directory$ + Entry$) ; Ensure we really have a full path (use the initial current directory if not: https://www.purebasic.fr/english/viewtopic.php?f=4&t=55801)
           
         ElseIf Explorer_FilesOnly = 0
           Result$ = Directory$ + Entry$ + #Separator ; to distinguish directories
@@ -299,7 +299,7 @@ Procedure.s NextExplorerEntry()
     If Explorer_CurrentItem = 0
       Explorer_CurrentItem = 1
       If GetGadgetState(#GADGET_Explorer) & #PB_Explorer_File
-        Result$ = ResolveRelativePath(CurrentDirectory$, GetGadgetText(#GADGET_Explorer)) ; Ensure we really have a full path (use the initial current directory if not: http://www.purebasic.fr/english/viewtopic.php?f=4&t=55801)
+        Result$ = ResolveRelativePath(CurrentDirectory$, GetGadgetText(#GADGET_Explorer)) ; Ensure we really have a full path (use the initial current directory if not: https://www.purebasic.fr/english/viewtopic.php?f=4&t=55801)
         
       ElseIf Explorer_FilesOnly = 0
         Result$ = GetGadgetText(#GADGET_Explorer) + #Separator ; to distinguish directories

--- a/PureBasicIDE/FormDesigner/gadgetitemswindow.pb
+++ b/PureBasicIDE/FormDesigner/gadgetitemswindow.pb
@@ -29,7 +29,7 @@ Procedure FD_UpdateItems()
   PopListPosition(FormWindows()\FormGadgets())
 EndProcedure
 Procedure FD_InitItems()
-  DisableWindow(#WINDOW_Main, #True) ; Important to disable the main window or it can lead to some issues: http://www.purebasic.fr/english/viewtopic.php?p=471724#p471724
+  DisableWindow(#WINDOW_Main, #True) ; Important to disable the main window or it can lead to some issues: https://www.purebasic.fr/english/viewtopic.php?p=471724#p471724
   
   OpenWindow(#Form_Items, 0, 0, 600, 400, "",#PB_Window_SystemMenu | #PB_Window_TitleBar | #PB_Window_WindowCentered | #PB_Window_SizeGadget, WindowID(#WINDOW_Main))
   AddKeyboardShortcut(#Form_Items, #PB_Shortcut_Command | #PB_Shortcut_C, #Menu_Copy)

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -59,7 +59,7 @@ Procedure FD_Save(Filename$)
   handle = CreateFile(#PB_Any, Filename$, Format)
   If handle
     If *ActiveSource\Parser\Encoding = 1 ; UTF-8
-      WriteStringFormat(handle, #PB_UTF8); Write the BOM: http://www.purebasic.fr/english/viewtopic.php?f=4&t=63080
+      WriteStringFormat(handle, #PB_UTF8); Write the BOM: https://www.purebasic.fr/english/viewtopic.php?f=4&t=63080
     EndIf
     
     MajorVersion = #PB_Compiler_Version/100

--- a/PureBasicIDE/HilightningFunctions.pb
+++ b/PureBasicIDE/HilightningFunctions.pb
@@ -76,7 +76,7 @@ Procedure GetWordBoundary(*Buffer, BufferLength, Position, *StartIndex.INTEGER, 
         EndIf
       Until *Cursor = 0
       
-      ; Another special case: *#CONSTANT (http://www.purebasic.fr/english/viewtopic.php?f=4&t=40104)
+      ; Another special case: *#CONSTANT (https://www.purebasic.fr/english/viewtopic.php?f=4&t=40104)
       *NextCharacter.Character = *WordStart+#CharSize
       If *WordStart\c = '*' And *NextCharacter\c = '#'
         *WordStart+1
@@ -370,7 +370,7 @@ Procedure InsertComments()
   
   GetSelection(@LineStart, 0, @LineEnd, @RowEnd)
   
-  If RowEnd <= 1 And LineStart <> LineEnd ; when selecting a full line, it actually selects the newline too, this results in one extra line. Needs at least 2 lines to work: http://www.purebasic.fr/english/viewtopic.php?f=23&t=48512
+  If RowEnd <= 1 And LineStart <> LineEnd ; when selecting a full line, it actually selects the newline too, this results in one extra line. Needs at least 2 lines to work: https://www.purebasic.fr/english/viewtopic.php?f=23&t=48512
     LineEnd - 1
   EndIf
   

--- a/PureBasicIDE/IDEDebugger.pb
+++ b/PureBasicIDE/IDEDebugger.pb
@@ -736,7 +736,7 @@ Procedure Debugger_Ended(*Debugger.DebuggerData)
   ChangeCurrentElement(FileList(), *ActiveSource)
   
   SetDebuggerMenuStates()
-  ActivateMainWindow() ; re-enable the focus on editor gadget (http://www.purebasic.fr/english/viewtopic.php?f=4&t=46375&p=352864#p352864)
+  ActivateMainWindow() ; re-enable the focus on editor gadget (https://www.purebasic.fr/english/viewtopic.php?f=4&t=46375&p=352864#p352864)
 EndProcedure
 
 ; returns true/false

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -1139,7 +1139,7 @@ Procedure SavePreferences()
     
     NbSavedWords = 0
     For i = 1 To NbFoldStartWords
-      ; Avoid writing duplicate (http://www.purebasic.fr/english/viewtopic.php?f=4&t=55717)
+      ; Avoid writing duplicate (https://www.purebasic.fr/english/viewtopic.php?f=4&t=55717)
       If i = 1  Or FoldStart$(i) <> FoldStart$(i-1)
         NbSavedWords+1
         WritePreferenceString("Start_"+Str(NbSavedWords), FoldStart$(i))
@@ -1149,7 +1149,7 @@ Procedure SavePreferences()
     
     NbSavedWords = 0
     For i = 1 To NbFoldEndWords
-      ; Avoid writing duplicate (http://www.purebasic.fr/english/viewtopic.php?f=4&t=55717)
+      ; Avoid writing duplicate (https://www.purebasic.fr/english/viewtopic.php?f=4&t=55717)
       If i = 1  Or FoldEnd$(i) <> FoldEnd$(i-1)
         NbSavedWords+1
         WritePreferenceString("End_"+Str(NbSavedWords), FoldEnd$(i))

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -157,7 +157,7 @@ Procedure IsProjectFile(FileName$)
     ;
     If LoadXML(#XML_CheckProject, FileName$)
       If XMLStatus(#XML_CheckProject) = #PB_XML_Success And MainXMLNode(#XML_CheckProject)
-        If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "http://www.purebasic.com/namespace/project"
+        If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "https://www.purebasic.com/namespace/project"
           Result = #True
         EndIf
       EndIf
@@ -175,7 +175,7 @@ Procedure.s ProjectName(FileName$) ; Get the project name from a project file
   
   If LoadXML(#XML_CheckProject, FileName$)
     If XMLStatus(#XML_CheckProject) = #PB_XML_Success And MainXMLNode(#XML_CheckProject)
-      If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "http://www.purebasic.com/namespace/project"
+      If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "https://www.purebasic.com/namespace/project"
         *Config = GetSection(MainXMLNode(#XML_CheckProject), "config")
         If *Config
           *Options = XMLNodeFromPath(*Config, "options")
@@ -825,7 +825,7 @@ Procedure IsPureBasicFile(FileName$)
     IsLoaded = 0
     If LoadXML(#XML_LoadProject, FileName$)
       If XMLStatus(#XML_LoadProject) = #PB_XML_Success And MainXMLNode(#XML_LoadProject)
-        If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = "http://www.purebasic.com/namespace/project"
+        If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = "https://www.purebasic.com/namespace/project"
           IsLoaded = 1
         EndIf
       EndIf
@@ -1299,7 +1299,7 @@ Procedure IsPureBasicFile(FileName$)
     ; The main layout of the project files is as follows:
     ;
     ; root: "project"
-    ;  - xmlns     (required): "http://www.purebasic.com/namespace" (important as this is checked!)
+    ;  - xmlns     (required): "https://www.purebasic.com/namespace" (important as this is checked!)
     ;  - version   (required): project file version (starts with 1.0)
     ;  - minversion(optional): minimum compatible file version (some sections may be unreadable)
     ;  - creator   (required): full PB version string of the file creator
@@ -1322,7 +1322,7 @@ Procedure IsPureBasicFile(FileName$)
       ; Generate main node
       ;
       *Main = CreateXMLNode(RootXMLNode(#XML_SaveProject), "project")
-      SetXMLAttribute(*Main, "xmlns",   "http://www.purebasic.com/namespace")
+      SetXMLAttribute(*Main, "xmlns",   "https://www.purebasic.com/namespace")
       SetXMLAttribute(*Main, "version", #Project_VersionString)
       SetXMLAttribute(*Main, "creator", DefaultCompiler\VersionString$)
       

--- a/PureBasicIDE/ProjectPanel.pb
+++ b/PureBasicIDE/ProjectPanel.pb
@@ -616,7 +616,7 @@ Procedure ProjectPanelMenuEvent(MenuItemID)
             Debug FileName$
             
             ; If the file doesn't exist, ask to create it, to ease the integration
-            ; http://www.purebasic.fr/english/viewtopic.php?f=4&t=47521
+            ; https://www.purebasic.fr/english/viewtopic.php?f=4&t=47521
             ;
             If FileSize(FileName$) < 0
               If MessageRequester(Language("FileStuff","AddNewFileTitle"), LanguagePattern("FileStuff","AddNewFileQuestion", "%filename%", Filename$), #PB_MessageRequester_YesNo | #FLAG_Question) = #PB_MessageRequester_Yes

--- a/PureBasicIDE/PureBasic IDE.pbp
+++ b/PureBasicIDE/PureBasic IDE.pbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.71 LTS (Windows - x64)">
+<project xmlns="https://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.71 LTS (Windows - x64)">
   <section name="config">
     <options closefiles="1" openmode="0" name="PureBasic IDE - 5.70"/>
   </section>

--- a/PureBasicIDE/RecentFiles.pb
+++ b/PureBasicIDE/RecentFiles.pb
@@ -18,7 +18,7 @@ Procedure.s RecentFiles_EntryString(Index)
     
   Else ; its a source file
     
-    ProcedureReturn RSet(Str(Index), Len(Str(FilesHistorySize))) + ")  " + RecentFiles(Index) ; Display full path here, to avoid issue if some files gets same name (ie: main.pb) http://www.purebasic.fr/english/viewtopic.php?f=3&t=60650
+    ProcedureReturn RSet(Str(Index), Len(Str(FilesHistorySize))) + ")  " + RecentFiles(Index) ; Display full path here, to avoid issue if some files gets same name (ie: main.pb) https://www.purebasic.fr/english/viewtopic.php?f=3&t=60650
     
   EndIf
   

--- a/PureBasicIDE/ScintillaHilightning.pb
+++ b/PureBasicIDE/ScintillaHilightning.pb
@@ -1023,7 +1023,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
   Procedure ChangeActiveLine(Line, TopOffset)  ; Line is 1 based
                                                ; *ActiveSource\CurrentLineOld = 0 ; do not scan procedurelist again!
     SendEditorMessage(#SCI_LINESCROLL, -99999, -99999)
-    SendEditorMessage(#SCI_ENSUREVISIBLE, Line-1, 0) ; Ensure the block is unfolded, if it was folded. Needs to be before #SCI_GOTOLINE (http://www.purebasic.fr/english/viewtopic.php?f=4&t=44871)
+    SendEditorMessage(#SCI_ENSUREVISIBLE, Line-1, 0) ; Ensure the block is unfolded, if it was folded. Needs to be before #SCI_GOTOLINE (https://www.purebasic.fr/english/viewtopic.php?f=4&t=44871)
     SendEditorMessage(#SCI_LINESCROLL, 0, Line+TopOffset)
     SendEditorMessage(#SCI_GOTOLINE, Line-1, 0)
     SetActiveGadget(*ActiveSource\EditorGadget)
@@ -3329,14 +3329,14 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     
     WordChars$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#*"
     For k = 192 To 255
-      WordChars$+Chr(k) ; For ASCII mode, to have "é, à" etc. (http://www.purebasic.fr/english/viewtopic.php?f=4&t=57421)
+      WordChars$+Chr(k) ; For ASCII mode, to have "é, à" etc. (https://www.purebasic.fr/english/viewtopic.php?f=4&t=57421)
     Next
     SendEditorMessage(#SCI_SETWORDCHARS, 0, ToAscii(WordChars$))
     
     SendEditorMessage(#SCI_SETMOUSEDWELLTIME, 750, 0)
     
     ; Auto adjust the horizontal scrollbar. Could have a performance impact according to the doc, to verify in practice
-    ; http://www.purebasic.fr/english/viewtopic.php?f=23&t=50693
+    ; https://www.purebasic.fr/english/viewtopic.php?f=23&t=50693
     ;
     ; Note: with new scintilla on OS X, this is broken (the horizontal scroll doesn't adjust at all)
     ; Also on OS X 10.8+ the scrollbar is hidden by default (new OS X scroll, so it's not an issue anymore)
@@ -3828,7 +3828,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     
     ; set the line into view (don't use ChangeActiveLine() here as it will scroll the line to top
     Position = SendEditorMessage(#SCI_POSITIONFROMLINE, LineNumber-1, 0)
-    SendEditorMessage(#SCI_ENSUREVISIBLE, LineNumber-1, 0) ; Ensure the block is unfolded, if it was folded. Needs to be before #SCI_GOTOLINE (http://www.purebasic.fr/english/viewtopic.php?f=4&t=44871)
+    SendEditorMessage(#SCI_ENSUREVISIBLE, LineNumber-1, 0) ; Ensure the block is unfolded, if it was folded. Needs to be before #SCI_GOTOLINE (https://www.purebasic.fr/english/viewtopic.php?f=4&t=44871)
     SendEditorMessage(#SCI_SETSEL, Position, Position)
     SendEditorMessage(#SCI_SCROLLCARET, 0, 0)
   EndProcedure

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -634,7 +634,7 @@ CompilerIf #CompileLinux | #CompileWindows
   #SHORTCUT_Copy               = #PB_Shortcut_Control | #PB_Shortcut_C
   #SHORTCUT_Paste              = #PB_Shortcut_Control | #PB_Shortcut_V
   #SHORTCUT_CommentSelection   = #PB_Shortcut_Control | #PB_Shortcut_B
-  #SHORTCUT_UnCommentSelection = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_B ; Avoid 'Alt+B' shorcut as it conflict with german menu title: http://www.purebasic.fr/english/viewtopic.php?f=23&t=37098
+  #SHORTCUT_UnCommentSelection = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_B ; Avoid 'Alt+B' shorcut as it conflict with german menu title: https://www.purebasic.fr/english/viewtopic.php?f=23&t=37098
   #SHORTCUT_SelectAll          = #PB_Shortcut_Control | #PB_Shortcut_A
   #SHORTCUT_Goto               = #PB_Shortcut_Control | #PB_Shortcut_G
   #SHORTCUT_JumpToKeyword      = #PB_Shortcut_Control | #PB_Shortcut_K

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -1709,7 +1709,7 @@ Procedure LoadSourceFile(FileName$, Activate = 1)
     If *Buffer
       ReadData(#FILE_LoadSource, *Buffer, FileLength)
       
-      ; Don't check PB sources, as it can contains wierd characters well handled by Scintilla: http://www.purebasic.fr/english/viewtopic.php?f=4&t=61467
+      ; Don't check PB sources, as it can contains wierd characters well handled by Scintilla: https://www.purebasic.fr/english/viewtopic.php?f=4&t=61467
       ;
       If (IsPureBasicFile(FileName$) = #False And IsBinaryFile(*Buffer, FileLength)) Or (Format <> #PB_Ascii And Format <> #PB_UTF8) ; check for binary files
         FreeMemory(*Buffer)
@@ -1884,7 +1884,7 @@ Procedure SaveSourceFile(FileName$)
     EndIf
     
     If *Buffer Or FileLength = 0
-      *ActiveSource\FileName$ = FileName$ ; SaveProjectSettings() needs an updated FileName$ (http://www.purebasic.fr/english/viewtopic.php?f=4&t=59566)
+      *ActiveSource\FileName$ = FileName$ ; SaveProjectSettings() needs an updated FileName$ (https://www.purebasic.fr/english/viewtopic.php?f=4&t=59566)
       *ActiveSource\IsCode = IsCodeFile(FileName$)
       
       SaveProjectSettings(*ActiveSource, *ActiveSource\IsCode, 0, 1)

--- a/PureBasicIDE/StructureViewer.pb
+++ b/PureBasicIDE/StructureViewer.pb
@@ -415,7 +415,7 @@ Procedure OpenStructureViewerWindow()
       EnsureWindowOnDesktop(#WINDOW_StructureViewer)
       
       CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
-        ; http://www.purebasic.fr/english/viewtopic.php?f=24&t=63494
+        ; https://www.purebasic.fr/english/viewtopic.php?f=24&t=63494
         ; Warning, DisplayStructureRootList() does the resize, so it must be after
         ;
         WindowBounds(#WINDOW_StructureViewer, 500, 300, #PB_Ignore, #PB_Ignore)

--- a/PureBasicIDE/TabBarGadget.pbi
+++ b/PureBasicIDE/TabBarGadget.pbi
@@ -13,8 +13,8 @@
 ;|
 ;|  Description      : Gadget for displaying and using tabs like in the browser
 ;|
-;|  Forum Topic      : http://www.purebasic.fr/german/viewtopic.php?f=8&t=24788
-;|                     http://www.purebasic.fr/english/viewtopic.php?f=12&t=47588
+;|  Forum Topic      : https://www.purebasic.fr/german/viewtopic.php?f=8&t=24788
+;|                     https://www.purebasic.fr/english/viewtopic.php?f=12&t=47588
 ;|  Website          : http://www.unionbytes.de/includes/tabbargadget/
 ;|
 ;|  Documentation    : http://help.unionbytes.de/tbg/

--- a/PureBasicIDE/UpdateCheck.pb
+++ b/PureBasicIDE/UpdateCheck.pb
@@ -9,7 +9,7 @@
 ; Example file:
 ;
 ; <?xml version="1.0" encoding="UTF-8"?>
-; <versions xmlns="http://www.purebasic.com/namespace">
+; <versions xmlns="https://www.purebasic.com/namespace">
 ;   <version category="bugfix" number="5.11" name="PureBasic 5.11" />
 ;   <version category="beta" number="5.30" beta="3" name="PureBasic 5.30 beta 3" />
 ;   <version category="release" number="5.20" lts="1" name="PureBasic 5.20 LTS" />

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -2112,7 +2112,7 @@ Procedure ResizeMainWindow()
   If ShowMainToolbar
     EditTop = ToolbarTopOffset
     CompilerIf #CompileLinux
-      ; On linux the toolbar can accept any sized icon, so use a dynamic height (http://www.purebasic.fr/english/viewtopic.php?f=23&t=48951)
+      ; On linux the toolbar can accept any sized icon, so use a dynamic height (https://www.purebasic.fr/english/viewtopic.php?f=23&t=48951)
       EditHeight = EditorWindowHeight - ToolBarHeight(#TOOLBAR) - StatusbarHeight - MenuHeight
     CompilerElse
       EditHeight = EditorWindowHeight - ToolbarHeight - StatusbarHeight - MenuHeight
@@ -2269,7 +2269,7 @@ Procedure EventLoopCallback()
             CompilerEndIf
             
             CompilerIf #CompileWindows
-              SendMessage_(GadgetID(*ActiveSource\EditorGadget), #WM_LBUTTONUP, 0, 0) ; simulate a mouseup to fix the ugly selection problem (http://www.purebasic.fr/english/viewtopic.php?f=4&t=50135)
+              SendMessage_(GadgetID(*ActiveSource\EditorGadget), #WM_LBUTTONUP, 0, 0) ; simulate a mouseup to fix the ugly selection problem (https://www.purebasic.fr/english/viewtopic.php?f=4&t=50135)
             CompilerEndIf
             
             JumpToProcedure()

--- a/PureBasicIDE/WindowsMisc.pb
+++ b/PureBasicIDE/WindowsMisc.pb
@@ -401,7 +401,7 @@ CompilerIf #CompileWindows
           ;   Window's queue, which will crash the IDE if the foreground window hangs.
           ;   Steps to reproduce:
           ;   - run a PB program (with GUI) which does "RunProgram(some PB source)"
-          ;   - the program and the IDE will crash.  (http://www.purebasic.fr/english/viewtopic.php?t=36934)
+          ;   - the program and the IDE will crash.  (https://www.purebasic.fr/english/viewtopic.php?t=36934)
           ;
           ;   Instead we use the normal SetWindowForeground() here, and it even works:
           ;   - the starting program has focus

--- a/PureBasicIDE/data/SilkTheme/Readme.txt
+++ b/PureBasicIDE/data/SilkTheme/Readme.txt
@@ -1,7 +1,7 @@
 Silk Icon Theme for the PureBasic IDE
 
 by Timo Harter
-http://www.purebasic.com
+https://www.purebasic.com
 
 
 This theme uses the icons (some slightly modified) 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ work in the PureBasic package.
 [PureBasic]: https://www.purebasic.com "Visit PureBasic website"
 [PureBasic Team Blog]: https://www.purebasic.fr/blog/ "Random thoughts on PureBasic development"
 
-[PBF EN]: http://www.purebasic.fr/english "PureBasic forum for English speakers"
-[PBF DE]: http://www.purebasic.fr/german "PureBasic forum for German speakers"
-[PBF FR]: http://www.purebasic.fr/french "PureBasic forum for French speakers"
+[PBF EN]: https://www.purebasic.fr/english "PureBasic forum for English speakers"
+[PBF DE]: https://www.purebasic.fr/german "PureBasic forum for German speakers"
+[PBF FR]: https://www.purebasic.fr/french "PureBasic forum for French speakers"
 
 <!-- 3r party websites -->
 


### PR DESCRIPTION
Change every occurrence of `http://` links to `https://` (both in source code files and documents) for the following URLs:

* www.spiderbasic.com
* www.purebasic.com
* www.purebasic.fr

(fixes #9)