### PR TITLE
Add Images Previews in README Files

### DIFF
--- a/PureBasicDebugger/Data/README.md
+++ b/PureBasicDebugger/Data/README.md
@@ -1,0 +1,71 @@
+# Debugger GUI Images
+
+The icon set for the [PureBasic debugging tools] GUI elements.
+
+-----
+
+**Table of Contents**
+
+<!-- MarkdownTOC autolink="true" bracket="round" autoanchor="false" lowercase="only_ascii" uri_encoding="true" levels="1,2,3" -->
+
+- [Folder Contents](#folder-contents)
+- [Images Preview](#images-preview)
+
+<!-- /MarkdownTOC -->
+
+-----
+
+# Folder Contents
+
+- [`icons.psd`][icons.psd] — Photoshop project for the Debugger icon set.
+- [`profiler.psd`][profiler.psd] — Photoshop project for the Profiler icon set.
+- `*.png` (21) — GUI elements icon images (16x16 px).
+
+
+# Images Preview
+
+|   image file  |                      |   image file  |                      |   image file  |                      |
+|---------------|----------------------|---------------|----------------------|---------------|----------------------|
+| [arrow.png]   | ![icon][arrow.png]   | [ascii.png]   | ![icon][ascii.png]   | [byte.png]    | ![icon][byte.png]    |
+| [char.png]    | ![icon][char.png]    | [cross.png]   | ![icon][cross.png]   | [double.png]  | ![icon][double.png]  |
+| [fixed.png]   | ![icon][fixed.png]   | [float.png]   | ![icon][float.png]   | [integer.png] | ![icon][integer.png] |
+| [long.png]    | ![icon][long.png]    | [quad.png]    | ![icon][quad.png]    | [select.png]  | ![icon][select.png]  |
+| [string.png]  | ![icon][string.png]  | [struct.png]  | ![icon][struct.png]  | [struct1.png] | ![icon][struct1.png] |
+| [struct2.png] | ![icon][struct2.png] | [unicode.png] | ![icon][unicode.png] | [word.png]    | ![icon][word.png]    |
+| [zoomall.png] | ![icon][zoomall.png] | [zoomin.png]  | ![icon][zoomin.png]  | [zoomout.png] | ![icon][zoomout.png] |
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[PureBasic debugging tools]: https://www.purebasic.com/documentation/reference/ide_debugtools.html "See PureBasic online documentation on the debugging tools included with the IDE"
+
+<!-- image files -->
+
+[arrow.png]: ./arrow.png
+[ascii.png]: ./ascii.png
+[byte.png]: ./byte.png
+[char.png]: ./char.png
+[cross.png]: ./cross.png
+[double.png]: ./double.png
+[fixed.png]: ./fixed.png
+[float.png]: ./float.png
+[integer.png]: ./integer.png
+[long.png]: ./long.png
+[quad.png]: ./quad.png
+[select.png]: ./select.png
+[string.png]: ./string.png
+[struct.png]: ./struct.png
+[struct1.png]: ./struct1.png
+[struct2.png]: ./struct2.png
+[unicode.png]: ./unicode.png
+[word.png]: ./word.png
+[zoomall.png]: ./zoomall.png
+[zoomin.png]: ./zoomin.png
+[zoomout.png]: ./zoomout.png
+
+
+[icons.psd]: ./icons.psd
+[profiler.psd]: ./profiler.psd
+
+<!-- EOF -->

--- a/PureBasicIDE/data/DefaultTheme/README.md
+++ b/PureBasicIDE/data/DefaultTheme/README.md
@@ -1,6 +1,6 @@
 # Default IDE Theme
 
-The PureBasic default theme, created by Gary Willoughby «[Kale]» — author of the book _[PureBasic: A Beginner's Guide to Computer Programming]_ (2006), now [freely available in PDF format] under [CC BY-NC-SA 3.0] license.
+The PureBasic default theme, created by [Gary «Kale» Willoughby] — author of the book _[PureBasic: A Beginner's Guide to Computer Programming]_ (2006), now [freely available in PDF format] under [CC BY-NC-SA 3.0] license.
 
 # Folder Contents
 
@@ -54,17 +54,17 @@ The PureBasic default theme, created by Gary Willoughby «[Kale]» — author of
                                REFERENCE LINKS
 ------------------------------------------------------------------------------>
 
-[Kale]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit «Kale» Gary Willoughby's profile on the PureBasic Forums"
-
 <!-- PB Beginner's Guide -->
 
 [PureBasic: A Beginner's Guide to Computer Programming]: https://web.archive.org/web/20071012170409/http://pb-beginners.co.uk:80/ "See the book web page on Wayback Machine"
 
 [freely available in PDF format]: http://www.purearea.net/pb/download/PureBasicBook.pdf "Free PDF eBook at PureArea.net (direct link)"
 
-
-
 [CC BY-NC-SA 3.0]: https://creativecommons.org/licenses/by-nc-sa/3.0/ "View the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported license"
+
+<!-- people -->
+
+[Gary «Kale» Willoughby]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit Gary «Kale» Willoughby's profile on the PureBasic Forums"
 
 <!-- icons files -->
 

--- a/PureBasicIDE/data/README.md
+++ b/PureBasicIDE/data/README.md
@@ -1,0 +1,137 @@
+# IDE Assets
+
+This directory tree contains various assets for the PureBasic and SpiderBasic IDEs.
+
+
+-----
+
+**Table of Contents**
+
+<!-- MarkdownTOC autolink="true" bracket="round" autoanchor="false" lowercase="only_ascii" uri_encoding="true" levels="1,2,3" -->
+
+- [Folder Contents](#folder-contents)
+- [Images Previews](#images-previews)
+    - [PureBasic Gears Logo](#purebasic-gears-logo)
+    - [PureBasic Splash Screen](#purebasic-splash-screen)
+    - [PureBasic Icons](#purebasic-icons)
+    - [SpiderBasic Logotype](#spiderbasic-logotype)
+
+<!-- /MarkdownTOC -->
+
+-----
+
+# Folder Contents
+
+- [`/DefaultTheme/`](./DefaultTheme/) — default IDE theme and icons.
+- [`/logo/`](./logo/) — PureBasic logos (images and icons).
+- [`/SilkTheme/`](./SilkTheme/) — "Silk icon set" IDE theme and icons.
+- [`/SpiderBasic/`](./SpiderBasic/) — SpiderBasic logo (images and icons).
+- [`CloseButton.png`](./CloseButton.png) — 16x16 icon.
+- [`ColorTable.xml`](./ColorTable.xml) — palettes dataset for the [Color Picker tool].
+- [`EmptySpace.png`](./EmptySpace.png) — 16x16 icon.
+- [`MissingIcon.png`](./MissingIcon.png) — 16x16 icon.
+- [`PBLogoBig.ico`](./PBLogoBig.ico) — PureBasic IDE icon (48x48 px).
+- [`PBLogoSmall.ico`](./PBLogoSmall.ico) — PureBasic IDE icon (32x32 px).
+- [`PBSourceFile.ico`](./PBSourceFile.ico) — PureBasic files icon (48x48 px).
+- [`purebasiclogo.bmp`](./purebasiclogo.bmp) — logo shown in PureBasic IDE "About" window (381x68 px).
+- [`spiderbasicstartuplogo_forum.pdn`](./spiderbasicstartuplogo_forum.pdn) — SpiderBasic Logotype ([Paint.NET] project file).
+- [`spiderbasicstartuplogo_forums.png`](./spiderbasicstartuplogo_forums.png) — SpiderBasic Logotype, red version (459x98 px).
+- [`spiderbasicstartuplogo_forums_blue.png`](./spiderbasicstartuplogo_forums_blue.png) — SpiderBasic Logotype, blue version (275x94 px).
+- [`startuplogo.png`](./startuplogo.png) — logo for PureBasic IDE splash screen (500x200 px).
+- [`startuplogo.psd`](./startuplogo.psd) — logo for PureBasic IDE splash screen (500x200 px).
+- [`templates.psd`](./templates.psd) — 16x16 icons project file.
+- [`ToolsPanelLeft.png`](./ToolsPanelLeft.png) — 16x16 icon.
+- [`ToolsPanelRight.png`](./ToolsPanelRight.png) — 16x16 icon.
+
+# Images Previews
+
+Images info and previews, grouped by relevance.
+
+## PureBasic Gears Logo
+
+The PureBasic logo shown in the "__Help__ » __About__" window.
+
+|      image file     |    size   |
+|---------------------|-----------|
+| [purebasiclogo.bmp] | 381x68 px |
+
+![PureBasic Gears Logo](./purebasiclogo.bmp)
+
+
+## PureBasic Splash Screen
+
+The PureBasic logo image shown while the PureBasic IDE starts up.
+
+|     image file    |    size    |
+|-------------------|------------|
+| [startuplogo.png] | 500x200 px |
+| [startuplogo.psd] | 500x200 px |
+
+
+![PureBasic IDE Splash Screen][startuplogo.png]
+
+## PureBasic Icons
+
+PureBasic IDE and source files icons.
+
+
+|     icon file      |   size   |                preview                 |
+|--------------------|----------|----------------------------------------|
+| [PBLogoBig.ico]    | 48x48 px | ![app icon 48x48](./PBLogoBig.ico)     |
+| [PBLogoSmall.ico]  | 32x32 px | ![app icon 32x32](./PBLogoSmall.ico)   |
+| [PBSourceFile.ico] | 48x48 px | ![file icon 48x48](./PBSourceFile.ico) |
+
+## SpiderBasic Logotype
+
+A logotype of the SpiderBasic name, in different colours.
+
+|                image file                |    size   |
+|------------------------------------------|-----------|
+| [spiderbasicstartuplogo_forum.pdn]       | ???       |
+| [spiderbasicstartuplogo_forums.png]      | 459x98 px |
+| [spiderbasicstartuplogo_forums_blue.png] | 275x94 px |
+
+The [`spiderbasicstartuplogo_forum.pdn`][spiderbasicstartuplogo_forum.pdn] file is a [Paint.NET] project file.
+
+
+![SpiderBasic Logotype red](./spiderbasicstartuplogo_forums.png)
+
+![SpiderBasic Logotype blue](./spiderbasicstartuplogo_forums_blue.png)
+
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+<!-- 3rd party apps -->
+
+[Paint.NET]: https://www.getpaint.net/ "Visit the website of Paint.NET, a free image editor for Windows "
+
+<!-- PB Docs -->
+
+[Color Picker tool]: https://www.purebasic.com/documentation/reference/ide_tools.html "See PureBasic online documentation on the IDE built-in tools"
+
+<!-- image files ------------------------------------------------------------->
+
+<!-- PureBasic Gears Logo -->
+
+[purebasiclogo.bmp]: ./purebasiclogo.bmp "Logo shown in PureBasic IDE 'About' window: 381x68 px"
+
+<!-- PureBasic Splash Screen -->
+
+[startuplogo.png]: ./startuplogo.png "PureBasic IDE splash screen: 500x200 px"
+[startuplogo.psd]: ./startuplogo.psd
+
+<!-- PureBasic Icons -->
+
+[PBLogoBig.ico]: ./PBLogoBig.ico "PureBasic IDE icon, big: 48x48 px"
+[PBLogoSmall.ico]: ./PBLogoSmall.ico "PureBasic IDE icon, small: 32x32 px"
+[PBSourceFile.ico]: ./PBSourceFile.ico "PureBasic files icon: 48x48 px"
+
+<!-- SpiderBasic Logotype -->
+
+[spiderbasicstartuplogo_forum.pdn]: ./spiderbasicstartuplogo_forum.pdn "SpiderBasic Logotype, Paint.NET project file"
+[spiderbasicstartuplogo_forums.png]: ./spiderbasicstartuplogo_forums.png "SpiderBasic Logotype, red version: 459x98 px"
+[spiderbasicstartuplogo_forums_blue.png]: ./spiderbasicstartuplogo_forums_blue.png "SpiderBasic Logotype, blue version: 275x94 px"
+
+<!-- EOF -->

--- a/PureBasicIDE/data/README.md
+++ b/PureBasicIDE/data/README.md
@@ -30,15 +30,15 @@ This directory tree contains various assets for the PureBasic and SpiderBasic ID
 - [`ColorTable.xml`](./ColorTable.xml) — palettes dataset for the [Color Picker tool].
 - [`EmptySpace.png`](./EmptySpace.png) — 16x16 icon.
 - [`MissingIcon.png`](./MissingIcon.png) — 16x16 icon.
-- [`PBLogoBig.ico`](./PBLogoBig.ico) — PureBasic IDE icon (48x48 px).
-- [`PBLogoSmall.ico`](./PBLogoSmall.ico) — PureBasic IDE icon (32x32 px).
-- [`PBSourceFile.ico`](./PBSourceFile.ico) — PureBasic files icon (48x48 px).
-- [`purebasiclogo.bmp`](./purebasiclogo.bmp) — logo shown in PureBasic IDE "About" window (381x68 px).
-- [`spiderbasicstartuplogo_forum.pdn`](./spiderbasicstartuplogo_forum.pdn) — SpiderBasic Logotype ([Paint.NET] project file).
-- [`spiderbasicstartuplogo_forums.png`](./spiderbasicstartuplogo_forums.png) — SpiderBasic Logotype, red version (459x98 px).
-- [`spiderbasicstartuplogo_forums_blue.png`](./spiderbasicstartuplogo_forums_blue.png) — SpiderBasic Logotype, blue version (275x94 px).
-- [`startuplogo.png`](./startuplogo.png) — logo for PureBasic IDE splash screen (500x200 px).
-- [`startuplogo.psd`](./startuplogo.psd) — logo for PureBasic IDE splash screen (500x200 px).
+- [`PBLogoBig.ico`][PBLogoBig.ico] — PureBasic IDE icon (48x48 px).
+- [`PBLogoSmall.ico`][PBLogoSmall.ico] — PureBasic IDE icon (32x32 px).
+- [`PBSourceFile.ico`][PBSourceFile.ico] — PureBasic files icon (48x48 px).
+- [`purebasiclogo.bmp`][purebasiclogo.bmp] — logo shown in PureBasic IDE "About" window (381x68 px).
+- [`spiderbasicstartuplogo_forum.pdn`][spiderbasicstartuplogo_forum.pdn] — SpiderBasic Logotype ([Paint.NET] project file).
+- [`spiderbasicstartuplogo_forums.png`][spiderbasicstartuplogo_forums.png] — SpiderBasic Logotype, red version (459x98 px).
+- [`spiderbasicstartuplogo_forums_blue.png`][spiderbasicstartuplogo_forums_blue.png] — SpiderBasic Logotype, blue version (275x94 px).
+- [`startuplogo.png`][startuplogo.png] — logo for PureBasic IDE splash screen (500x200 px).
+- [`startuplogo.psd`][startuplogo.psd] — logo for PureBasic IDE splash screen (500x200 px).
 - [`templates.psd`](./templates.psd) — 16x16 icons project file.
 - [`ToolsPanelLeft.png`](./ToolsPanelLeft.png) — 16x16 icon.
 - [`ToolsPanelRight.png`](./ToolsPanelRight.png) — 16x16 icon.
@@ -49,18 +49,18 @@ Images info and previews, grouped by relevance.
 
 ## PureBasic Gears Logo
 
-The PureBasic logo shown in the "__Help__ » __About__" window.
+The logo shown in PureBasic IDE "__Help__ » __About__" window.
 
 |      image file     |    size   |
 |---------------------|-----------|
 | [purebasiclogo.bmp] | 381x68 px |
 
-![PureBasic Gears Logo](./purebasiclogo.bmp)
+![PureBasic Gears Logo][purebasiclogo.bmp]
 
 
 ## PureBasic Splash Screen
 
-The PureBasic logo image shown while the PureBasic IDE starts up.
+The logo image shown while the PureBasic IDE starts up.
 
 |     image file    |    size    |
 |-------------------|------------|
@@ -94,9 +94,9 @@ A logotype of the SpiderBasic name, in different colours.
 The [`spiderbasicstartuplogo_forum.pdn`][spiderbasicstartuplogo_forum.pdn] file is a [Paint.NET] project file.
 
 
-![SpiderBasic Logotype red](./spiderbasicstartuplogo_forums.png)
+![SpiderBasic Logotype red][spiderbasicstartuplogo_forums.png]
 
-![SpiderBasic Logotype blue](./spiderbasicstartuplogo_forums_blue.png)
+![SpiderBasic Logotype blue][spiderbasicstartuplogo_forums_blue.png]
 
 
 <!-----------------------------------------------------------------------------

--- a/PureBasicIDE/data/SilkTheme/README.md
+++ b/PureBasicIDE/data/SilkTheme/README.md
@@ -2,13 +2,11 @@
 
 [![CC-BY-2.5][CC-BY badge]][CC-BY license]
 
-by Timo Harter
-(https://www.purebasic.com)
+by [Timo «Freak» Harter], member of the [PureBasic Team].
 
+This theme uses the icons (some slightly modified) from the __[Silk icon set 1.3]__ by [Mark James].
 
-This theme uses the icons (some slightly modified) from the __[Silk icon set 1.3]__ by Mark James.
-
-To reuse or distribute this theme, you must honor [the license terms by the original author] listed below.
+To reuse or distribute this theme, you must honor [the license terms by the original author], listed below.
 
 -----
 
@@ -31,10 +29,10 @@ To reuse or distribute this theme, you must honor [the license terms by the orig
 - [`Readme.txt`](./Readme.txt) — original info file attachment.
 - `*.png` (151) — theme icons + original icons that were modified.
 
-> __NOTE__ — Images with a filename beginning in `modified_` are the icons modified by Timo Harter, used in the actual IDE theme; their original version from the Silk Icon set is also included, with the same filename but without the `modified_` prefix.
+> __NOTE__ — Images with a filename beginning in `modified_` are the icons modified by [Timo «Freak» Harter], used in the actual IDE theme; their original version from the Silk Icon set is also included, with the same filename but without the `modified_` prefix.
 > Example:
 >
-> * [modified_find.png] (![icon][modified_find.png])  &rarr; [find.png] (![icon][find.png])
+> * [modified_find.png]  (![icon][modified_find.png])  &rarr; [find.png]  (![icon][find.png])
 
 # Icons Preview
 
@@ -126,6 +124,7 @@ contact mjames@gmail.com
                                REFERENCE LINKS
 ------------------------------------------------------------------------------>
 
+[PureBasic Team]: https://www.purebasic.com/support.php "Learn more about the PureBasic Team at www.PureBasic.com"
 [Silk icon set 1.3]: http://www.famfamfam.com/lab/icons/silk/ "Visit the Silk Icons page at www.famfamfam.com"
 
 <!-- xrefs -->
@@ -136,6 +135,11 @@ contact mjames@gmail.com
 
 [CC-BY license]: https://creativecommons.org/licenses/by/2.5/ "Creative Commons Attribution 2.5 Generic"
 [CC-BY badge]: https://img.shields.io/badge/License-CC--BY--2.5-blue
+
+<!-- people -->
+
+[Mark James]: https://twitter.com/markjames "Visit Mark James's profile on Twitter"
+[Timo «Freak» Harter]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=25 "Visit Timo «Freak» Harter's profile on the PureBasic Forums"
 
 <!-- image files -->
 

--- a/PureBasicIDE/data/SilkTheme/README.md
+++ b/PureBasicIDE/data/SilkTheme/README.md
@@ -92,6 +92,53 @@ To reuse or distribute this theme, you must honor [the license terms by the orig
 | [wand.png]                      | ![icon][wand.png]                      | [world.png]                     | ![icon][world.png]                     | [wrench.png]                   | ![icon][wrench.png]                   |
 | [zoom.png]                      | ![icon][zoom.png]                      |                                 |                                        |                                |                                       |
 
+# License and Info
+
+Original icon set information:
+
+```
+Silk icon set 1.3
+
+_________________________________________
+Mark James
+http://www.famfamfam.com/lab/icons/silk/
+_________________________________________
+
+This work is licensed under a
+Creative Commons Attribution 2.5 License.
+[ http://creativecommons.org/licenses/by/2.5/ ]
+
+This means you may use it for any purpose,
+and make any changes you like.
+All I ask is that you include a link back
+to this page in your credits.
+
+Are you using this icon set? Send me an email
+(including a link or picture if available) to
+mjames@gmail.com
+
+Any other questions about this icon set please
+contact mjames@gmail.com
+```
+
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[Silk icon set 1.3]: http://www.famfamfam.com/lab/icons/silk/ "Visit the Silk Icons page at www.famfamfam.com"
+
+<!-- xrefs -->
+
+[the license terms by the original author]: #license-and-info
+
+<!-- license badge -->
+
+[CC-BY license]: https://creativecommons.org/licenses/by/2.5/ "Creative Commons Attribution 2.5 Generic"
+[CC-BY badge]: https://img.shields.io/badge/License-CC--BY--2.5-blue
+
+<!-- image files -->
+
 [accept.png]: ./accept.png
 [add.png]: ./add.png
 [application_add.png]: ./application_add.png
@@ -243,52 +290,6 @@ To reuse or distribute this theme, you must honor [the license terms by the orig
 [world.png]: ./world.png
 [wrench.png]: ./wrench.png
 [zoom.png]: ./zoom.png
-
-# License and Info
-
-Original icon set information:
-
-```
-Silk icon set 1.3
-
-_________________________________________
-Mark James
-http://www.famfamfam.com/lab/icons/silk/
-_________________________________________
-
-This work is licensed under a
-Creative Commons Attribution 2.5 License.
-[ http://creativecommons.org/licenses/by/2.5/ ]
-
-This means you may use it for any purpose,
-and make any changes you like.
-All I ask is that you include a link back
-to this page in your credits.
-
-Are you using this icon set? Send me an email
-(including a link or picture if available) to
-mjames@gmail.com
-
-Any other questions about this icon set please
-contact mjames@gmail.com
-```
-
-
-<!-----------------------------------------------------------------------------
-                               REFERENCE LINKS
------------------------------------------------------------------------------->
-
-[Silk icon set 1.3]: http://www.famfamfam.com/lab/icons/silk/ "Visit the Silk Icons page at www.famfamfam.com"
-
-<!-- xrefs -->
-
-[the license terms by the original author]: #license-and-info
-
-<!-- license badge -->
-
-[CC-BY license]: https://creativecommons.org/licenses/by/2.5/ "Creative Commons Attribution 2.5 Generic"
-[CC-BY badge]: https://img.shields.io/badge/License-CC--BY--2.5-blue
-
 
 <!-- EOF -->
 

--- a/PureBasicIDE/data/SpiderBasic/README.md
+++ b/PureBasicIDE/data/SpiderBasic/README.md
@@ -1,0 +1,113 @@
+# SpiderBasic Logo and Icons
+
+Images of the SpiderBasic logo, icons and splash screen.
+
+The SpiderBasic logo was designed by Fabien Laboureur.
+
+-----
+
+**Table of Contents**
+
+<!-- MarkdownTOC autolink="true" bracket="round" autoanchor="false" lowercase="only_ascii" uri_encoding="true" levels="1,2,3" -->
+
+- [Folder Contents](#folder-contents)
+- [Images Info and Previews](#images-info-and-previews)
+    - [SpiderBasic Logo](#spiderbasic-logo)
+    - [SpiderBasic Icons](#spiderbasic-icons)
+    - [SpiderBasic IDE Splash Screen](#spiderbasic-ide-splash-screen)
+    - [SpiderBasic IDE "About" Logo](#spiderbasic-ide-about-logo)
+- [Notes on Editing the Icons](#notes-on-editing-the-icons)
+
+<!-- /MarkdownTOC -->
+
+-----
+
+# Folder Contents
+
+- [`About.bmp`][About.bmp] — logo shown in SpiderBasic IDE "About" window (381x68 px).
+- [`Logo.icns`][Logo.icns] — Mac OS X Icon Resource file.
+- [`Logo.ico`][Logo.ico] — SpiderBasic icon (256x256 px).
+- [`Logo.png`][Logo.png] — SpiderBasic logo (512x512 px).
+- [`Logo.psd`][Logo.psd] — Photoshop project for SpiderBasic logo (512x512 px).
+- [`Logo_16x16.png`][Logo_16x16.png] — SpiderBasic PNG icon (16x16 px).
+- [`Logo_32x32.png`][Logo_32x32.png] — SpiderBasic PNG icon (32x32 px).
+- [`Logo_48x48.png`][Logo_48x48.png] — SpiderBasic PNG icon (48x48 px).
+- [`Logo_256x256.png`][Logo_256x256.png] — SpiderBasic PNG icon (256x256 px).
+- [`SplashScreen.png`][SplashScreen.png] — SpiderBasic IDE splash screen (500x200 px).
+
+# Images Info and Previews
+
+Images info and previews, grouped by relevance.
+
+## SpiderBasic Logo
+
+The SpiderBasic logo Photoshop project (raster image) and its PNG version.
+
+| image file |    size    |
+|------------|------------|
+| [Logo.png] | 512x512 px |
+| [Logo.psd] | 512x512 px |
+
+![SpiderBasic logo][Logo.png]
+
+
+## SpiderBasic Icons
+
+The icon images in various formats and sizes.
+
+|     icon file      |    size    |        preview/description        |
+|--------------------|------------|-----------------------------------|
+| [Logo.icns]        |            | Mac OS X Icon Resource file       |
+| [Logo.ico]         | 256x256 px |                                   |
+| [Logo_16x16.png]   | 16x16 px   | ![icon 16x16][Logo_16x16.png]     |
+| [Logo_32x32.png]   | 32x32 px   | ![icon 32x32][Logo_32x32.png]     |
+| [Logo_48x48.png]   | 48x48 px   | ![icon 48x48][Logo_48x48.png]     |
+| [Logo_256x256.png] | 256x256 px | ![icon 256x256][Logo_256x256.png] |
+
+## SpiderBasic IDE Splash Screen
+
+The logo image shown while the SpiderBasic IDE starts up.
+
+|     image file     |    size    |
+|--------------------|------------|
+| [SplashScreen.png] | 500x200 px |
+
+## SpiderBasic IDE "About" Logo
+
+The logo shown in SpiderBasic IDE "__Help__ » __About__" window.
+
+|  image file |    size   |
+|-------------|-----------|
+| [About.bmp] | 381x68 px |
+
+![About.bmp][About.bmp]
+
+
+# Notes on Editing the Icons
+
+To edit the icons under Windows and Linux, you can use __[Greenfish Icon Editor Pro]__ (GFIE Pro), a powerful open source image editor, especially suitable for creating icons, cursors, animations and icon libraries.
+
+On Windows 7, 8 and 10, only icons in the 32x32, 48x48 and 256x256 formats are supported (although the Taskbar does display 24x24 icons, Window will not use a 24x24 icon found in the `.ico` file).
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+<!-- 3rd party tools -->
+
+[Greenfish Icon Editor Pro]: http://greenfishsoftware.org/gfie.php#apage
+
+<!-- image files -->
+
+[About.bmp]: ./About.bmp "Logo shown in SpiderBasic IDE 'About' window: 381x68 px"
+[Logo.icns]: ./Logo.icns "SpiderBasic Mac OS X Icon Resource file"
+[Logo.ico]: ./Logo.ico "SpiderBasic icon: 256x256 px"
+[Logo.png]: ./Logo.png "SpiderBasic Logo: 512x512 px"
+[Logo.psd]: ./Logo.psd "SpiderBasic Logo, Photoshop project: 512x512 px"
+[Logo_16x16.png]: ./Logo_16x16.png "SpiderBasic PNG icon: 16x16 px"
+[Logo_32x32.png]: ./Logo_32x32.png "SpiderBasic PNG icon: 32x32 px"
+[Logo_48x48.png]: ./Logo_48x48.png "SpiderBasic PNG icon: 48x48 px"
+[Logo_256x256.png]: ./Logo_256x256.png "SpiderBasic PNG icon: 256x256 px"
+[SplashScreen.png]: ./SplashScreen.png "SpiderBasic IDE splash screen: 500x200 px"
+
+<!-- EOF -->

--- a/PureBasicIDE/data/SpiderBasic/ReadMe Icon.txt
+++ b/PureBasicIDE/data/SpiderBasic/ReadMe Icon.txt
@@ -1,3 +1,0 @@
-On Windows, we can use "Greenfish Icon Editor Pro", which is free and veruy powerful.
-On Windows 7-8-10, only 32x32, 48x48 and 256x256 format are supported (even if the bottom Windows toolbar display 24x24 icon, 
-it won't be used if found in the .ico file).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Welcome to __PureBasic OpenSources Projects__, a central public repository to ac
     - [Downloading a ZIP Archive](#downloading-a-zip-archive)
     - [Cloning the Repository Locally via Git](#cloning-the-repository-locally-via-git)
     - [Forking on GitHub](#forking-on-github)
+- [Credits](#credits)
+    - [Silk Icon Set](#silk-icon-set)
+- [Acknowledgements](#acknowledgements)
 - [License](#license)
 - [Links](#links)
 
@@ -90,6 +93,35 @@ After forking the repository, to download a local copy you should then clone _yo
 where `<your GitHub username>` is whatever user name you registered your GitHub account with.
 
 
+# Credits
+
+The list of third party components used in this project, with due credits to their authors and license terms.
+More details can be found inside the folder of each asset.
+
+## Silk Icon Set
+
+- [`PureBasicIDE/data/SilkTheme/`][SilkTheme]
+
+The __Silk Icon Theme__ included with PureBasic and SpiderBasic IDEs is based on [Mark James]'s __[Silk icon set 1.3]__, released under [CC-BY-2.5].
+Some icons were slightly modified by [Timo «Freak» Harter].
+
+[CC-BY-2.5]: https://creativecommons.org/licenses/by/2.5/ "Creative Commons Attribution 2.5 Generic"
+[Silk icon set 1.3]: http://www.famfamfam.com/lab/icons/silk/ "Visit the Silk Icons page at www.famfamfam.com"
+
+
+# Acknowledgements
+
+Our gratitude goes out to all those who helped us improve PureBasic and SpiderBasic in the course of time.
+The list is quite long, and we refer you to the Acknowledgements section of the [PureBasic][AcknPB] and [SpiderBasic][AcknSB] documentation for more details.
+
+Here follows a list of people who contributed to the assets found in this repository.
+The list is still in the making and incomplete, and we apologise for any temporary omissions.
+
+- __[Gary «Kale» Willoughby]__ — for designing the [default theme] of the PureBasic IDE.
+- __[Timo «Freak» Harter]__ — for the IDE, the Debugger, many commands and great ideas. PureBasic wouldn't be the same without him!
+- __Fabien Laboureur__ — for designing the [SpiderBasic logo].
+
+
 # License
 
 - [`LICENSE`][GPL License] — GPLv3
@@ -137,7 +169,12 @@ work in the PureBasic package.
 [PBF DE]: https://www.purebasic.fr/german "PureBasic forum for German speakers"
 [PBF FR]: https://www.purebasic.fr/french "PureBasic forum for French speakers"
 
-<!-- 3r party websites -->
+<!-- PureBasic and SpiderBasic documentation -->
+
+[AcknPB]: https://www.purebasic.com/documentation/mainguide/greats.html "Read the Acknowledgements section of PureBasic documentation"
+[AcknSB]: https://www.spiderbasic.com/documentation/mainguide/greats.html "Read the Acknowledgements section of SpiderBasic documentation"
+
+<!-- 3rd party websites -->
 
 [Git]: https://git-scm.com "Visit Git website"
 
@@ -164,5 +201,17 @@ work in the PureBasic package.
 
 [GPL License]: ./LICENSE "The GNU General Public License v3"
 [Fantaisie License]: ./LICENSE-FANTAISIE "The Fantaisie Software License"
+
+<!-- project folders -->
+
+[default theme]: ./PureBasicIDE/data/DefaultTheme/ "Navigate to the Default Theme folder"
+[SilkTheme]: ./PureBasicIDE/data/SilkTheme/ "Navigate to the Silk Icon Theme folder"
+[SpiderBasic logo]: ./PureBasicIDE/data/SpiderBasic/ "Navigate to the SpiderBasic logo folder"
+
+<!-- people -->
+
+[Gary «Kale» Willoughby]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit Gary «Kale» Willoughby's profile on the PureBasic Forums"
+[Mark James]: https://twitter.com/markjames "Visit Mark James's profile on Twitter"
+[Timo «Freak» Harter]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=25 "Visit Timo «Freak» Harter's profile on the PureBasic Forums"
 
 <!-- EOF -->


### PR DESCRIPTION
These commits all relate to adding README files to various subfolders, providing info about their contents and image previews.

The goal is to improve the navigation experience and contents discovery on GitHub WebUI, reducing the overwhelming impact of a project that contains so many files. The ultimate goal is to provide in each folder a README file that allows end users to grasp what's there and what does what, without having to leave the page in order to peek at previews of single files (code or image) or folders.

I've kept the commits separate, instead of squashing them together into a huge single commit, because this is a long term task and more commits of this type are on the way anyhow, so it's worth keeping them to human-manageable sizes.

