### PR TITLE
Dark mode support for macOS

### DIFF
--- a/PureBasicIDE/AboutWindow.pb
+++ b/PureBasicIDE/AboutWindow.pb
@@ -57,7 +57,10 @@ Procedure OpenAboutWindow()
               "Thanks to Neil Hodgson for the scintilla" + #NewLine +
               "editing component." + #NewLine +
               #NewLine +
-              "Scintilla © 1998-2017 Neil Hodgson <neilh@scintilla.org> "
+              "Scintilla © 1998-2017 Neil Hodgson <neilh@scintilla.org> " + #NewLine +
+              #NewLine +
+              "Thanks to Wimer Hazenberg for Monokai color palette." + #NewLine +
+              "http://www.monokai.nl/"
       
       ; For better debugging
       ;

--- a/PureBasicIDE/MacExtensions.pb
+++ b/PureBasicIDE/MacExtensions.pb
@@ -206,4 +206,29 @@ CompilerIf #CompileMacCocoa
     RunProgram("open", Url$, "")
   EndProcedure
   
+  Procedure GetCocoaColor(NSColorName.s)
+    Protected.CGFloat r, g, b, a
+    Protected NSColor, NSColorSpace
+    
+    ; There is no controlAccentColor on macOS < 10.14
+    If NSColorName = "controlAccentColor" And OSVersion() < #PB_OS_MacOSX_10_14
+      ProcedureReturn $D5ABAD
+    EndIf
+    
+    ; There are no system colors on macOS < 10.10
+    If Left(NSColorName, 6) = "system" And OSVersion() < #PB_OS_MacOSX_10_10
+      NSColorName = LCase(Mid(NSColorName, 7, 1)) + Mid(NSColorName, 8)
+    EndIf
+    
+    NSColorSpace = CocoaMessage(0, 0, "NSColorSpace deviceRGBColorSpace")
+    NSColor = CocoaMessage(0, CocoaMessage(0, 0, "NSColor " + NSColorName), "colorUsingColorSpace:", NSColorSpace)
+    If NSColor
+      CocoaMessage(@r, NSColor, "redComponent")
+      CocoaMessage(@g, NSColor, "greenComponent")
+      CocoaMessage(@b, NSColor, "blueComponent")
+      CocoaMessage(@a, NSColor, "alphaComponent")
+      ProcedureReturn RGBA(r * 255.0, g * 255.0, b * 255.0, a * 255.0)
+    EndIf
+  EndProcedure
+  
 CompilerEndIf

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -5389,7 +5389,7 @@ DataSection
   
   CompilerIf #SpiderBasic
     
-    Data.l 9
+    Data.l 10
     
     ; now each color scheme. first the name string, then the front & backcolor
     ; for the toolspanel, then all the colors
@@ -5440,7 +5440,7 @@ DataSection
   CompilerElse
     
     ; total number of defined schemes:
-    Data.l 8
+    Data.l 9
     
   CompilerEndIf
   
@@ -5617,6 +5617,49 @@ DataSection
   Data.l $C08000 ; #COLOR_Module
   Data.l $464646 ; #COLOR_SelectionRepeat
   Data.l $000000 ; #COLOR_PlainBackground
