### PR TITLE
Use HTTP namespace constants for backwards compatibility

### DIFF
--- a/PureBasicIDE/CompilerFlags.pb
+++ b/PureBasicIDE/CompilerFlags.pb
@@ -52,6 +52,8 @@ CompilerEndIf
 CompilerIf #SpiderBasic
   #ProductName$ = "SpiderBasic"
   #ProductWebSite$ = "https://www.spiderbasic.com"
+  #ProjectFileNamespace$ = "http://www.purebasic.com/namespace" ; SBP uses PBP namespace
+  #UpdateCheckNamespace$ = "http://www.spiderbasic.com/namespace"
   
   #SourceFileExtension  = ".sb"
   #IncludeFileExtension = ".sbi"
@@ -62,6 +64,8 @@ CompilerIf #SpiderBasic
 CompilerElse
   #ProductName$ = "PureBasic"
   #ProductWebSite$ = "https://www.purebasic.com"
+  #ProjectFileNamespace$ = "http://www.purebasic.com/namespace"
+  #UpdateCheckNamespace$ = "http://www.purebasic.com/namespace"
   
   #SourceFileExtension  = ".pb"
   #IncludeFileExtension = ".pbi"

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -157,7 +157,7 @@ Procedure IsProjectFile(FileName$)
     ;
     If LoadXML(#XML_CheckProject, FileName$)
       If XMLStatus(#XML_CheckProject) = #PB_XML_Success And MainXMLNode(#XML_CheckProject)
-        If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "https://www.purebasic.com/namespace/project"
+        If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = #ProjectFileNamespace$ + "/project"
           Result = #True
         EndIf
       EndIf
@@ -175,7 +175,7 @@ Procedure.s ProjectName(FileName$) ; Get the project name from a project file
   
   If LoadXML(#XML_CheckProject, FileName$)
     If XMLStatus(#XML_CheckProject) = #PB_XML_Success And MainXMLNode(#XML_CheckProject)
-      If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = "https://www.purebasic.com/namespace/project"
+      If ResolveXMLNodeName(MainXMLNode(#XML_CheckProject), "/") = #ProjectFileNamespace$ + "/project"
         *Config = GetSection(MainXMLNode(#XML_CheckProject), "config")
         If *Config
           *Options = XMLNodeFromPath(*Config, "options")
@@ -825,7 +825,7 @@ Procedure IsPureBasicFile(FileName$)
     IsLoaded = 0
     If LoadXML(#XML_LoadProject, FileName$)
       If XMLStatus(#XML_LoadProject) = #PB_XML_Success And MainXMLNode(#XML_LoadProject)
-        If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = "https://www.purebasic.com/namespace/project"
+        If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = #ProjectFileNamespace$ + "/project"
           IsLoaded = 1
         EndIf
       EndIf
@@ -1299,7 +1299,7 @@ Procedure IsPureBasicFile(FileName$)
     ; The main layout of the project files is as follows:
     ;
     ; root: "project"
-    ;  - xmlns     (required): "https://www.purebasic.com/namespace" (important as this is checked!)
+    ;  - xmlns     (required): "http://www.purebasic.com/namespace" (important as this is checked!)
     ;  - version   (required): project file version (starts with 1.0)
     ;  - minversion(optional): minimum compatible file version (some sections may be unreadable)
     ;  - creator   (required): full PB version string of the file creator
@@ -1322,7 +1322,7 @@ Procedure IsPureBasicFile(FileName$)
       ; Generate main node
       ;
       *Main = CreateXMLNode(RootXMLNode(#XML_SaveProject), "project")
-      SetXMLAttribute(*Main, "xmlns",   "https://www.purebasic.com/namespace")
+      SetXMLAttribute(*Main, "xmlns",   #ProjectFileNamespace$)
       SetXMLAttribute(*Main, "version", #Project_VersionString)
       SetXMLAttribute(*Main, "creator", DefaultCompiler\VersionString$)
       

--- a/PureBasicIDE/PureBasic IDE.pbp
+++ b/PureBasicIDE/PureBasic IDE.pbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="https://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.71 LTS (Windows - x64)">
+<project xmlns="http://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.71 LTS (Windows - x86)">
   <section name="config">
     <options closefiles="1" openmode="0" name="PureBasic IDE - 5.70"/>
   </section>

--- a/PureBasicIDE/UpdateCheck.pb
+++ b/PureBasicIDE/UpdateCheck.pb
@@ -9,7 +9,7 @@
 ; Example file:
 ;
 ; <?xml version="1.0" encoding="UTF-8"?>
-; <versions xmlns="https://www.purebasic.com/namespace">
+; <versions xmlns="http://www.purebasic.com/namespace">
 ;   <version category="bugfix" number="5.11" name="PureBasic 5.11" />
 ;   <version category="beta" number="5.30" beta="3" name="PureBasic 5.30 beta 3" />
 ;   <version category="release" number="5.20" lts="1" name="PureBasic 5.20 LTS" />
@@ -135,7 +135,7 @@ Procedure ReadVersionFile(FileName$, List Releases.Release())
     If XMLStatus(#XML_UpdateCheck) = #PB_XML_Success And MainXMLNode(#XML_UpdateCheck)
       ; check the namespace
       *AllVersions = MainXMLNode(#XML_UpdateCheck)
-      If ResolveXMLNodeName(*AllVersions, "/") = #ProductWebSite$ + "/namespace/versions"
+      If ResolveXMLNodeName(*AllVersions, "/") = #UpdateCheckNamespace$ + "/versions"
         
         ; examine child nodes
         *Version = ChildXMLNode(*AllVersions)


### PR DESCRIPTION
The PB IDE 5.71 and earlier check for HTTP namespaces in project files and the update check XML file. The change to HTTPS namespaces in PR #10 broke backwards compatibility.

This pull request reverts the namespaces to HTTP, but keeps HTTPS for web links presented to the user. It also uses new named constants rather than repeated string literals.