### PR TITLE
Git compliance improvements/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ ___*.*
 *.lnk
 *.url
 
+# Generated output files
+Build/
+
 ## ==================
 ## Binary Executables
 ## ==================

--- a/BUILD.md
+++ b/BUILD.md
@@ -50,7 +50,6 @@ PureBasic to open the "`PureBasic IDE.pbp`" project file and
 run it from PureBasic itself (be sure to adjust the constants in 'Compilers Options.../Contants')
 
 - The `#BUILD_DIRECTORY` constant must point to the Build/x64/ide/ folder created before by the 'make'
-- The `#PureBasicPath` constant must point to a full PureBasic installation.
 
 Don't hesitate to [drop a word] to improve this build guide, as right now it's very slim!
 

--- a/PureBasicIDE/PureBasic IDE.pbp
+++ b/PureBasicIDE/PureBasic IDE.pbp
@@ -358,11 +358,10 @@
       <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
-        <constant value="#BUILD_DIRECTORY=C:\PureBasic\GitHub\purebasic\Build\x64\ide\" enable="1"/>
+        <constant value="#BUILD_DIRECTORY=..\Build\x64\ide\" enable="1"/>
         <constant value="#FredLocalCompile=1" enable="0"/>
         <constant value="#SpiderBasic=1" enable="0"/>
         <constant value="#SVNVersion=&quot;v5.70&quot;" enable="0"/>
-        <constant value="#PureBasicPath=C:\PureBasic\Svn\v5.70\Build\PureBasic_x64\" enable="1"/>
       </constants>
     </target>
   </section>

--- a/PureBasicIDE/PureBasic.pb
+++ b/PureBasicIDE/PureBasic.pb
@@ -275,8 +275,18 @@ Procedure CloseSplashScreen()
   
   If IsClosed = 0 And NoSplashScreen = 0
     IsClosed = 1
-    CloseWindow(#WINDOW_Startup)
-    FreeImage(#IMAGE_Startup)
+    CompilerIf #PB_Compiler_Debugger
+      ; Prevent debugger errors when missing Scintilla.dll causes early exit
+      If IsWindow(#WINDOW_Startup)
+        CloseWindow(#WINDOW_Startup)
+      EndIf
+      If IsImage(#IMAGE_Startup)
+        FreeImage(#IMAGE_Startup)
+      EndIf
+    CompilerElse
+      CloseWindow(#WINDOW_Startup)
+      FreeImage(#IMAGE_Startup)
+    CompilerEndIf
   EndIf
 EndProcedure
 

--- a/PureBasicIDE/WindowsMisc.pb
+++ b/PureBasicIDE/WindowsMisc.pb
@@ -97,7 +97,7 @@ CompilerIf #CompileWindows
         CompilerEndIf
       CompilerEndIf
       
-      ; PureBasicPath$ = "C:\Users\GDupontPanon\Downloads\PureBasicEnvironment\PureBasicEnvironment\svn\v5.10\Build\PureBasic_x86\" ; Fred config
+      PureBasicPath$ = #PB_Compiler_Home
       
     CompilerEndIf
     


### PR DESCRIPTION
Here are some small changes which I think improve the repo:

- Set Git to ignore the generated `Build` subfolder
- Remove the hard-coded constant `#PureBasicPath` which doesn't seem to be used anymore
- Change `#BUILD_DIRECTORY` from a hard-coded absolute path to a relative path
- Set `PureBasicPath$` to `#PB_Compiler_Home` instead of a hard-coded path
- Prevent 2 debugger errors whenever `Scintilla.dll` is not found (can happen a lot while getting the repo up-and-running)