### PR TITLE
Check for IDE Settings in Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ install:
   - npm install -g eclint
 
 script:
-  # ==============================================
-  # EditorConfig Code Styles Validation via EClint
-  # ==============================================
-  # https://editorconfig.org
-  # https://www.npmjs.com/package/eclint
+  # =======================
+  # Source Files Validation
+  # =======================
+  # 1. Check PureBasic sources for IDE Settings.
+  # 2. Validate EditorConfig code styles via EClint:
+  #      https://editorconfig.org
+  #      https://www.npmjs.com/package/eclint
   - bash ./validate.sh

--- a/PureBasicDebugger/Communication.pb
+++ b/PureBasicDebugger/Communication.pb
@@ -1102,11 +1102,3 @@ Procedure Debugger_NetworkConnect(Mode, Host$, Port, Password$)
   ; return the debugger structure
   ProcedureReturn @RunningDebuggers()
 EndProcedure
-
-
-; IDE Options = PureBasic 5.20 beta 12 LTS (Linux - x64)
-; CursorPosition = 840
-; FirstLine = 822
-; Folding = ---
-; EnableUnicode
-; EnableXP

--- a/PureBasicDebugger/Communication_PipeUnix.pb
+++ b/PureBasicDebugger/Communication_PipeUnix.pb
@@ -686,10 +686,3 @@ CompilerIf #CompileWindows = 0
   EndDataSection
   
 CompilerEndIf
-
-
-; IDE Options = PureBasic 5.20 beta 12 LTS (Linux - x64)
-; CursorPosition = 538
-; FirstLine = 515
-; Folding = ---
-; EnableXP

--- a/PureBasicDebugger/DebuggerCommon.pb
+++ b/PureBasicDebugger/DebuggerCommon.pb
@@ -1029,9 +1029,3 @@ CompilerIf Defined(PUREBASIC_IDE, #PB_Constant) = 0 ; only define if it is the s
   #FILE_LoadFunctions = 0
   #FILE_LoadAPI = 1
 CompilerEndIf
-; IDE Options = PureBasic 5.21 LTS (Linux - x64)
-; CursorPosition = 35
-; FirstLine = 20
-; Folding = ----
-; EnableUnicode
-; EnableXP

--- a/PureBasicDebugger/History.pb
+++ b/PureBasicDebugger/History.pb
@@ -392,8 +392,3 @@ Procedure History_DebuggerEvent(*Debugger.DebuggerData)
   EndSelect
   
 EndProcedure
-; IDE Options = PureBasic 5.20 beta 12 LTS (Linux - x64)
-; CursorPosition = 271
-; FirstLine = 267
-; Folding = -
-; EnableXP

--- a/PureBasicDebugger/MemoryViewer.pb
+++ b/PureBasicDebugger/MemoryViewer.pb
@@ -739,9 +739,3 @@ DataSection
   Data$ "[CAN]", "[EM]" , "[SUB]", "[ESC]", "[FS]" , "[GS]" , "[RS]" , "[US]"
   
 EndDataSection
-; IDE Options = PureBasic 5.20 beta 12 LTS (Linux - x64)
-; CursorPosition = 692
-; FirstLine = 671
-; Folding = ----
-; EnableUnicode
-; EnableXP

--- a/PureBasicDebugger/Standalone_Common.pb
+++ b/PureBasicDebugger/Standalone_Common.pb
@@ -135,9 +135,3 @@ Global NewList CustomKeywordList.s()
 ; this is required for Language.pb of the ide
 Procedure BuildShortcutNamesTable()
 EndProcedure
-
-; IDE Options = PureBasic 5.20 beta 2 (Windows - x64)
-; CursorPosition = 127
-; FirstLine = 97
-; Folding = -
-; EnableXP

--- a/PureBasicDebugger/Standalone_Preferences.pb
+++ b/PureBasicDebugger/Standalone_Preferences.pb
@@ -469,8 +469,3 @@ Procedure Standalone_SavePreferences()
   EndIf
   
 EndProcedure
-; IDE Options = PureBasic 5.20 beta 2 (Windows - x64)
-; CursorPosition = 203
-; FirstLine = 174
-; Folding = -
-; EnableXP

--- a/PureBasicDebugger/Standalone_ScintillaStuff.pb
+++ b/PureBasicDebugger/Standalone_ScintillaStuff.pb
@@ -654,8 +654,3 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
   EndProcedure
   
 CompilerEndIf
-; IDE Options = PureBasic 5.20 beta 2 (Windows - x64)
-; CursorPosition = 484
-; FirstLine = 464
-; Folding = ---
-; EnableXP

--- a/PureBasicDebugger/VariableDebug.pb
+++ b/PureBasicDebugger/VariableDebug.pb
@@ -1891,11 +1891,3 @@ Procedure VariableDebug_DebuggerEvent(*Debugger.DebuggerData)
   EndSelect
   
 EndProcedure
-
-
-
-; IDE Options = PureBasic 5.20 beta 12 LTS (Linux - x64)
-; CursorPosition = 1075
-; FirstLine = 1071
-; Folding = --
-; EnableXP

--- a/validate.sh
+++ b/validate.sh
@@ -23,10 +23,10 @@ for pbfile in $(find . 	-name '*.pb'  -o \
 						-name '*.pbi' -o \
 						-name '*.pbf' );
 do
-    result="$(grep -c '^; IDE Options =' $pbfile)"
-    if [ "$result" != "0" ] ; then
-    	echo "$pbfile" >> $tmpLog
-    	passed=
+	result="$(grep -c '^; IDE Options =' $pbfile)"
+	if [ "$result" != "0" ] ; then
+		echo "$pbfile" >> $tmpLog
+		passed=
 	fi
 done
 


### PR DESCRIPTION

The firs of these two commits solves the problem of IDE Settings creeping into the repository files accidentally (as discussed in #15). In the end, I opted to use GREP to check for the presence of IDE setting in any PB sources (`*.pb`, `*.pbi`, `*.pbf`).

The second commit removes IDE settings from a number of sources that still had them (not sure if they were there before or if they creped back with some recent PR).