+  
+  ; Based on the Monokai color scheme, copyright by Wimer Hazenberg (https://monokai.nl)
+  Data$ "Monokai"
+  Data.l $C2CFCF
+  Data.l $222827
+  Data.l $EFD966 ; #COLOR_ASMKeyword
+  Data.l $222827 ; #COLOR_Background
+  Data.l $7226F9 ; #COLOR_BasicKeyword
+  Data.l $5E7175 ; #COLOR_Comment
+  Data.l $FF81AE ; #COLOR_Constant
+  Data.l $669FE6 ; #COLOR_Label
+  Data.l $F2F8F8 ; #COLOR_NormalText
+  Data.l $FF81AE ; #COLOR_Number
+  Data.l $7226F9 ; #COLOR_Operator
+  Data.l $FF81AE ; #COLOR_Pointer
+  Data.l $2EE2A6 ; #COLOR_PureKeyword
+  Data.l $F0F8F8 ; #COLOR_Separator
+  Data.l $74DBE6 ; #COLOR_String
+  Data.l $2EE2A6 ; #COLOR_Structure
+  Data.l $808080 ; #COLOR_LineNumber
+  Data.l $222827 ; #COLOR_LineNumberBack
+  Data.l $AAAA00 ; #COLOR_Marker
+  Data.l $292929 ; #COLOR_CurrentLine
+  Data.l $C0C0C0 ; #COLOR_Selection
+  Data.l $000000 ; #COLOR_SelectionFront
+  Data.l $F0F8F8 ; #COLOR_Cursor
+  Data.l $F2F8F8 ; #COLOR_DebuggerLine
+  Data.l $F2F8F8 ; #COLOR_DebuggerLineSymbol
+  Data.l $0000FF ; #COLOR_DebuggerError
+  Data.l $0000FF ; #COLOR_DebuggerErrorSymbol
+  Data.l $99994D ; #COLOR_DebuggerBreakPoint
+  Data.l $99994D ; #COLOR_DebuggerBreakpointSymbol
+  Data.l $1E1E1E ; #COLOR_DisabledBack
+  Data.l $669FE6 ; #COLOR_GoodBrace
+  Data.l $7226F9 ; #COLOR_BadBrace
+  Data.l $222827 ; #COLOR_ProcedureBack
+  Data.l $EFD966 ; #COLOR_CustomKeyword
+  Data.l $0080FF ; #COLOR_DebuggerWarning
+  Data.l $0080FF ; #COLOR_DebuggerWarningSymbol
+  Data.l $808080 ; #COLOR_Whitespace
+  Data.l $2EE2A6 ; #COLOR_Module
+  Data.l $464646 ; #COLOR_SelectionRepeat
+  Data.l $222827 ; #COLOR_PlainBackground
   
   Data$ "Blue Style"
   Data.l $80FFFF

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -699,8 +699,14 @@ Procedure IsPureBasicFile(FileName$)
           AddTabBarGadgetItem(#GADGET_FilesPanel, 0, Language("Project", "TabTitle"))
         EndIf
         
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
+        CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
+          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+        CompilerElse
+          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
+        CompilerEndIf
+        
         SetTabBarGadgetItemImage(#GADGET_FilesPanel, 0, OptionalImageID(#IMAGE_FilePanel_Project))
         
         UpdateProjectInfo()

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -46,22 +46,41 @@ Procedure RefreshSourceTitle(*Source.SourceFile)
   
   SetTabBarGadgetItemText(#GADGET_FilesPanel, Index, GetSourceTitle(*Source))
   
-  If *Source = *ProjectInfo
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
-  ElseIf *Source\IsForm And *Source\ProjectFile
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormProjectFile)
-  ElseIf *Source\IsForm
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormFile)
-  ElseIf *Source\ProjectFile
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectFile)
-  Else
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #PB_Default)
-  EndIf
+  CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
+    If *Source = *ProjectInfo
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+    ElseIf *Source\IsForm And *Source\ProjectFile
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+    ElseIf *Source\IsForm
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+    ElseIf *Source\ProjectFile
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+    Else
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlBackgroundColor"))
+    EndIf
+  CompilerElse
+    If *Source = *ProjectInfo
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
+    ElseIf *Source\IsForm And *Source\ProjectFile
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormProjectFile)
+    ElseIf *Source\IsForm
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormFile)
+    ElseIf *Source\ProjectFile
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectFile)
+    Else
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #PB_Default)
+    EndIf
+  CompilerEndIf
 EndProcedure
 
 ; get the title string for the current element in FileList()

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -589,44 +589,54 @@ Procedure CustomizeTabBarGadget()
   CompilerEndIf
   
   CompilerIf #CompileMac
