### PR TITLE
Add Escape shortcut to close Build Window

### DIFF
--- a/PureBasicIDE/CompilerWindow.pb
+++ b/PureBasicIDE/CompilerWindow.pb
@@ -489,6 +489,13 @@ EndProcedure
 Procedure BuildWindowEvents(EventID)
   Quit = 0
   
+  If EventID = #PB_Event_Menu     ; Little wrapper to map the shortcut events (identified as menu)
+    EventID  = #PB_Event_Gadget   ; to normal gadget events...
+    GadgetID = EventMenu()
+  Else
+    GadgetID = EventGadget()
+  EndIf
+  
   If EventID = #PB_Event_Gadget
     Select EventGadget()
       Case #GADGET_Build_Targets
@@ -558,7 +565,11 @@ Procedure BuildWindowEvents(EventID)
         ForEver
         
       Case #GADGET_Build_Close
-        Quit = 1
+        ; CompilerBusy goes to 0 after each target
+        ; UseProjectBuildWindow goes to 0 when all are done
+        If (Not CompilerBusy) And (Not UseProjectBuildWindow)
+          Quit = 1
+        EndIf
         
     EndSelect
     

--- a/PureBasicIDE/dialogs/Build.xml
+++ b/PureBasicIDE/dialogs/Build.xml
@@ -40,4 +40,6 @@
     </multibox>
 
   </vbox>
+  
+  <shortcut key="#PB_Shortcut_Escape" id="#GADGET_Build_Close" />
 </window>


### PR DESCRIPTION
Add an Escape shortcut to the Build All window — but only allow it once all targets are finished.

It maps the shortcut's Menu event to a "Close" Gadget event, like the Find and About windows do.

I'm pulling to `master` because a `development` branch hasn't been created yet — should be OK for VERY simple features like this!