-    ;
-    ; Note: The GetThemeBrushAsColor() color below always gives me full white no matter what brush i try (except the black brush),
-    ;   so i think there is something wrong with that.
-    ;   Try the 10.4+ only alternative first in the x86 version where this is always available
-    ;
-    HIThemeBrushCreateCGColor(#kThemeBrushAlertBackgroundActive, @CGColor.i)
-    If CGColor
-      NbComponents = CGColorGetNumberOfComponents(CGColor)
-      *Components  = CGColorGetComponents(CGColor)
-      
-      If *Components And NbComponents = 2 ; its grey and alpha
-        
-        CompilerIf #PB_Compiler_Processor = #PB_Processor_x64 ; CGFloat is a double on 64 bit system
-          c = 255 * PeekD(*Components)
-        CompilerElse
-          c = 255 * PeekF(*Components)
-        CompilerEndIf
-        
-        TabBarGadgetInclude\TabBarColor = RGBA(c, c, c, $FF)
-        
-      ElseIf *Components And NbComponents = 4 ; its rgba
-        
-        CompilerIf #PB_Compiler_Processor = #PB_Processor_x64
-          r = 255 * PeekD(*Components)
-          g = 255 * PeekD(*Components + 8)
-          b = 255 * PeekD(*Components + 16)
-        CompilerElse
-          r = 255 * PeekF(*Components)
-          g = 255 * PeekF(*Components + 4)
-          b = 255 * PeekF(*Components + 8)
-        CompilerEndIf
-        
-        TabBarGadgetInclude\TabBarColor = RGBA(r, g, b, $FF)
+    With TabBarGadgetInclude
+      If OSVersion() >= #PB_OS_MacOSX_10_14
+        \TabBarColor   = GetCocoaColor("windowBackgroundColor")
+      Else
+        ;
+        ; Note: The GetThemeBrushAsColor() color below always gives me full white no matter what brush i try (except the black brush),
+        ;   so i think there is something wrong with that.
+        ;   Try the 10.4+ only alternative first in the x86 version where this is always available
+        ;
+        HIThemeBrushCreateCGColor(#kThemeBrushAlertBackgroundActive, @CGColor.i)
+        If CGColor
+          NbComponents = CGColorGetNumberOfComponents(CGColor)
+          *Components  = CGColorGetComponents(CGColor)
+          
+          If *Components And NbComponents = 2 ; its grey and alpha
+            
+            CompilerIf #PB_Compiler_Processor = #PB_Processor_x64 ; CGFloat is a double on 64 bit system
+              c = 255 * PeekD(*Components)
+            CompilerElse
+              c = 255 * PeekF(*Components)
+            CompilerEndIf
+            
+            \TabBarColor = RGBA(c, c, c, $FF)
+            
+          ElseIf *Components And NbComponents = 4 ; its rgba
+            
+            CompilerIf #PB_Compiler_Processor = #PB_Processor_x64
+              r = 255 * PeekD(*Components)
+              g = 255 * PeekD(*Components + 8)
+              b = 255 * PeekD(*Components + 16)
+            CompilerElse
+              r = 255 * PeekF(*Components)
+              g = 255 * PeekF(*Components + 4)
+              b = 255 * PeekF(*Components + 8)
+            CompilerEndIf
+            
+            \TabBarColor = RGBA(r, g, b, $FF)
+          EndIf
+          
+          CGColorRelease(CGColor)
+        EndIf
       EndIf
-      
-      CGColorRelease(CGColor)
-    EndIf
+      \BorderColor   = GetCocoaColor("systemGrayColor")
+      \FaceColor     = GetCocoaColor("controlBackgroundColor")
+      \TextColor     = GetCocoaColor("textColor")
+    EndWith
   CompilerEndIf
+  
 EndProcedure
 
 Procedure CreateGUI()
@@ -635,6 +645,13 @@ Procedure CreateGUI()
   LoadEditorFonts()
   
   If OpenWindow(#WINDOW_Main, EditorWindowX, EditorWindowY, EditorWindowWidth, EditorWindowHeight, DefaultCompiler\VersionString$, #WINDOW_Main_Flags)
+    
+    CompilerIf #CompileMac
+      ; Quick fix for TabBarGadget And ToolbarGadget lack of transparency support
+      If OSVersion() >= #PB_OS_MacOSX_10_14
+        SetWindowColor(#WINDOW_Main, GetCocoaColor("windowBackgroundColor"))
+      EndIf
+    CompilerEndIf
     
     SmartWindowRefresh(#WINDOW_Main, 1)
     

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Welcome to __PureBasic OpenSources Projects__, a central public repository to ac
 - [Contributing](#contributing)
 - [Credits](#credits)
     - [Libmba](#libmba)
+    - [Monokai Theme](#monokai-theme)
     - [Silk Icon Set](#silk-icon-set)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
@@ -120,13 +121,22 @@ The MIT License
 Copyright (c) 2001-2005 Michael B. Allen <mba2000 ioplex.com>
 ```
 
+## Monokai Theme
+
+- [`PureBasicIDE/Preferences.pb`][MonokaiTheme]
+
+The PureBasic IDE uses the Monokai color scheme, created by [Wimer Hazenberg].
+
+    Monokai, copyright by Wimer Hazenberg (https://monokai.nl)
+
+The Monokai scheme is free to use provided that the above copyright notice and link to the author website are included in any work using the scheme.
+
 ## Silk Icon Set
 
 - [`PureBasicIDE/data/SilkTheme/`][SilkTheme]
 
 The __Silk Icon Theme__ included with PureBasic and SpiderBasic IDEs is based on [Mark James]'s __[Silk icon set 1.3]__, released under [CC-BY-2.5].
 Some icons were slightly modified by [Timo «Freak» Harter].
-
 
 # Acknowledgements
 
@@ -227,6 +237,7 @@ work in the PureBasic package.
 [GPL License]: ./LICENSE "The GNU General Public License v3"
 [Fantaisie License]: ./LICENSE-FANTAISIE "The Fantaisie Software License"
 [CONTRIBUTING.md]: ./CONTRIBUTING.md "Contributors' Guidelines"
+[MonokaiTheme]: ./PureBasicIDE/Preferences.pb#L5621 "View the source file containing the Monokai color scheme"
 
 <!-- project folders -->
 
@@ -240,5 +251,6 @@ work in the PureBasic package.
 [Gary «Kale» Willoughby]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit Gary «Kale» Willoughby's profile on the PureBasic Forums"
 [Mark James]: https://twitter.com/markjames "Visit Mark James's profile on Twitter"
 [Timo «Freak» Harter]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=25 "Visit Timo «Freak» Harter's profile on the PureBasic Forums"
+[Wimer Hazenberg]: https://www.monokai.nl/ "Visit Wimer Hazenberg's website"
 
 <!-- EOF -->


### PR DESCRIPTION
Adds a basic dark mode and theme accent support to the IDE (needs to be compiled with a recent XCode).

What it does in details:
1. Adds Cocoa-specific procedure GetCocoaColor(), tuned to support older macOS versions down to 10.4.
2. Explicitly sets window color to [windowBackgroundColor](https://developer.apple.com/documentation/appkit/nscolor/1528630-windowbackgroundcolor?language=objc) to mitigate the lack of transparency support in TabBarGadget and StatusBar.
3. Sets mode-specific colors for TabBarGadget.
4. Adds a Monokai theme to Preferences - one of the most popular dark themes that fits perfectly to macOS dark mode.

I tried to make it as non-intrusive as possible and this is the bare minimum.

Limitations:
1. No support for theme switching on the fly, since it requires a large rework inside TabBarGadget and probably massive changes for Scintilla theming approach. I feel it's kinda out of scope for this PR.
2. ScintillaGadget has a light border so i tried to use that as a design feature, but ideally this should be fixed someday.

Screenshots:
![](https://d7.wtf/NonlayingTerebraConflow.png)
![](https://d7.wtf/CirculateWorkpeopleUnattracting.png)