### PR TITLE
Balance keywords to fix incorrect indentation

### DIFF
--- a/PureBasicDebugger/Communication_Network.pb
+++ b/PureBasicDebugger/Communication_Network.pb
@@ -17,1409 +17,1411 @@ CompilerIf #CompileWindows
   Import "wsock32.lib"
   EndImport
   
-  ImportC #BUILD_DIRECTORY + "NetworkSupport.obj"
-  CompilerElse
+  #NetworkSupport_Library = "NetworkSupport.obj"
+CompilerElse
+  
+  #SOCKET_ERROR = -1
+  #INVALID_SOCKET = -1
+  
+  #NetworkSupport_Library = "NetworkSupport.o"
+CompilerEndIf
+
+ImportC #BUILD_DIRECTORY + #NetworkSupport_Library
+  
+  ; // Wrappers For the simple stuff For consistency
+  ; //
+  Network_Initialize()
+  Network_CreateSocket()
+  Network_CloseSocket(Socket)
+  
+  ; // Only initiates the connect.
+  ; // Use Network_ConnectSocketCheck() To wait For a connection/failure.
+  ; // Returns 0 on failure
+  ; //
+  Network_ConnectSocketStart(Socket, Hostname.p-ascii, Port)
+  
+  ; // Check the status of a connect()
+  ; //
+  ; // Returns:
+  ; //   0 = still pending
+  ; //   1 = connected
+  ; //   2 = connection failed
+  ; //
+  Network_ConnectSocketCheck(Socket)
+  
+  ; // Put the socket in listen mode (1 connection max)
+  ; // If Interface is empty, bind to all interfaces
+  ; //
+  Network_Listen(Socket, InterfaceName.p-ascii, Port)
+  
+  ; // Check If an incoming connection is made on a listening socket, does Not block
+  ; // returns new Socket Or SOCKET_ERROR (= no incoming connection)
+  ; //
+  Network_CheckAccept(Socket)
+  
+  ; // Check if data is ready For reading
+  ; //
+  ; // Returns:
+  ; //   0 = no Data
+  ; //   1 = Data available
+  ; //   2 = disconnect
+  Network_CheckData(Socket)
+  
+  ; // Ensure the Data is Read fully
+  ; // Returns true If ok, false If network disconnect
+  ; //
+  Network_ReceiveData(Socket, *Buffer, Size)
+  
+  ; // Blocking send of Data
+  ; // Returns true If ok, false If network disconnect
+  ; //
+  Network_SendData(Socket, *Buffer, Size)
+  
+  ; // Blocking send of string Data (ascii)
+  ; // Returns true If ok, false If network disconnect
+  ; //
+  Network_SendString(Socket, String.p-ascii)
+  
+EndImport
+
+ImportC ""
+  
+  ; Import of the AES functions (included in Cypher lib, linked because we use MD5 too)
+  ; (so we do not have to use the PB object system for thread safety)
+  ;
+  rijndael_set_key.l(*context, *key, bits)
+  
+  rijndael_ecb_decrypt.l(*context, *input, *output, length)
+  rijndael_ecb_encrypt.l(*context, *input, *output, length)
+  rijndael_cbc_decrypt.l(*context, *input, *output, length, *iv)
+  rijndael_cbc_encrypt.l(*context, *input, *output, length, *iv)
+  
+  ; imported so we can get the binary data instead of the string (for key creation)
+  MD5Init(*Context)
+  MD5Update(*Context, *Buffer, Size)
+  MD5Final(*Output, *Context)
+  
+EndImport
+
+#SizeOf_rijndael_ctx = 488 ; size in bytes of a context structure (in C)
+#SizeOf_MD5_ctx      = 88
+
+DataSection
+  
+  CiperInitializer:
+  Data.b $D7, $2F, $E7, $B8, $AA, $9F, $E9, $01, $A5, $A5, $09, $58, $C9, $85, $A9, $CC
+  
+EndDataSection
+
+; in bytes, must be multiple of 16, not too large (can be different from debugger lib)
+#EncryptionHandshakeSize = 32
+
+;- ----> Data structure
+Structure Network_Communication
+  *Vtbl.CommunicationVtbl
+  
+  Host$
+  Password$
+  Port.l
+  
+  Connected.l         ; should we try to read or not ?
+  IsFatalError.l
+  CommandReceived.l   ; was there any command received yet?
+  CommandTimeout.q    ; time of exe creation for timeout test
+  EndReceived.l       ; was #COMMAND_End received yet ?
+  EndTimeout.q        ; time of exe quit, timeout to be able to receive COMMAND_End before firing an error
+  
+  Socket.i
+  
+  ; The command stack is protected by a mutex separate from the overall
+  ; "receive" mutex, so commands can be read from the stack while the thread
+  ; is actually receiving data.
+  StackMutex.i
+  
+  ; Stores Gadget/Window data during connection
+  Window.i
+  LogGadget.i
+  PasswordGadget.i
+  AbortGadget.i
+  OkGadget.i
+  
+  ; set on user action
+  PasswordSet.l
+  AbortPressed.l
+  InvisibleTimeout.q
+  
+  ; encryption support
+  EncryptionHash$
+  EncryptStream.l
+  EncryptionDataSent.l
+  CryptContext.b[#SizeOf_rijndael_ctx]
+  HashContext.b[#SizeOf_MD5_ctx]
+  InitializerEncrypt.b[16]
+  InitializerDecrypt.b[16]
+  
+  ; waiting commands
+  StackCount.l
+  Stack.CommandStackStruct[#MAX_COMMANDSTACK]
+EndStructure
+
+
+;- ----> Globals
+; All WinPipe Objects are handled in a LinkedList,
+; protected by a mutex for ALL access to make it save with the thread
+;
+Global NewList Network_Data.Network_Communication()
+Global Network_Mutex.i = CreateMutex()
+Global Network_Thread  = 0
+Global Network_Initialized = 0
+
+;- ----> Encryption support
+
+Procedure Network_SetupEncryption(*This.Network_Communication, Password$)
+  *Key = AllocateMemory(16)
+  If *Key
     
-    #SOCKET_ERROR = -1
-    #INVALID_SOCKET = -1
+    Debug "[Network] Setup password: "+Chr(34)+Password$+Chr(34)
     
-    ImportC #BUILD_DIRECTORY + "NetworkSupport.o"
+    ; This has to match what the debugger lib does
+    ; Use the imported functions, so we get directly a binary representation
+    MD5Init(@*This\HashContext)
+    MD5Update(@*This\HashContext, ?CiperInitializer, 16)
+    MD5Update(@*This\HashContext, ToAscii(Password$), StringByteLength(Password$, #PB_Ascii))
+    MD5Final(*Key, @*This\HashContext)
+    
+    CompilerIf #PB_Compiler_Debugger
+      Hex$ = ""
+      For i = 0 To 15
+        Hex$ + RSet(Hex(PeekA(*Key+i)), 2, "0")
+      Next i
+      Debug "[Network] Encryption Key: " + LCase(Hex$)
     CompilerEndIf
     
-    ; // Wrappers For the simple stuff For consistency
-    ; //
-    Network_Initialize()
-    Network_CreateSocket()
-    Network_CloseSocket(Socket)
+    rijndael_set_key(@*This\CryptContext, *Key, 128)
     
-    ; // Only initiates the connect.
-    ; // Use Network_ConnectSocketCheck() To wait For a connection/failure.
-    ; // Returns 0 on failure
-    ; //
-    Network_ConnectSocketStart(Socket, Hostname.p-ascii, Port)
+    ; this will be needed for CBC on the actual data stream
+    CopyMemory(?CiperInitializer, @*This\InitializerEncrypt, 16)
+    CopyMemory(?CiperInitializer, @*This\InitializerDecrypt, 16)
     
-    ; // Check the status of a connect()
-    ; //
-    ; // Returns:
-    ; //   0 = still pending
-    ; //   1 = connected
-    ; //   2 = connection failed
-    ; //
-    Network_ConnectSocketCheck(Socket)
-    
-    ; // Put the socket in listen mode (1 connection max)
-    ; // If Interface is empty, bind to all interfaces
-    ; //
-    Network_Listen(Socket, InterfaceName.p-ascii, Port)
-    
-    ; // Check If an incoming connection is made on a listening socket, does Not block
-    ; // returns new Socket Or SOCKET_ERROR (= no incoming connection)
-    ; //
-    Network_CheckAccept(Socket)
-    
-    ; // Check if data is ready For reading
-    ; //
-    ; // Returns:
-    ; //   0 = no Data
-    ; //   1 = Data available
-    ; //   2 = disconnect
-    Network_CheckData(Socket)
-    
-    ; // Ensure the Data is Read fully
-    ; // Returns true If ok, false If network disconnect
-    ; //
-    Network_ReceiveData(Socket, *Buffer, Size)
-    
-    ; // Blocking send of Data
-    ; // Returns true If ok, false If network disconnect
-    ; //
-    Network_SendData(Socket, *Buffer, Size)
-    
-    ; // Blocking send of string Data (ascii)
-    ; // Returns true If ok, false If network disconnect
-    ; //
-    Network_SendString(Socket, String.p-ascii)
-    
-  EndImport
+    FreeMemory(*Key)
+  EndIf
+EndProcedure
+
+; must be freed by caller
+Procedure Network_CreateHandshakeBlock(*This.Network_Communication)
+  *Block      = AllocateMemory(#EncryptionHandshakeSize * 2)
+  *BlockPlain = *Block + #EncryptionHandshakeSize ; use the same buffer
   
-  ImportC ""
+  If *Block
+    ; create random plaintext
+    ; this can differ from what the debugger lib does
+    ; does not need to be a strong random, as even a known-plaintext-attack on AES has not been done yet
+    For i = 0 To (#EncryptionHandshakeSize/4)-1
+      PokeL(*BlockPlain + i*4, Random($FFFFFFFF))
+    Next i
     
-    ; Import of the AES functions (included in Cypher lib, linked because we use MD5 too)
-    ; (so we do not have to use the PB object system for thread safety)
-    ;
-    rijndael_set_key.l(*context, *key, bits)
-    
-    rijndael_ecb_decrypt.l(*context, *input, *output, length)
-    rijndael_ecb_encrypt.l(*context, *input, *output, length)
-    rijndael_cbc_decrypt.l(*context, *input, *output, length, *iv)
-    rijndael_cbc_encrypt.l(*context, *input, *output, length, *iv)
-    
-    ; imported so we can get the binary data instead of the string (for key creation)
-    MD5Init(*Context)
-    MD5Update(*Context, *Buffer, Size)
-    MD5Final(*Output, *Context)
-    
-  EndImport
-  
-  #SizeOf_rijndael_ctx = 488 ; size in bytes of a context structure (in C)
-  #SizeOf_MD5_ctx      = 88
-  
-  DataSection
-    
-    CiperInitializer:
-    Data.b $D7, $2F, $E7, $B8, $AA, $9F, $E9, $01, $A5, $A5, $09, $58, $C9, $85, $A9, $CC
-    
-  EndDataSection
-  
-  ; in bytes, must be multiple of 16, not too large (can be different from debugger lib)
-  #EncryptionHandshakeSize = 32
-  
-  ;- ----> Data structure
-  Structure Network_Communication
-    *Vtbl.CommunicationVtbl
-    
-    Host$
-    Password$
-    Port.l
-    
-    Connected.l         ; should we try to read or not ?
-    IsFatalError.l
-    CommandReceived.l   ; was there any command received yet?
-    CommandTimeout.q    ; time of exe creation for timeout test
-    EndReceived.l       ; was #COMMAND_End received yet ?
-    EndTimeout.q        ; time of exe quit, timeout to be able to receive COMMAND_End before firing an error
-    
-    Socket.i
-    
-    ; The command stack is protected by a mutex separate from the overall
-    ; "receive" mutex, so commands can be read from the stack while the thread
-    ; is actually receiving data.
-    StackMutex.i
-    
-    ; Stores Gadget/Window data during connection
-    Window.i
-    LogGadget.i
-    PasswordGadget.i
-    AbortGadget.i
-    OkGadget.i
-    
-    ; set on user action
-    PasswordSet.l
-    AbortPressed.l
-    InvisibleTimeout.q
-    
-    ; encryption support
-    EncryptionHash$
-    EncryptStream.l
-    EncryptionDataSent.l
-    CryptContext.b[#SizeOf_rijndael_ctx]
-    HashContext.b[#SizeOf_MD5_ctx]
-    InitializerEncrypt.b[16]
-    InitializerDecrypt.b[16]
-    
-    ; waiting commands
-    StackCount.l
-    Stack.CommandStackStruct[#MAX_COMMANDSTACK]
-  EndStructure
-  
-  
-  ;- ----> Globals
-  ; All WinPipe Objects are handled in a LinkedList,
-  ; protected by a mutex for ALL access to make it save with the thread
-  ;
-  Global NewList Network_Data.Network_Communication()
-  Global Network_Mutex.i = CreateMutex()
-  Global Network_Thread  = 0
-  Global Network_Initialized = 0
-  
-  ;- ----> Encryption support
-  
-  Procedure Network_SetupEncryption(*This.Network_Communication, Password$)
-    *Key = AllocateMemory(16)
-    If *Key
-      
-      Debug "[Network] Setup password: "+Chr(34)+Password$+Chr(34)
-      
-      ; This has to match what the debugger lib does
-      ; Use the imported functions, so we get directly a binary representation
-      MD5Init(@*This\HashContext)
-      MD5Update(@*This\HashContext, ?CiperInitializer, 16)
-      MD5Update(@*This\HashContext, ToAscii(Password$), StringByteLength(Password$, #PB_Ascii))
-      MD5Final(*Key, @*This\HashContext)
-      
-      CompilerIf #PB_Compiler_Debugger
-        Hex$ = ""
-        For i = 0 To 15
-          Hex$ + RSet(Hex(PeekA(*Key+i)), 2, "0")
-        Next i
-        Debug "[Network] Encryption Key: " + LCase(Hex$)
-      CompilerEndIf
-      
-      rijndael_set_key(@*This\CryptContext, *Key, 128)
-      
-      ; this will be needed for CBC on the actual data stream
-      CopyMemory(?CiperInitializer, @*This\InitializerEncrypt, 16)
-      CopyMemory(?CiperInitializer, @*This\InitializerDecrypt, 16)
-      
-      FreeMemory(*Key)
-    EndIf
-  EndProcedure
-  
-  ; must be freed by caller
-  Procedure Network_CreateHandshakeBlock(*This.Network_Communication)
-    *Block      = AllocateMemory(#EncryptionHandshakeSize * 2)
-    *BlockPlain = *Block + #EncryptionHandshakeSize ; use the same buffer
-    
-    If *Block
-      ; create random plaintext
-      ; this can differ from what the debugger lib does
-      ; does not need to be a strong random, as even a known-plaintext-attack on AES has not been done yet
-      For i = 0 To (#EncryptionHandshakeSize/4)-1
-        PokeL(*BlockPlain + i*4, Random($FFFFFFFF))
+    CompilerIf #PB_Compiler_Debugger
+      Debug "[Network] Calling Network_CreateHandshakeBlock()"
+      Debug "[Network] Encryption handshake block PLAIN (" + Str(#EncryptionHandshakeSize)+") bytes"
+      B$ = ""
+      For i = 0 To #EncryptionHandshakeSize-1
+        B$ + LCase(RSet(Hex(PeekA(*BlockPlain+i)), 2, "0")) + " "
       Next i
+      Debug B$
+    CompilerEndIf
+    
+    ; get MD5 of it
+    *This\EncryptionHash$ = Fingerprint(*BlockPlain, #EncryptionHandshakeSize, #PB_Cipher_MD5)
+    
+    ; encrypt
+    rijndael_ecb_encrypt(@*This\CryptContext, *BlockPlain, *Block, #EncryptionHandshakeSize)
+    
+    CompilerIf #PB_Compiler_Debugger
+      Debug "[Network] Encryption Hash: " + *This\EncryptionHash$
+      Debug "[Network] Encryption handshake block CIPHER (" + Str(#EncryptionHandshakeSize)+") bytes"
+      B$ = ""
+      For i = 0 To #EncryptionHandshakeSize-1
+        B$ + LCase(RSet(Hex(PeekA(*Block+i)), 2, "0")) + " "
+      Next i
+      Debug B$
+    CompilerEndIf
+  EndIf
+  
+  ProcedureReturn *Block
+EndProcedure
+
+
+Procedure.s Network_DecryptHandshakeBlock(*This.Network_Communication, *Block, Size)
+  Result$ = "-invalid-"
+  
+  If *Block And Size > 0
+    *Decrypted = AllocateMemory(Size)
+    If *Decrypted
       
       CompilerIf #PB_Compiler_Debugger
-        Debug "[Network] Calling Network_CreateHandshakeBlock()"
-        Debug "[Network] Encryption handshake block PLAIN (" + Str(#EncryptionHandshakeSize)+") bytes"
+        Debug "[Network] Calling Network_DecryptHandshakeBlock()"
+        Debug "[Network] Encryption handshake block CIPHER (" + Str(Size)+") bytes"
         B$ = ""
-        For i = 0 To #EncryptionHandshakeSize-1
-          B$ + LCase(RSet(Hex(PeekA(*BlockPlain+i)), 2, "0")) + " "
-        Next i
-        Debug B$
-      CompilerEndIf
-      
-      ; get MD5 of it
-      *This\EncryptionHash$ = Fingerprint(*BlockPlain, #EncryptionHandshakeSize, #PB_Cipher_MD5)
-      
-      ; encrypt
-      rijndael_ecb_encrypt(@*This\CryptContext, *BlockPlain, *Block, #EncryptionHandshakeSize)
-      
-      CompilerIf #PB_Compiler_Debugger
-        Debug "[Network] Encryption Hash: " + *This\EncryptionHash$
-        Debug "[Network] Encryption handshake block CIPHER (" + Str(#EncryptionHandshakeSize)+") bytes"
-        B$ = ""
-        For i = 0 To #EncryptionHandshakeSize-1
+        For i = 0 To Size-1
           B$ + LCase(RSet(Hex(PeekA(*Block+i)), 2, "0")) + " "
         Next i
         Debug B$
       CompilerEndIf
+      
+      rijndael_ecb_decrypt(@*This\CryptContext, *Block, *Decrypted, Size)
+      
+      ; The debugger lib uses a compatible method
+      Result$ = Fingerprint(*Decrypted, Size, #PB_Cipher_MD5)
+      
+      CompilerIf #PB_Compiler_Debugger
+        Debug "[Network] Encryption Hash: " + Result$
+        Debug "[Network] Encryption handshake block PLAIN (" + Str(Size)+") bytes"
+        B$ = ""
+        For i = 0 To Size-1
+          B$ + LCase(RSet(Hex(PeekA(*Decrypted+i)), 2, "0")) + " "
+        Next i
+        Debug B$
+      CompilerEndIf
+      
+      FreeMemory(*Decrypted)
     EndIf
-    
-    ProcedureReturn *Block
-  EndProcedure
+  EndIf
   
+  ProcedureReturn Result$
+EndProcedure
+
+
+;- ----> Functions for the text-based negotiation
+
+; Read a string until newline (CRLF or LF)
+; returns "-error-" if network connection failed
+;
+Procedure.s Network_ReadString(Socket)
+  Result$ = ""
   
-  Procedure.s Network_DecryptHandshakeBlock(*This.Network_Communication, *Block, Size)
-    Result$ = "-invalid-"
-    
-    If *Block And Size > 0
-      *Decrypted = AllocateMemory(Size)
-      If *Decrypted
-        
-        CompilerIf #PB_Compiler_Debugger
-          Debug "[Network] Calling Network_DecryptHandshakeBlock()"
-          Debug "[Network] Encryption handshake block CIPHER (" + Str(Size)+") bytes"
-          B$ = ""
-          For i = 0 To Size-1
-            B$ + LCase(RSet(Hex(PeekA(*Block+i)), 2, "0")) + " "
-          Next i
-          Debug B$
-        CompilerEndIf
-        
-        rijndael_ecb_decrypt(@*This\CryptContext, *Block, *Decrypted, Size)
-        
-        ; The debugger lib uses a compatible method
-        Result$ = Fingerprint(*Decrypted, Size, #PB_Cipher_MD5)
-        
-        CompilerIf #PB_Compiler_Debugger
-          Debug "[Network] Encryption Hash: " + Result$
-          Debug "[Network] Encryption handshake block PLAIN (" + Str(Size)+") bytes"
-          B$ = ""
-          For i = 0 To Size-1
-            B$ + LCase(RSet(Hex(PeekA(*Decrypted+i)), 2, "0")) + " "
-          Next i
-          Debug B$
-        CompilerEndIf
-        
-        FreeMemory(*Decrypted)
-      EndIf
-    EndIf
-    
-    ProcedureReturn Result$
-  EndProcedure
-  
-  
-  ;- ----> Functions for the text-based negotiation
-  
-  ; Read a string until newline (CRLF or LF)
-  ; returns "-error-" if network connection failed
-  ;
-  Procedure.s Network_ReadString(Socket)
-    Result$ = ""
-    
-    *Buffer = AllocateMemory(1024)
-    Size    = 1024
-    If *Buffer
-      *Pointer.BYTE = *Buffer
-      
-      Repeat
-        If (*Pointer - *Buffer) > Size-10
-          ; reallocate buffer
-          Size + 1024
-          *Pointer - *Buffer ; get index
-          
-          *NewBuffer = ReAllocateMemory(*Buffer, Size)
-          If *NewBuffer
-            *Buffer = *NewBuffer
-            *Pointer + *Buffer ; get pointer
-          Else
-            Result$ = PeekS(*Buffer, *Pointer, #PB_Ascii) ; pointer has the length
-            Break
-          EndIf
-        EndIf
-        
-        If Network_ReceiveData(Socket, *Pointer, 1)
-          If *Pointer\b = 10 ; newline
-            *Pointer\b = 0
-            
-            ; check and remove a CR before the LF
-            If *Pointer > *Buffer And PeekB(*Pointer-1) = 13
-              PokeB(*Pointer-1, 0)
-            EndIf
-            
-            Result$ = PeekS(*Buffer, -1, #PB_Ascii)
-            Break
-          Else
-            *Pointer + 1
-          EndIf
-        Else
-          Result$ = "-error-"
-          Break
-        EndIf
-      ForEver
-      
-      FreeMemory(*Buffer)
-    EndIf
-    
-    Debug "Network_ReadString(): " + Result$
-    ProcedureReturn Result$
-  EndProcedure
-  
-  ; Read one Value from the values list (Key<LF>Value pairs)
-  ;
-  Procedure.s Network_GetValue(Key$, List Values$())
-    Key$ = UCase(Key$)
-    
-    ForEach Values$()
-      If StringField(Values$(), 1, Chr(10)) = Key$
-        ProcedureReturn StringField(Values$(), 2, Chr(10))
-      EndIf
-    Next Values$()
-    
-    ProcedureReturn ""
-  EndProcedure
-  
-  ; Read a header (until empty line) including data and values (Key<LF>Value)
-  ; Returnvalue is the header first line (cleaned up)
-  ;
-  Procedure.s Network_ReadHeader(Socket, List Values$(), *pCommandData.INTEGER)
-    ClearList(Values$())
-    *pCommandData\i = 0
-    
-    Header$ =  Network_ReadString(Socket)
-    If Header$ <> "" And Header$ <> "-error-"
-      ; remove extra whitespace by tokenizing
-      ;
-      String$ = Trim(RemoveString(Header$, Chr(9)))
-      Header$ = ""
-      
-      While String$
-        Option$ = StringField(String$, 1, " ")
-        Header$ + Option$ + " "
-        String$ = LTrim(Right(String$, Len(String$)-Len(Option$)))
-      Wend
-      
-      Header$ = RTrim(Header$)
-      
-      ; read additional values
-      ;
-      Repeat
-        Pair$ = Network_ReadString(Socket)
-        If Pair$ = "-error-"
-          ClearList(Values$())
-          ProcedureReturn "-error-"
-        ElseIf Pair$ <> ""
-          Pair$ = RemoveString(Pair$, Chr(9))
-          Separator = FindString(Pair$, ":", 1)
-          If Separator <> 0
-            AddElement(Values$())
-            Values$() = UCase(Trim(Left(Pair$, Separator-1)))+Chr(10)+Trim(Right(Pair$, Len(Pair$)-Separator))
-          EndIf
-        EndIf
-      Until Pair$ = ""
-      
-      LengthValue$ = Network_GetValue("Length", Values$())
-      If LengthValue$
-        Length = Val(LengthValue$)
-        If Length > 0
-          *pCommandData\i = AllocateMemory(Length)
-          If *pCommandData\i
-            If Network_ReceiveData(Socket, *pCommandData\i, Length) = 0
-              Header$ = "-error-"
-              ClearList(Values$())
-              FreeMemory(*pCommandData\i)
-              *pCommandData\i = 0
-            EndIf
-          EndIf
-        EndIf
-      EndIf
-    EndIf
-    
-    ProcedureReturn Header$
-  EndProcedure
-  
-  ; the message is in english, not translated
-  Procedure Network_SendError(Socket, Key$, Message$)
-    Response$ = "ERROR " + Str(#PB_Compiler_Version) + " " + Key$ + #LF$
-    Response$ + "  Message: " + Message$ + #LF$
-    Response$ + #LF$
-    
-    Network_SendString(Socket, Response$)
-  EndProcedure
-  
-  ;- ----> Functions for the status Window
-  
-  Procedure Network_ShowPasswordEntry(*This.Network_Communication, State)
-    GetRequiredSize(*This\AbortGadget, @AbortWidth.l, @AbortHeight.l)
-    GetRequiredSize(*This\OkGadget, @OkWidth.l, @OkHeight.l)
-    OkHeight   = Max(OkHeight, GetRequiredHeight(*This\PasswordGadget))
-    OkWidth    = Max(OkWidth, 50)
-    AbortWidth = Max(AbortWidth, 100)
-    
-    If State
-      HideGadget(*This\PasswordGadget, 0)
-      HideGadget(*This\OkGadget, 0)
-      ResizeGadget(*This\LogGadget, 10, 10, 330, 215-AbortHeight-OkHeight)
-      ResizeGadget(*This\PasswordGadget, 10, 230-AbortHeight-OkHeight, 325-OkWidth, OkHeight)
-      ResizeGadget(*This\OkGadget, 340-OkWidth, 230-AbortHeight-OkHeight, OkWidth, OkHeight)
-      
-      ; reset the password
-      *This\PasswordSet = 0
-      HideWindow(*This\Window, 0) ; make sure it is visible
-      SetGadgetText(*This\PasswordGadget, "")
-      SetActiveWindow(*This\Window)
-      SetActiveGadget(*This\PasswordGadget)
-    Else
-      HideGadget(*This\PasswordGadget, 1)
-      HideGadget(*This\OkGadget, 1)
-      ResizeGadget(*This\LogGadget, 10, 10, 330, 220-AbortHeight)
-    EndIf
-    
-    ResizeGadget(*This\AbortGadget, (350-AbortWidth)/2, 240-AbortHeight, AbortWidth, AbortHeight)
-  EndProcedure
-  
-  Procedure Network_OpenWindow(*This.Network_Communication, Title$)
-    CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
-      DisableWindow(#WINDOW_Main, 1)
-      Parent = WindowID(#WINDOW_Main)
-    CompilerElse
-      DisableWindow(#WINDOW_Main, 1)
-      Parent = WindowID(#WINDOW_Main)
-    CompilerEndIf
-    
-    *This\Window = OpenWindow(#PB_Any, 0, 0, 350, 250, Title$, #PB_Window_TitleBar|#PB_Window_WindowCentered|#PB_Window_Invisible, Parent)
-    If *This\Window
-      *This\LogGadget      = ListViewGadget(#PB_Any, 0, 0, 0, 0)
-      *This\PasswordGadget = StringGadget(#PB_Any, 0, 0, 0, 0, "", #PB_String_Password)
-      *This\AbortGadget    = ButtonGadget(#PB_Any, 0, 0, 0, 0, Language("Misc", "Cancel"))
-      *This\OkGadget       = ButtonGadget(#PB_Any, 0, 0, 0, 0, Language("Misc", "Ok"))
-      
-      AddKeyboardShortcut(*This\Window, #PB_Shortcut_Return, 1)
-      
-      ; Initially the window stays hidden, until the timeout expires
-      ; (so it does Not popup shortly when connecting to localhost for example)
-      ;
-      *This\InvisibleTimeout = ElapsedMilliseconds() + 500
-      
-      Network_ShowPasswordEntry(*This, #False) ; resize the content
-      *This\AbortPressed = #False
-    EndIf
-  EndProcedure
-  
-  Procedure Network_CloseWindow(*This.Network_Communication)
-    CloseWindow(*This\Window)
-    
-    CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
-      DisableWindow(#WINDOW_Main, 0)
-    CompilerElse
-      DisableWindow(#WINDOW_Main, 0)
-    CompilerEndIf
-  EndProcedure
-  
-  Procedure Network_FlushWindowEvents(*This.Network_Communication)
-    EventCount = 0
-    
-    If *This\InvisibleTimeout <> -1 And *This\InvisibleTimeout < ElapsedMilliseconds()
-      ; show the window now
-      HideWindow(*This\Window, 0) ; it took a while, make the window visible
-      SetActiveWindow(*This\Window)
-      *This\InvisibleTimeout = -1 ; do not do it again
-    EndIf
+  *Buffer = AllocateMemory(1024)
+  Size    = 1024
+  If *Buffer
+    *Pointer.BYTE = *Buffer
     
     Repeat
-      EventID = WindowEvent()
-      
-      If EventID = 0
-        ProcedureReturn EventCount
+      If (*Pointer - *Buffer) > Size-10
+        ; reallocate buffer
+        Size + 1024
+        *Pointer - *Buffer ; get index
         
-      Else
-        EventCount + 1
-        
-        If EventWindow() = *This\Window
-          If EventID = #PB_Event_Gadget And EventGadget() = *This\AbortGadget
-            *This\AbortPressed = #True
-            ProcedureReturn EventCount
-            
-          ElseIf EventID = #PB_Event_Gadget And EventGadget() = *This\OkGadget
-            *This\PasswordSet = #True
-            ProcedureReturn EventCount
-            
-          ElseIf EventID = #PB_Event_Menu And EventMenu() = 1
-            If GetActiveGadget() = *This\PasswordGadget
-              *This\PasswordSet = #True
-              ProcedureReturn EventCount
-            EndIf
-            
-          EndIf
-          
+        *NewBuffer = ReAllocateMemory(*Buffer, Size)
+        If *NewBuffer
+          *Buffer = *NewBuffer
+          *Pointer + *Buffer ; get pointer
         Else
-          ; For the standalone debugger we just drop the event as the main
-          ; window is disabled anyway
-          CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
-            DispatchEvent(EventID)
-          CompilerEndIf
-          
+          Result$ = PeekS(*Buffer, *Pointer, #PB_Ascii) ; pointer has the length
+          Break
         EndIf
       EndIf
+      
+      If Network_ReceiveData(Socket, *Pointer, 1)
+        If *Pointer\b = 10 ; newline
+          *Pointer\b = 0
+          
+          ; check and remove a CR before the LF
+          If *Pointer > *Buffer And PeekB(*Pointer-1) = 13
+            PokeB(*Pointer-1, 0)
+          EndIf
+          
+          Result$ = PeekS(*Buffer, -1, #PB_Ascii)
+          Break
+        Else
+          *Pointer + 1
+        EndIf
+      Else
+        Result$ = "-error-"
+        Break
+      EndIf
     ForEver
-  EndProcedure
-  
-  Procedure Network_AddLog(*This.Network_Communication, Message$)
-    AddGadgetItem(*This\LogGadget, -1, Message$)
-    SetGadgetState(*This\LogGadget, CountGadgetItems(*This\LogGadget)-1)
-    Network_FlushWindowEvents(*This)
-  EndProcedure
-  
-  ;- ----> Connect functions
-  
-  
-  Procedure Network_ConnectServer(*This.Network_Communication)
-    Success = #False
-    Protected NewList Values$()
-    AcceptSocket = #SOCKET_ERROR
     
-    If *This\Password$
-      Network_SetupEncryption(*This, *This\Password$)
+    FreeMemory(*Buffer)
+  EndIf
+  
+  Debug "Network_ReadString(): " + Result$
+  ProcedureReturn Result$
+EndProcedure
+
+; Read one Value from the values list (Key<LF>Value pairs)
+;
+Procedure.s Network_GetValue(Key$, List Values$())
+  Key$ = UCase(Key$)
+  
+  ForEach Values$()
+    If StringField(Values$(), 1, Chr(10)) = Key$
+      ProcedureReturn StringField(Values$(), 2, Chr(10))
     EndIf
+  Next Values$()
+  
+  ProcedureReturn ""
+EndProcedure
+
+; Read a header (until empty line) including data and values (Key<LF>Value)
+; Returnvalue is the header first line (cleaned up)
+;
+Procedure.s Network_ReadHeader(Socket, List Values$(), *pCommandData.INTEGER)
+  ClearList(Values$())
+  *pCommandData\i = 0
+  
+  Header$ =  Network_ReadString(Socket)
+  If Header$ <> "" And Header$ <> "-error-"
+    ; remove extra whitespace by tokenizing
+    ;
+    String$ = Trim(RemoveString(Header$, Chr(9)))
+    Header$ = ""
     
-    If *This\Host$ <> ""
-      Title$ = ReplaceString(ReplaceString(Language("NetworkDebugger", "ServerTitleNamed"), "%port%", Str(*This\Port)), "%host%", *This\Host$)
+    While String$
+      Option$ = StringField(String$, 1, " ")
+      Header$ + Option$ + " "
+      String$ = LTrim(Right(String$, Len(String$)-Len(Option$)))
+    Wend
+    
+    Header$ = RTrim(Header$)
+    
+    ; read additional values
+    ;
+    Repeat
+      Pair$ = Network_ReadString(Socket)
+      If Pair$ = "-error-"
+        ClearList(Values$())
+        ProcedureReturn "-error-"
+      ElseIf Pair$ <> ""
+        Pair$ = RemoveString(Pair$, Chr(9))
+        Separator = FindString(Pair$, ":", 1)
+        If Separator <> 0
+          AddElement(Values$())
+          Values$() = UCase(Trim(Left(Pair$, Separator-1)))+Chr(10)+Trim(Right(Pair$, Len(Pair$)-Separator))
+        EndIf
+      EndIf
+    Until Pair$ = ""
+    
+    LengthValue$ = Network_GetValue("Length", Values$())
+    If LengthValue$
+      Length = Val(LengthValue$)
+      If Length > 0
+        *pCommandData\i = AllocateMemory(Length)
+        If *pCommandData\i
+          If Network_ReceiveData(Socket, *pCommandData\i, Length) = 0
+            Header$ = "-error-"
+            ClearList(Values$())
+            FreeMemory(*pCommandData\i)
+            *pCommandData\i = 0
+          EndIf
+        EndIf
+      EndIf
+    EndIf
+  EndIf
+  
+  ProcedureReturn Header$
+EndProcedure
+
+; the message is in english, not translated
+Procedure Network_SendError(Socket, Key$, Message$)
+  Response$ = "ERROR " + Str(#PB_Compiler_Version) + " " + Key$ + #LF$
+  Response$ + "  Message: " + Message$ + #LF$
+  Response$ + #LF$
+  
+  Network_SendString(Socket, Response$)
+EndProcedure
+
+;- ----> Functions for the status Window
+
+Procedure Network_ShowPasswordEntry(*This.Network_Communication, State)
+  GetRequiredSize(*This\AbortGadget, @AbortWidth.l, @AbortHeight.l)
+  GetRequiredSize(*This\OkGadget, @OkWidth.l, @OkHeight.l)
+  OkHeight   = Max(OkHeight, GetRequiredHeight(*This\PasswordGadget))
+  OkWidth    = Max(OkWidth, 50)
+  AbortWidth = Max(AbortWidth, 100)
+  
+  If State
+    HideGadget(*This\PasswordGadget, 0)
+    HideGadget(*This\OkGadget, 0)
+    ResizeGadget(*This\LogGadget, 10, 10, 330, 215-AbortHeight-OkHeight)
+    ResizeGadget(*This\PasswordGadget, 10, 230-AbortHeight-OkHeight, 325-OkWidth, OkHeight)
+    ResizeGadget(*This\OkGadget, 340-OkWidth, 230-AbortHeight-OkHeight, OkWidth, OkHeight)
+    
+    ; reset the password
+    *This\PasswordSet = 0
+    HideWindow(*This\Window, 0) ; make sure it is visible
+    SetGadgetText(*This\PasswordGadget, "")
+    SetActiveWindow(*This\Window)
+    SetActiveGadget(*This\PasswordGadget)
+  Else
+    HideGadget(*This\PasswordGadget, 1)
+    HideGadget(*This\OkGadget, 1)
+    ResizeGadget(*This\LogGadget, 10, 10, 330, 220-AbortHeight)
+  EndIf
+  
+  ResizeGadget(*This\AbortGadget, (350-AbortWidth)/2, 240-AbortHeight, AbortWidth, AbortHeight)
+EndProcedure
+
+Procedure Network_OpenWindow(*This.Network_Communication, Title$)
+  CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
+    DisableWindow(#WINDOW_Main, 1)
+    Parent = WindowID(#WINDOW_Main)
+  CompilerElse
+    DisableWindow(#WINDOW_Main, 1)
+    Parent = WindowID(#WINDOW_Main)
+  CompilerEndIf
+  
+  *This\Window = OpenWindow(#PB_Any, 0, 0, 350, 250, Title$, #PB_Window_TitleBar|#PB_Window_WindowCentered|#PB_Window_Invisible, Parent)
+  If *This\Window
+    *This\LogGadget      = ListViewGadget(#PB_Any, 0, 0, 0, 0)
+    *This\PasswordGadget = StringGadget(#PB_Any, 0, 0, 0, 0, "", #PB_String_Password)
+    *This\AbortGadget    = ButtonGadget(#PB_Any, 0, 0, 0, 0, Language("Misc", "Cancel"))
+    *This\OkGadget       = ButtonGadget(#PB_Any, 0, 0, 0, 0, Language("Misc", "Ok"))
+    
+    AddKeyboardShortcut(*This\Window, #PB_Shortcut_Return, 1)
+    
+    ; Initially the window stays hidden, until the timeout expires
+    ; (so it does Not popup shortly when connecting to localhost for example)
+    ;
+    *This\InvisibleTimeout = ElapsedMilliseconds() + 500
+    
+    Network_ShowPasswordEntry(*This, #False) ; resize the content
+    *This\AbortPressed = #False
+  EndIf
+EndProcedure
+
+Procedure Network_CloseWindow(*This.Network_Communication)
+  CloseWindow(*This\Window)
+  
+  CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
+    DisableWindow(#WINDOW_Main, 0)
+  CompilerElse
+    DisableWindow(#WINDOW_Main, 0)
+  CompilerEndIf
+EndProcedure
+
+Procedure Network_FlushWindowEvents(*This.Network_Communication)
+  EventCount = 0
+  
+  If *This\InvisibleTimeout <> -1 And *This\InvisibleTimeout < ElapsedMilliseconds()
+    ; show the window now
+    HideWindow(*This\Window, 0) ; it took a while, make the window visible
+    SetActiveWindow(*This\Window)
+    *This\InvisibleTimeout = -1 ; do not do it again
+  EndIf
+  
+  Repeat
+    EventID = WindowEvent()
+    
+    If EventID = 0
+      ProcedureReturn EventCount
+      
     Else
-      Title$ = ReplaceString(Language("NetworkDebugger", "ServerTitle"), "%port%", Str(*This\Port))
+      EventCount + 1
+      
+      If EventWindow() = *This\Window
+        If EventID = #PB_Event_Gadget And EventGadget() = *This\AbortGadget
+          *This\AbortPressed = #True
+          ProcedureReturn EventCount
+          
+        ElseIf EventID = #PB_Event_Gadget And EventGadget() = *This\OkGadget
+          *This\PasswordSet = #True
+          ProcedureReturn EventCount
+          
+        ElseIf EventID = #PB_Event_Menu And EventMenu() = 1
+          If GetActiveGadget() = *This\PasswordGadget
+            *This\PasswordSet = #True
+            ProcedureReturn EventCount
+          EndIf
+          
+        EndIf
+        
+      Else
+        ; For the standalone debugger we just drop the event as the main
+        ; window is disabled anyway
+        CompilerIf Defined(PUREBASIC_IDE, #PB_Constant)
+          DispatchEvent(EventID)
+        CompilerEndIf
+        
+      EndIf
     EndIf
+  ForEver
+EndProcedure
+
+Procedure Network_AddLog(*This.Network_Communication, Message$)
+  AddGadgetItem(*This\LogGadget, -1, Message$)
+  SetGadgetState(*This\LogGadget, CountGadgetItems(*This\LogGadget)-1)
+  Network_FlushWindowEvents(*This)
+EndProcedure
+
+;- ----> Connect functions
+
+
+Procedure Network_ConnectServer(*This.Network_Communication)
+  Success = #False
+  Protected NewList Values$()
+  AcceptSocket = #SOCKET_ERROR
+  
+  If *This\Password$
+    Network_SetupEncryption(*This, *This\Password$)
+  EndIf
+  
+  If *This\Host$ <> ""
+    Title$ = ReplaceString(ReplaceString(Language("NetworkDebugger", "ServerTitleNamed"), "%port%", Str(*This\Port)), "%host%", *This\Host$)
+  Else
+    Title$ = ReplaceString(Language("NetworkDebugger", "ServerTitle"), "%port%", Str(*This\Port))
+  EndIf
+  
+  Network_OpenWindow(*This, Title$)
+  HideWindow(*This\Window, 0) ; show it immediately here, as it won't be an instant connect
+  
+  If Network_Listen(*This\Socket, *This\Host$, *This\Port)
     
-    Network_OpenWindow(*This, Title$)
-    HideWindow(*This\Window, 0) ; show it immediately here, as it won't be an instant connect
-    
-    If Network_Listen(*This\Socket, *This\Host$, *This\Port)
+    While *This\AbortPressed = #False And Success = 0
+      ; wait for connection
+      Network_AddLog(*This, Language("NetworkDebugger", "Listen"))
+      
+      While *This\AbortPressed = #False And AcceptSocket = #SOCKET_ERROR
+        AcceptSocket = Network_CheckAccept(*This\Socket)
+        If AcceptSocket = #SOCKET_ERROR ; no connection yet
+          If Network_FlushWindowEvents(*This) = 0
+            Delay(50)
+          EndIf
+        EndIf
+      Wend
+      
+      If *This\AbortPressed
+        Break
+      EndIf
+      
+      ; handle requests from client
+      Network_FlushWindowEvents(*This)
+      
+      *This\EncryptionDataSent = 0
       
       While *This\AbortPressed = #False And Success = 0
-        ; wait for connection
-        Network_AddLog(*This, Language("NetworkDebugger", "Listen"))
-        
-        While *This\AbortPressed = #False And AcceptSocket = #SOCKET_ERROR
-          AcceptSocket = Network_CheckAccept(*This\Socket)
-          If AcceptSocket = #SOCKET_ERROR ; no connection yet
+        Select Network_CheckData(AcceptSocket)
+            
+          Case 0 ; nothing to read
             If Network_FlushWindowEvents(*This) = 0
               Delay(50)
             EndIf
-          EndIf
-        Wend
-        
-        If *This\AbortPressed
-          Break
-        EndIf
-        
-        ; handle requests from client
-        Network_FlushWindowEvents(*This)
-        
-        *This\EncryptionDataSent = 0
-        
-        While *This\AbortPressed = #False And Success = 0
-          Select Network_CheckData(AcceptSocket)
-              
-            Case 0 ; nothing to read
-              If Network_FlushWindowEvents(*This) = 0
-                Delay(50)
-              EndIf
-              
-            Case 1
-              Header$   = Network_ReadHeader(AcceptSocket, Values$(), @*CommandData)
-              VersionNb = Val(StringField(Header$, 2, " "))
-              
-              If Header$ = "-error-" Or Header$ = ""
-                Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
-                Break
-                
-              ElseIf VersionNb <> #PB_Compiler_Version
-                Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_WrongVersion"))
-                Network_AddLog(*This, Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2))
-                Network_AddLog(*This, Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2))
-                Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
-                Network_SendError(AcceptSocket, "WrongVersion", "The PureBasic Version does not match.")
-                Break
-                
-              Else
-                Select UCase(StringField(Header$, 1, " "))
-                    
-                  Case "CONNECT"
-                    Select UCase(StringField(Header$, 3, " ")); check the target
-                        
-                      Case "EXECUTABLE"
-                        Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_NoExecutable"))
-                        Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
-                        Network_SendError(AcceptSocket, "NoExecutable", "The server is not a debug-able executable.")
-                        Break
-                        
-                      Case "DEBUGGER"
-                        PasswordOK = 0
-                        
-                        If *This\Password$ And *This\EncryptionDataSent > 0
-                          If *This\EncryptionHash$ = Network_GetValue("EncryptionHash", Values$())
-                            PasswordOK = 1
-                          EndIf
-                        EndIf
-                        
-                        If *This\Password$ And PasswordOK = 0
-                          ; create a new handshake block and send response
-                          *Block = Network_CreateHandshakeBlock(*This)
-                          If *Block
-                            Response$ = "ENCRYPTION " + Str(#PB_Compiler_Version) + " AES" + #LF$
-                            Response$ + "  Length: "+Str(#EncryptionHandshakeSize) + #LF$
-                            Response$ + #LF$
-                            
-                            If Network_SendString(AcceptSocket, Response$) = 0 Or Network_SendData(AcceptSocket, *Block, #EncryptionHandshakeSize) = 0
-                              Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
-                              FreeMemory(*Block)
-                              Break
-                            EndIf
-                            *This\EncryptionDataSent + 1
-                            ; no break in this case
-                            
-                            FreeMemory(*Block)
-                          Else
-                            Network_AddLog(*This, Language("Misc", "Error")+": " + Language("NetworkDebugger", "Error_FatalError"))
-                            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
-                            Network_SendError(AcceptSocket, "FatalError", "Fatal error.")
-                            Break
-                          EndIf
-                          
-                          
-                        Else ; no password, or match
-                          
-                          ; Send the ACCEPT response with our settings
-                          If *This\Password$
-                            *This\EncryptStream = 1
-                          EndIf
-                          
-                          Response$ = "ACCEPT " + Str(#PB_Compiler_Version) + " DEBUGGER" + #LF$
-                          Response$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
-                          Response$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
-                          Response$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
-                          Response$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
-                          Response$ + "  Encryption: "+Str(*This\EncryptStream) + #LF$
-                          Response$ + #LF$
-                          
-                          If Network_SendString(AcceptSocket, Response$)
-                            Success = #True
-                            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionSuccess"))
-                          Else
-                            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
-                          EndIf
-                          Break
-                        EndIf
-                        
-                      Default
-                        Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_NoService"))
-                        Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
-                        Network_SendError(AcceptSocket, "NoService", "The server cannot provide the requested service.")
-                        Break
-                        
-                    EndSelect
-                    
-                  Default
-                    Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidRequest"))
-                    Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
-                    Network_SendError(AcceptSocket, "InvalidRequest", "Invalid request.")
-                    Break
-                    
-                EndSelect
-                
-              EndIf
-              
-              If *CommandData
-                FreeMemory(*CommandData)
-                *CommandData = 0
-              EndIf
-              
-            Case 2
+            
+          Case 1
+            Header$   = Network_ReadHeader(AcceptSocket, Values$(), @*CommandData)
+            VersionNb = Val(StringField(Header$, 2, " "))
+            
+            If Header$ = "-error-" Or Header$ = ""
               Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
               Break
               
-          EndSelect
-        Wend
-        
-        If Success = 0
-          ; if we get here with no success then we have to close the socket
-          Network_CloseSocket(AcceptSocket)
-          AcceptSocket = #SOCKET_ERROR
-        EndIf
-        
-      Wend
-      
-    Else
-      Network_AddLog(*This, Language("NetworkDebugger", "ServerFailed") + " " + Str(*This\Port))
-      
-      ; This is the only place where we have a hard error as server.
-      ; All others just go to the log and the user has to press abort to cancel the wait
-      ;
-      SetActiveWindow(*This\Window)
-      MessageRequester("PureBasic Debugger", Language("NetworkDebugger", "ServerFailed") + " " + Str(*This\Port), #FLAG_Error)
-    EndIf
-    
-    
-    If Success
-      
-      ; Close the listen socket and keep the accept one
-      Network_CloseSocket(*This\Socket)
-      *This\Socket = AcceptSocket
-      
-      ; Start the command received timeout now
-      ;
-      *This\CommandReceived = 0
-      *This\CommandTimeout  = ElapsedMilliseconds()
-      
-      *This\Connected = 1 ; the thread can start reading
-      
-    EndIf
-    
-    Network_CloseWindow(*This)
-    
-    ProcedureReturn Success
-  EndProcedure
-  
-  
-  
-  Procedure Network_ConnectClient(*This.Network_Communication)
-    Success = #False
-    Connected = #False
-    Protected NewList Values$()
-    Message$ = ""
-    
-    Title$ = Language("NetworkDebugger", "ConnectTitle") + " " + *This\Host$ + " (" + Language("NetworkDebugger", "Port") + " " + Str(*This\Port) + ") ..."
-    Network_OpenWindow(*This, Title$)
-    Network_AddLog(*This, Language("NetworkDebugger", "Connect"))
-    
-    If Network_ConnectSocketStart(*This\Socket, *This\Host$, *This\Port)
-      Network_FlushWindowEvents(*This)
-      
-      While *This\AbortPressed = #False And Connected = #False
-        Select Network_ConnectSocketCheck(*This\Socket)
-            
-          Case 0 ; pending
-            If Network_FlushWindowEvents(*This) = 0
-              Delay(50)
+            ElseIf VersionNb <> #PB_Compiler_Version
+              Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_WrongVersion"))
+              Network_AddLog(*This, Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2))
+              Network_AddLog(*This, Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2))
+              Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
+              Network_SendError(AcceptSocket, "WrongVersion", "The PureBasic Version does not match.")
+              Break
+              
+            Else
+              Select UCase(StringField(Header$, 1, " "))
+                  
+                Case "CONNECT"
+                  Select UCase(StringField(Header$, 3, " ")); check the target
+                      
+                    Case "EXECUTABLE"
+                      Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_NoExecutable"))
+                      Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
+                      Network_SendError(AcceptSocket, "NoExecutable", "The server is not a debug-able executable.")
+                      Break
+                      
+                    Case "DEBUGGER"
+                      PasswordOK = 0
+                      
+                      If *This\Password$ And *This\EncryptionDataSent > 0
+                        If *This\EncryptionHash$ = Network_GetValue("EncryptionHash", Values$())
+                          PasswordOK = 1
+                        EndIf
+                      EndIf
+                      
+                      If *This\Password$ And PasswordOK = 0
+                        ; create a new handshake block and send response
+                        *Block = Network_CreateHandshakeBlock(*This)
+                        If *Block
+                          Response$ = "ENCRYPTION " + Str(#PB_Compiler_Version) + " AES" + #LF$
+                          Response$ + "  Length: "+Str(#EncryptionHandshakeSize) + #LF$
+                          Response$ + #LF$
+                          
+                          If Network_SendString(AcceptSocket, Response$) = 0 Or Network_SendData(AcceptSocket, *Block, #EncryptionHandshakeSize) = 0
+                            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
+                            FreeMemory(*Block)
+                            Break
+                          EndIf
+                          *This\EncryptionDataSent + 1
+                          ; no break in this case
+                          
+                          FreeMemory(*Block)
+                        Else
+                          Network_AddLog(*This, Language("Misc", "Error")+": " + Language("NetworkDebugger", "Error_FatalError"))
+                          Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
+                          Network_SendError(AcceptSocket, "FatalError", "Fatal error.")
+                          Break
+                        EndIf
+                        
+                        
+                      Else ; no password, or match
+                        
+                        ; Send the ACCEPT response with our settings
+                        If *This\Password$
+                          *This\EncryptStream = 1
+                        EndIf
+                        
+                        Response$ = "ACCEPT " + Str(#PB_Compiler_Version) + " DEBUGGER" + #LF$
+                        Response$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
+                        Response$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
+                        Response$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
+                        Response$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
+                        Response$ + "  Encryption: "+Str(*This\EncryptStream) + #LF$
+                        Response$ + #LF$
+                        
+                        If Network_SendString(AcceptSocket, Response$)
+                          Success = #True
+                          Network_AddLog(*This, Language("NetworkDebugger", "ConnectionSuccess"))
+                        Else
+                          Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
+                        EndIf
+                        Break
+                      EndIf
+                      
+                    Default
+                      Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_NoService"))
+                      Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
+                      Network_SendError(AcceptSocket, "NoService", "The server cannot provide the requested service.")
+                      Break
+                      
+                  EndSelect
+                  
+                Default
+                  Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidRequest"))
+                  Network_AddLog(*This, Language("NetworkDebugger", "ConnectionDenied"))
+                  Network_SendError(AcceptSocket, "InvalidRequest", "Invalid request.")
+                  Break
+                  
+              EndSelect
+              
             EndIf
             
-          Case 1 ; connected
-            Connected = #True
+            If *CommandData
+              FreeMemory(*CommandData)
+              *CommandData = 0
+            EndIf
             
-          Case 2 ; failed
-            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
+          Case 2
+            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
             Break
             
         EndSelect
       Wend
-    Else
-      Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
-    EndIf
+      
+      If Success = 0
+        ; if we get here with no success then we have to close the socket
+        Network_CloseSocket(AcceptSocket)
+        AcceptSocket = #SOCKET_ERROR
+      EndIf
+      
+    Wend
     
-    If Connected
-      Network_AddLog(*This, Language("NetworkDebugger", "QueryStatus"))
+  Else
+    Network_AddLog(*This, Language("NetworkDebugger", "ServerFailed") + " " + Str(*This\Port))
+    
+    ; This is the only place where we have a hard error as server.
+    ; All others just go to the log and the user has to press abort to cancel the wait
+    ;
+    SetActiveWindow(*This\Window)
+    MessageRequester("PureBasic Debugger", Language("NetworkDebugger", "ServerFailed") + " " + Str(*This\Port), #FLAG_Error)
+  EndIf
+  
+  
+  If Success
+    
+    ; Close the listen socket and keep the accept one
+    Network_CloseSocket(*This\Socket)
+    *This\Socket = AcceptSocket
+    
+    ; Start the command received timeout now
+    ;
+    *This\CommandReceived = 0
+    *This\CommandTimeout  = ElapsedMilliseconds()
+    
+    *This\Connected = 1 ; the thread can start reading
+    
+  EndIf
+  
+  Network_CloseWindow(*This)
+  
+  ProcedureReturn Success
+EndProcedure
+
+
+
+Procedure Network_ConnectClient(*This.Network_Communication)
+  Success = #False
+  Connected = #False
+  Protected NewList Values$()
+  Message$ = ""
+  
+  Title$ = Language("NetworkDebugger", "ConnectTitle") + " " + *This\Host$ + " (" + Language("NetworkDebugger", "Port") + " " + Str(*This\Port) + ") ..."
+  Network_OpenWindow(*This, Title$)
+  Network_AddLog(*This, Language("NetworkDebugger", "Connect"))
+  
+  If Network_ConnectSocketStart(*This\Socket, *This\Host$, *This\Port)
+    Network_FlushWindowEvents(*This)
+    
+    While *This\AbortPressed = #False And Connected = #False
+      Select Network_ConnectSocketCheck(*This\Socket)
+          
+        Case 0 ; pending
+          If Network_FlushWindowEvents(*This) = 0
+            Delay(50)
+          EndIf
+          
+        Case 1 ; connected
+          Connected = #True
+          
+        Case 2 ; failed
+          Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
+          Break
+          
+      EndSelect
+    Wend
+  Else
+    Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
+  EndIf
+  
+  If Connected
+    Network_AddLog(*This, Language("NetworkDebugger", "QueryStatus"))
+    
+    Request$ = "CONNECT " + Str(#PB_Compiler_Version) + " EXECUTABLE" + #LF$
+    Request$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
+    Request$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
+    Request$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
+    Request$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
+    Request$ + #LF$
+    
+    If Network_SendString(*This\Socket, Request$)
+      Network_FlushWindowEvents(*This)
       
-      Request$ = "CONNECT " + Str(#PB_Compiler_Version) + " EXECUTABLE" + #LF$
-      Request$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
-      Request$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
-      Request$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
-      Request$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
-      Request$ + #LF$
-      
-      If Network_SendString(*This\Socket, Request$)
-        Network_FlushWindowEvents(*This)
-        
-        While *This\AbortPressed = #False
-          Select Network_CheckData(*This\Socket)
-              
-            Case 0 ; nothing to read
-              If Network_FlushWindowEvents(*This) = 0
-                Delay(50)
-              EndIf
-              
-            Case 1
-              Header$   = Network_ReadHeader(*This\Socket, Values$(), @*CommandData)
-              VersionNb = Val(StringField(Header$, 2, " "))
-              
-              If Header$ = "-error-"
-                Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
-                Message$ = Language("NetworkDebugger", "ConnectionLost")
-                Break
-                
-              ElseIf VersionNb <> #PB_Compiler_Version
-                Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_WrongVersion"))
-                Network_AddLog(*This, Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2))
-                Network_AddLog(*This, Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2))
-                Message$ = Language("NetworkDebugger", "Error_WrongVersion") + #NewLine + Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2) + #NewLine +Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2)
-                Break
-                
-              Else
-                Select UCase(StringField(Header$, 1, " "))
-                    
-                  Case "ACCEPT"
-                    Network_AddLog(*This, Language("NetworkDebugger","ConnectionSuccess"))
-                    
-                    ; check if the server has encryption enabled
-                    ; (we will only receive this after a succeeded encryption handshake)
-                    Value$ = Network_GetValue("Encryption", Values$())
-                    If Value$ And Val(Value$) <> 0
-                      *This\EncryptStream = #True
-                    EndIf
-                    
-                    Success = #True
-                    Break
-                    
-                  Case "ENCRYPTION"
-                    
-                    If *This\Password$ And *This\EncryptionDataSent = 0
-                      ; password not yet send
-                      Password$ = *This\Password$
-                    Else
-                      If *This\EncryptionDataSent = 0
-                        Network_AddLog(*This, Language("NetworkDebugger","NeedPassword"))
-                      Else
-                        Network_AddLog(*This, Language("NetworkDebugger","WrongPassword"))
-                      EndIf
-                      
-                      ; get the password
-                      Network_ShowPasswordEntry(*This, #True)
-                      While *This\PasswordSet = #False And *This\AbortPressed = #False
-                        If Network_FlushWindowEvents(*This) = 0
-                          Delay(50)
-                        EndIf
-                      Wend
-                      Password$ = GetGadgetText(*This\PasswordGadget)
-                      Network_ShowPasswordEntry(*This, #False)
-                      
-                      If *This\AbortPressed
-                        Break
-                      EndIf
-                    EndIf
-                    
-                    ; setup the context with the password
-                    Network_SetupEncryption(*This, Password$)
-                    
-                    ; decrypt the buffer with this password and send a new request
-                    Hash$ = Network_DecryptHandshakeBlock(*This, *CommandData, Val(Network_GetValue("Length", Values$())))
-                    
-                    Request$ = "CONNECT " + Str(#PB_Compiler_Version) + " EXECUTABLE" + #LF$
-                    Request$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
-                    Request$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
-                    Request$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
-                    Request$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
-                    Request$ + "  EncryptionHash: "+ Hash$ + #LF$
-                    Request$ + #LF$
-                    
-                    If Network_SendString(*This\Socket, Request$) = 0
-                      Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
-                      Message$ = Language("NetworkDebugger", "ConnectionLost")
-                      Break
-                    EndIf
-                    
-                    *This\EncryptionDataSent + 1
-                    
-                  Case "ERROR"
-                    Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_"+StringField(Header$, 3, " ")))
-                    Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
-                    Message$ = Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_"+StringField(Header$, 3, " "))
-                    Break
-                    
-                  Default
-                    Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidResponse"))
-                    Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
-                    Message$ = Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidResponse")
-                    Break
-                    
-                EndSelect
-                
-              EndIf
-              
-              If *CommandData
-                FreeMemory(*CommandData)
-                *CommandData = 0
-              EndIf
-              
-            Case 2
+      While *This\AbortPressed = #False
+        Select Network_CheckData(*This\Socket)
+            
+          Case 0 ; nothing to read
+            If Network_FlushWindowEvents(*This) = 0
+              Delay(50)
+            EndIf
+            
+          Case 1
+            Header$   = Network_ReadHeader(*This\Socket, Values$(), @*CommandData)
+            VersionNb = Val(StringField(Header$, 2, " "))
+            
+            If Header$ = "-error-"
               Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
               Message$ = Language("NetworkDebugger", "ConnectionLost")
               Break
               
-          EndSelect
-        Wend
-        
-      EndIf
-    EndIf
-    
-    If Success
-      
-      ; Start the command received timeout now
-      ;
-      *This\CommandReceived = 0
-      *This\CommandTimeout  = ElapsedMilliseconds()
-      
-      *This\Connected = 1 ; the thread can start reading
-      
-    ElseIf *This\AbortPressed = #False  ; no error when abort was pressed
-      
-      HideWindow(*This\Window, 0) ; make sure the window is visible
-      SetActiveWindow(*This\Window)
-      
-      MessageStart$ = Language("NetworkDebugger","ConnectFailed") + ":" + #NewLine + *This\Host$ + " (" + Language("NetworkDebugger","Port") + " " + Str(*This\Port) + ")"
-      If Message$ <> ""
-        MessageStart$ + #NewLine + #NewLine + Message$
-      EndIf
-      
-      MessageRequester("PureBasic Debugger", MessageStart$, #FLAG_Error)
-      
-    EndIf
-    
-    Network_CloseWindow(*This)
-    
-    ProcedureReturn Success
-  EndProcedure
-  
-  
-  
-  ;- ----> Communication Interface
-  
-  DisableDebugger
-  
-  Procedure Network_FatalError(*This.Network_Communication, *Command.CommandInfo, FatalError)
-    *This\IsFatalError = #True
-    
-    CompilerIf #NOTHREAD = 0
-      LockMutex(*This\StackMutex)
-      
-      ; clear stack, so the fatal error is the only one
-      For i = 0 To *This\StackCount-1
-        If *This\Stack[i]\CommandData
-          FreeMemory(*This\Stack[i]\CommandData)
-        EndIf
-      Next i
-      
-      *This\Stack[0]\Command\Command   = #COMMAND_FatalError
-      *This\Stack[0]\Command\Value1    = FatalError
-      *This\Stack[0]\Command\Value2    = 0
-      *This\Stack[0]\Command\TimeStamp = Date()
-      *This\Stack[0]\CommandData       = 0
-      *This\StackCount = 1
-      
-      UnlockMutex(*This\StackMutex)
-      
-    CompilerElse
-      *Command\Command   = #COMMAND_FatalError
-      *Command\Value1    = FatalError
-      *Command\Value2    = 0
-      *Command\TimeStamp = Date()
-      
-    CompilerEndIf
-    
-  EndProcedure
-  
-  Procedure Network_ReadCommandCrypt(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
-    Protected CommandCrypt.CommandInfo
-    
-    If Network_ReceiveData(*This\Socket, @CommandCrypt, SizeOf(CommandInfo)) = 0
-      ProcedureReturn #False
-    EndIf
-    
-    rijndael_cbc_decrypt(@*This\CryptContext, @CommandCrypt, *Command, SizeOf(CommandInfo), @*This\InitializerDecrypt)
-    ;rijndael_ecb_decrypt(@*This\CryptContext, @CommandCrypt, *Command, SizeOf(CommandInfo))
-    ;CopyMemory(@CommandCrypt, *Command, SizeOf(CommandInfo))
-    
-    If *Command\DataSize > 0
-      
-      ; Padding for blocks < 16 bytes
-      If *Command\DataSize < 16
-        Size = 16
-      Else
-        Size = *Command\DataSize
-      EndIf
-      
-      *pCommandData\i   = AllocateMemory(Size)
-      *CommandDataCrypt = AllocateMemory(Size)
-      If *pCommandData\i = 0 Or *CommandDataCrypt = 0
-        ProcedureReturn #False
-      EndIf
-      
-      If Network_ReceiveData(*This\Socket, *CommandDataCrypt, Size) = 0
-        FreeMemory(*pCommandData\i)
-        FreeMemory(*CommandDataCrypt)
-        *pCommandData\i = 0
-        ProcedureReturn #False
-      EndIf
-      
-      rijndael_cbc_decrypt(@*This\CryptContext, *CommandDataCrypt, *pCommandData\i, Size, @*This\InitializerDecrypt)
-      ;rijndael_ecb_decrypt(@*This\CryptContext, *CommandDataCrypt, *pCommandData\i, Size)
-      ;CopyMemory(*CommandDataCrypt, *pCommandData\i, Size)
-      
-      FreeMemory(*CommandDataCrypt)
-    EndIf
-    
-    ProcedureReturn #True
-  EndProcedure
-  
-  Procedure Network_ReadCommand(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
-    *pCommandData\i = 0
-    
-    If *This\EncryptStream
-      ProcedureReturn Network_ReadCommandCrypt(*This, *Command, *pCommandData)
-      
-    Else
-      
-      If Network_ReceiveData(*This\Socket, *Command, SizeOf(CommandInfo)) = 0
-        ProcedureReturn #False
-      EndIf
-      
-      If *Command\DataSize > 0
-        *pCommandData\i = AllocateMemory(*Command\DataSize)
-        If *pCommandData\i = 0
-          ProcedureReturn #False
-          
-        ElseIf Network_ReceiveData(*This\Socket, *pCommandData\i, *Command\DataSize) = 0
-          ProcedureReturn #False
-          
-        EndIf
-      EndIf
-    EndIf
-    
-    ProcedureReturn #True
-  EndProcedure
-  
-  CompilerIf #NOTHREAD = 0
-    
-    ; ProcedureDLL for OSX !! (weird errors else!)
-    ;
-    ProcedureDLL Network_ReceiveThread(Dummy)
-      
-      Protected Command.CommandInfo
-      Protected *CommandData
-      
-      Repeat
-        LockMutex(Network_Mutex)  ; full protection needed!
-        
-        TotalCount = 0
-        ForEach Network_Data()
-          
-          ; receive as long as there is data, and as long as there is space
-          ;
-          While Network_Data()\Connected And Network_Data()\EndReceived = 0 And Network_Data()\IsFatalError = 0
-            
-            ; Do not receive anything if the stack is full
-            If Network_Data()\StackCount >= #MAX_COMMANDSTACK
-              ; This check can be done without a mutex lock, as only this thread
-              ; can increase the stack, and a decrease during the check has no concequence
+            ElseIf VersionNb <> #PB_Compiler_Version
+              Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_WrongVersion"))
+              Network_AddLog(*This, Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2))
+              Network_AddLog(*This, Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2))
+              Message$ = Language("NetworkDebugger", "Error_WrongVersion") + #NewLine + Language("NetworkDebugger", "ExeVersion")+": "+StrF(VersionNb / 100.0, 2) + #NewLine +Language("NetworkDebugger", "DebuggerVersion")+": "+StrF(#PB_Compiler_Version / 100.0, 2)
               Break
-            EndIf
-            
-            Select Network_CheckData(Network_Data()\Socket)
-                
-              Case 0 ; no data
-                Break
-                
-              Case 1 ; data
-                If Network_ReadCommand(@Network_Data(), @Command, @*CommandData)
-                  ; now lock the stack mutex and add data to the stack
-                  ; we know there is a free spot, as we checked above
-                  ; (And the main thread only decreases the stack)
-                  LockMutex(Network_Data()\StackMutex)
-                  
-                  ; add to stack
-                  CopyMemory(@Command, @Network_Data()\Stack[Network_Data()\StackCount]\Command, SizeOf(CommandInfo))
-                  Network_Data()\Stack[Network_Data()\StackCount]\CommandData = *CommandData
-                  Network_Data()\StackCount + 1
-                  
-                  Network_Data()\CommandReceived = 1
-                  
-                  If Command\Command = #COMMAND_End
-                    Network_Data()\EndReceived = 1
-                  EndIf
-                  
-                  UnlockMutex(Network_Data()\StackMutex)
-                  
-                  TotalCount + 1
-                  
-                  ; break (and unlock mutex) after a lot of commands are read so the main thread can read it
-                  If TotalCount > 50
-                    Break 2
-                  EndIf
-                Else
-                  If Network_Data()\EndReceived = 0
-                    Network_FatalError(@Network_Data(), @Command, #ERROR_NetworkFail)
-                  EndIf
-                  Break
-                EndIf
-                
-              Case 2 ; disconnect
-                If Network_Data()\EndReceived = 0  ; its no error if we terminated normally
-                  Network_FatalError(@Network_Data(), @Command, #ERROR_NetworkFail)
-                EndIf
-                Break
-                
-            EndSelect
-            
-          Wend
-          
-        Next Network_Data()
-        
-        UnlockMutex(Network_Mutex)
-        
-        Delay(10) ; time for the main thread to access the data
-      ForEver
-      
-    EndProcedure
-    
-  CompilerEndIf
-  
-  EnableDebugger
-  
-  
-  Procedure.s Network_GetInfo(*This.Network_Communication)
-    ProcedureReturn "" ; nothing to pass back here
-  EndProcedure
-  
-  
-  Procedure Network_Disconnect(*This.Network_Communication)
-    LockMutex(Network_Mutex)
-    ; Tell the thread to no longer try any reads (the socket is closed in Close())
-    *This\Connected = 0
-    UnlockMutex(Network_Mutex)
-  EndProcedure
-  
-  Procedure Network_SendCrypt(*This.Network_Communication, *Command.CommandInfo, *CommandData)
-    Protected CommandCrypt.CommandInfo
-    Size = *Command\DataSize
-    
-    ; Encrypt/send the command (always > 16 byte)
-    rijndael_cbc_encrypt(@*This\CryptContext, *Command, @CommandCrypt, SizeOf(CommandInfo), @*This\InitializerEncrypt)
-    ;rijndael_ecb_encrypt(@*This\CryptContext, *Command, @CommandCrypt, SizeOf(CommandInfo))
-    ;CopyMemory(*Command, @CommandCrypt, SizeOf(CommandInfo))
-    
-    Network_SendData(*This\Socket, @CommandCrypt, SizeOf(CommandInfo))
-    
-    If Size > 0 And *CommandData
-      
-      If Size < 16
-        ; AES cannot handle buffers < 16byte, must be padded
-        ;
-        *Buffer = AllocateMemory(16)
-        If *Buffer = 0
-          ProcedureReturn
-        EndIf
-        
-        CopyMemory(*CommandData, *Buffer, Size)
-        SizeReal = 16
-      Else
-        *Buffer = *CommandData
-        SizeReal = Size
-      EndIf
-      
-      *CommandDataCrypt = AllocateMemory(Size)
-      If *CommandDataCrypt
-        rijndael_cbc_encrypt(@*This\CryptContext, *Buffer, *CommandDataCrypt, SizeReal, @*This\InitializerEncrypt)
-        ;rijndael_ecb_encrypt(@*This\CryptContext, *Buffer, *CommandDataCrypt, SizeReal)
-        ;CopyMemory(*Buffer, *CommandDataCrypt, SizeReal)
-        
-        Network_SendData(*This\Socket, *CommandDataCrypt, SizeReal)
-        FreeMemory(*CommandDataCrypt)
-      EndIf
-      
-      If Size < 16
-        FreeMemory(*Buffer)
-      EndIf
-    EndIf
-    
-  EndProcedure
-  
-  
-  
-  Procedure Network_Send(*This.Network_Communication, *Command.CommandInfo, *CommandData)
-    
-    ; Note: We no longer do any disconnect detection when sending, because if the
-    ;   exe closes normally while we send something, we do not want a "fatal error"
-    ;   but rather the normal end message which we get when we get to read the COMMAND_End
-    ;   from the exe later
-    ;
-    If *This\Connected And *This\EndReceived = 0
-      
-      If *This\EncryptStream
-        Network_SendCrypt(*This, *Command, *CommandData)
-      Else
-        
-        Network_SendData(*This\Socket, *Command, SizeOf(CommandInfo))
-        
-        If *Command\DataSize > 0 And *CommandData
-          Network_SendData(*This\Socket, *CommandData, *Command\DataSize)
-        EndIf
-        
-      EndIf
-      
-    EndIf
-    
-  EndProcedure
-  
-  
-  Procedure Network_Receive(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
-    Result = 0
-    
-    CompilerIf #NOTHREAD = 0
-      
-      LockMutex(*This\StackMutex)
-      
-      If *This\StackCount > 0
-        CopyMemory(@*This\Stack[0]\command, *Command, SizeOf(CommandInfo))
-        *pCommandData\i = *This\Stack[0]\commanddata
-        
-        ; remove this command from the stack
-        *This\StackCount - 1
-        If *This\StackCount > 0
-          MoveMemory(@*This\Stack[1], @*This\Stack[0], SizeOf(CommandStackStruct) * *This\StackCount)
-        EndIf
-        
-        Result = 1
-      EndIf
-      
-      UnlockMutex(*This\StackMutex)
-      
-      
-    CompilerElse
-      
-      If *This\Connected And *This\EndReceived = 0 And *This\IsFatalError = 0
-        Select Network_CheckData(*This\Socket)
-          Case 1
-            If Not Network_ReadCommand(*This, *Command, *pCommandData)
-              If *This\EndReceived = 0
-                Network_FatalError(*This, *Command, #ERROR_NetworkFail)
-                Result = 1
-              EndIf
-            Else
-              *This\CommandReceived = 1
               
-              If *Command\Command = #COMMAND_End
-                *This\EndReceived = 1
-              EndIf
-              Result = 1
+            Else
+              Select UCase(StringField(Header$, 1, " "))
+                  
+                Case "ACCEPT"
+                  Network_AddLog(*This, Language("NetworkDebugger","ConnectionSuccess"))
+                  
+                  ; check if the server has encryption enabled
+                  ; (we will only receive this after a succeeded encryption handshake)
+                  Value$ = Network_GetValue("Encryption", Values$())
+                  If Value$ And Val(Value$) <> 0
+                    *This\EncryptStream = #True
+                  EndIf
+                  
+                  Success = #True
+                  Break
+                  
+                Case "ENCRYPTION"
+                  
+                  If *This\Password$ And *This\EncryptionDataSent = 0
+                    ; password not yet send
+                    Password$ = *This\Password$
+                  Else
+                    If *This\EncryptionDataSent = 0
+                      Network_AddLog(*This, Language("NetworkDebugger","NeedPassword"))
+                    Else
+                      Network_AddLog(*This, Language("NetworkDebugger","WrongPassword"))
+                    EndIf
+                    
+                    ; get the password
+                    Network_ShowPasswordEntry(*This, #True)
+                    While *This\PasswordSet = #False And *This\AbortPressed = #False
+                      If Network_FlushWindowEvents(*This) = 0
+                        Delay(50)
+                      EndIf
+                    Wend
+                    Password$ = GetGadgetText(*This\PasswordGadget)
+                    Network_ShowPasswordEntry(*This, #False)
+                    
+                    If *This\AbortPressed
+                      Break
+                    EndIf
+                  EndIf
+                  
+                  ; setup the context with the password
+                  Network_SetupEncryption(*This, Password$)
+                  
+                  ; decrypt the buffer with this password and send a new request
+                  Hash$ = Network_DecryptHandshakeBlock(*This, *CommandData, Val(Network_GetValue("Length", Values$())))
+                  
+                  Request$ = "CONNECT " + Str(#PB_Compiler_Version) + " EXECUTABLE" + #LF$
+                  Request$ + "  CallOnStart: "+Str(CallDebuggerOnStart) + #LF$
+                  Request$ + "  CallOnEnd: "+Str(CallDebuggerOnEnd) + #LF$
+                  Request$ + "  Unicode: "+Str(#PB_Compiler_Unicode) + #LF$
+                  Request$ + "  BigEndian: "+Str(#DEBUGGER_BigEndian) + #LF$
+                  Request$ + "  EncryptionHash: "+ Hash$ + #LF$
+                  Request$ + #LF$
+                  
+                  If Network_SendString(*This\Socket, Request$) = 0
+                    Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
+                    Message$ = Language("NetworkDebugger", "ConnectionLost")
+                    Break
+                  EndIf
+                  
+                  *This\EncryptionDataSent + 1
+                  
+                Case "ERROR"
+                  Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_"+StringField(Header$, 3, " ")))
+                  Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
+                  Message$ = Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_"+StringField(Header$, 3, " "))
+                  Break
+                  
+                Default
+                  Network_AddLog(*This, Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidResponse"))
+                  Network_AddLog(*This, Language("NetworkDebugger", "ConnectionFailed"))
+                  Message$ = Language("Misc", "Error")+": "+Language("NetworkDebugger", "Error_InvalidResponse")
+                  Break
+                  
+              EndSelect
+              
             EndIf
             
+            If *CommandData
+              FreeMemory(*CommandData)
+              *CommandData = 0
+            EndIf
             
           Case 2
-            If *This\EndReceived = 0
-              Network_FatalError(*This, *Command, #ERROR_NetworkFail)
-              Result = 1
-            EndIf
+            Network_AddLog(*This, Language("NetworkDebugger", "ConnectionLost"))
+            Message$ = Language("NetworkDebugger", "ConnectionLost")
+            Break
             
         EndSelect
-      EndIf
-      
-    CompilerEndIf
-    
-    ProcedureReturn Result
-  EndProcedure
-  
-  
-  Procedure Network_CheckErrors(*This.Network_Communication, *Command.CommandInfo, ProcessObject)
-    
-    If *This\EndReceived
-      ; COMMAND_End was received. Fire no errors anymore
-      ProcedureReturn #False
-      
-    ElseIf *This\CommandReceived = 0 And ElapsedMilliseconds() - *This\CommandTimeout > DebuggerTimeout
-      *Command\Command   = #COMMAND_FatalError
-      *Command\Value1    = #ERROR_Timeout
-      *Command\Value2    = 0
-      *Command\TimeStamp = Date()
-      *This\IsFatalError = #True
-      ProcedureReturn #True
-      
-    Else
-      ProcedureReturn #False
+      Wend
       
     EndIf
+  EndIf
+  
+  If Success
     
-  EndProcedure
-  
-  
-  
-  Procedure Network_Close(*This.Network_Communication)
-    LockMutex(Network_Mutex)
-    Network_CloseSocket(*This\Socket)
+    ; Start the command received timeout now
+    ;
+    *This\CommandReceived = 0
+    *This\CommandTimeout  = ElapsedMilliseconds()
     
-    ; clear stack, if any data left
+    *This\Connected = 1 ; the thread can start reading
+    
+  ElseIf *This\AbortPressed = #False  ; no error when abort was pressed
+    
+    HideWindow(*This\Window, 0) ; make sure the window is visible
+    SetActiveWindow(*This\Window)
+    
+    MessageStart$ = Language("NetworkDebugger","ConnectFailed") + ":" + #NewLine + *This\Host$ + " (" + Language("NetworkDebugger","Port") + " " + Str(*This\Port) + ")"
+    If Message$ <> ""
+      MessageStart$ + #NewLine + #NewLine + Message$
+    EndIf
+    
+    MessageRequester("PureBasic Debugger", MessageStart$, #FLAG_Error)
+    
+  EndIf
+  
+  Network_CloseWindow(*This)
+  
+  ProcedureReturn Success
+EndProcedure
+
+
+
+;- ----> Communication Interface
+
+DisableDebugger
+
+Procedure Network_FatalError(*This.Network_Communication, *Command.CommandInfo, FatalError)
+  *This\IsFatalError = #True
+  
+  CompilerIf #NOTHREAD = 0
+    LockMutex(*This\StackMutex)
+    
+    ; clear stack, so the fatal error is the only one
     For i = 0 To *This\StackCount-1
       If *This\Stack[i]\CommandData
         FreeMemory(*This\Stack[i]\CommandData)
       EndIf
     Next i
     
-    ; when we hold the global mutex, this is save
-    FreeMutex(Network_Data()\StackMutex)
+    *This\Stack[0]\Command\Command   = #COMMAND_FatalError
+    *This\Stack[0]\Command\Value1    = FatalError
+    *This\Stack[0]\Command\Value2    = 0
+    *This\Stack[0]\Command\TimeStamp = Date()
+    *This\Stack[0]\CommandData       = 0
+    *This\StackCount = 1
     
-    ChangeCurrentElement(Network_Data(), *This)
-    DeleteElement(Network_Data())
-    UnlockMutex(Network_Mutex)
-  EndProcedure
-  
-  ;- ----> Initialisation
-  
-  ; Mode: 1=client, 2=server (ignores Host$)
-  ;
-  Procedure CreateNetworkCommunication(Mode, Host$, Port, Password$)
-    *Result = 0
+    UnlockMutex(*This\StackMutex)
     
-    ; Initialize just once for all network stuff
-    ;
-    If Network_Initialized = 0
-      Network_Initialized = Network_Initialize()
+  CompilerElse
+    *Command\Command   = #COMMAND_FatalError
+    *Command\Value1    = FatalError
+    *Command\Value2    = 0
+    *Command\TimeStamp = Date()
+    
+  CompilerEndIf
+  
+EndProcedure
+
+Procedure Network_ReadCommandCrypt(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
+  Protected CommandCrypt.CommandInfo
+  
+  If Network_ReceiveData(*This\Socket, @CommandCrypt, SizeOf(CommandInfo)) = 0
+    ProcedureReturn #False
+  EndIf
+  
+  rijndael_cbc_decrypt(@*This\CryptContext, @CommandCrypt, *Command, SizeOf(CommandInfo), @*This\InitializerDecrypt)
+  ;rijndael_ecb_decrypt(@*This\CryptContext, @CommandCrypt, *Command, SizeOf(CommandInfo))
+  ;CopyMemory(@CommandCrypt, *Command, SizeOf(CommandInfo))
+  
+  If *Command\DataSize > 0
+    
+    ; Padding for blocks < 16 bytes
+    If *Command\DataSize < 16
+      Size = 16
+    Else
+      Size = *Command\DataSize
     EndIf
     
-    If Network_Initialized
+    *pCommandData\i   = AllocateMemory(Size)
+    *CommandDataCrypt = AllocateMemory(Size)
+    If *pCommandData\i = 0 Or *CommandDataCrypt = 0
+      ProcedureReturn #False
+    EndIf
+    
+    If Network_ReceiveData(*This\Socket, *CommandDataCrypt, Size) = 0
+      FreeMemory(*pCommandData\i)
+      FreeMemory(*CommandDataCrypt)
+      *pCommandData\i = 0
+      ProcedureReturn #False
+    EndIf
+    
+    rijndael_cbc_decrypt(@*This\CryptContext, *CommandDataCrypt, *pCommandData\i, Size, @*This\InitializerDecrypt)
+    ;rijndael_ecb_decrypt(@*This\CryptContext, *CommandDataCrypt, *pCommandData\i, Size)
+    ;CopyMemory(*CommandDataCrypt, *pCommandData\i, Size)
+    
+    FreeMemory(*CommandDataCrypt)
+  EndIf
+  
+  ProcedureReturn #True
+EndProcedure
+
+Procedure Network_ReadCommand(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
+  *pCommandData\i = 0
+  
+  If *This\EncryptStream
+    ProcedureReturn Network_ReadCommandCrypt(*This, *Command, *pCommandData)
+    
+  Else
+    
+    If Network_ReceiveData(*This\Socket, *Command, SizeOf(CommandInfo)) = 0
+      ProcedureReturn #False
+    EndIf
+    
+    If *Command\DataSize > 0
+      *pCommandData\i = AllocateMemory(*Command\DataSize)
+      If *pCommandData\i = 0
+        ProcedureReturn #False
+        
+      ElseIf Network_ReceiveData(*This\Socket, *pCommandData\i, *Command\DataSize) = 0
+        ProcedureReturn #False
+        
+      EndIf
+    EndIf
+  EndIf
+  
+  ProcedureReturn #True
+EndProcedure
+
+CompilerIf #NOTHREAD = 0
+  
+  ; ProcedureDLL for OSX !! (weird errors else!)
+  ;
+  ProcedureDLL Network_ReceiveThread(Dummy)
+    
+    Protected Command.CommandInfo
+    Protected *CommandData
+    
+    Repeat
+      LockMutex(Network_Mutex)  ; full protection needed!
       
-      ; there is only 1 thread for everything
-      CompilerIf #NOTHREAD = 0
-        If Network_Thread = 0
-          Network_Thread = CreateThread(@Network_ReceiveThread(), 0)
-        EndIf
+      TotalCount = 0
+      ForEach Network_Data()
         
-        If Network_Thread
-        CompilerEndIf
+        ; receive as long as there is data, and as long as there is space
+        ;
+        While Network_Data()\Connected And Network_Data()\EndReceived = 0 And Network_Data()\IsFatalError = 0
+          
+          ; Do not receive anything if the stack is full
+          If Network_Data()\StackCount >= #MAX_COMMANDSTACK
+            ; This check can be done without a mutex lock, as only this thread
+            ; can increase the stack, and a decrease during the check has no concequence
+            Break
+          EndIf
+          
+          Select Network_CheckData(Network_Data()\Socket)
+              
+            Case 0 ; no data
+              Break
+              
+            Case 1 ; data
+              If Network_ReadCommand(@Network_Data(), @Command, @*CommandData)
+                ; now lock the stack mutex and add data to the stack
+                ; we know there is a free spot, as we checked above
+                ; (And the main thread only decreases the stack)
+                LockMutex(Network_Data()\StackMutex)
+                
+                ; add to stack
+                CopyMemory(@Command, @Network_Data()\Stack[Network_Data()\StackCount]\Command, SizeOf(CommandInfo))
+                Network_Data()\Stack[Network_Data()\StackCount]\CommandData = *CommandData
+                Network_Data()\StackCount + 1
+                
+                Network_Data()\CommandReceived = 1
+                
+                If Command\Command = #COMMAND_End
+                  Network_Data()\EndReceived = 1
+                EndIf
+                
+                UnlockMutex(Network_Data()\StackMutex)
+                
+                TotalCount + 1
+                
+                ; break (and unlock mutex) after a lot of commands are read so the main thread can read it
+                If TotalCount > 50
+                  Break 2
+                EndIf
+              Else
+                If Network_Data()\EndReceived = 0
+                  Network_FatalError(@Network_Data(), @Command, #ERROR_NetworkFail)
+                EndIf
+                Break
+              EndIf
+              
+            Case 2 ; disconnect
+              If Network_Data()\EndReceived = 0  ; its no error if we terminated normally
+                Network_FatalError(@Network_Data(), @Command, #ERROR_NetworkFail)
+              EndIf
+              Break
+              
+          EndSelect
+          
+        Wend
         
-        LockMutex(Network_Mutex)
-        
-        AddElement(Network_Data())
-        If Mode = 1
-          Network_Data()\Vtbl = ?NetworkClient_Vtbl ; client mode
-        Else
-          Network_Data()\Vtbl = ?NetworkServer_Vtbl ; server mode
-        EndIf
-        Network_Data()\Host$      = Host$
-        Network_Data()\Port       = Port
-        Network_Data()\Password$  = Password$
-        Network_Data()\StackMutex = CreateMutex()
-        Network_Data()\Socket     = Network_CreateSocket()
-        
-        If Network_Data()\Socket <> #INVALID_SOCKET
-          *Result = @Network_Data()
-        Else
-          DeleteElement(Network_Data())
-        EndIf
-        
-        UnlockMutex(Network_Mutex)
-        
-        CompilerIf #NOTHREAD = 0
-        EndIf
+      Next Network_Data()
+      
+      UnlockMutex(Network_Mutex)
+      
+      Delay(10) ; time for the main thread to access the data
+    ForEver
+    
+  EndProcedure
+  
+CompilerEndIf
+
+EnableDebugger
+
+
+Procedure.s Network_GetInfo(*This.Network_Communication)
+  ProcedureReturn "" ; nothing to pass back here
+EndProcedure
+
+
+Procedure Network_Disconnect(*This.Network_Communication)
+  LockMutex(Network_Mutex)
+  ; Tell the thread to no longer try any reads (the socket is closed in Close())
+  *This\Connected = 0
+  UnlockMutex(Network_Mutex)
+EndProcedure
+
+Procedure Network_SendCrypt(*This.Network_Communication, *Command.CommandInfo, *CommandData)
+  Protected CommandCrypt.CommandInfo
+  Size = *Command\DataSize
+  
+  ; Encrypt/send the command (always > 16 byte)
+  rijndael_cbc_encrypt(@*This\CryptContext, *Command, @CommandCrypt, SizeOf(CommandInfo), @*This\InitializerEncrypt)
+  ;rijndael_ecb_encrypt(@*This\CryptContext, *Command, @CommandCrypt, SizeOf(CommandInfo))
+  ;CopyMemory(*Command, @CommandCrypt, SizeOf(CommandInfo))
+  
+  Network_SendData(*This\Socket, @CommandCrypt, SizeOf(CommandInfo))
+  
+  If Size > 0 And *CommandData
+    
+    If Size < 16
+      ; AES cannot handle buffers < 16byte, must be padded
+      ;
+      *Buffer = AllocateMemory(16)
+      If *Buffer = 0
+        ProcedureReturn
+      EndIf
+      
+      CopyMemory(*CommandData, *Buffer, Size)
+      SizeReal = 16
+    Else
+      *Buffer = *CommandData
+      SizeReal = Size
+    EndIf
+    
+    *CommandDataCrypt = AllocateMemory(Size)
+    If *CommandDataCrypt
+      rijndael_cbc_encrypt(@*This\CryptContext, *Buffer, *CommandDataCrypt, SizeReal, @*This\InitializerEncrypt)
+      ;rijndael_ecb_encrypt(@*This\CryptContext, *Buffer, *CommandDataCrypt, SizeReal)
+      ;CopyMemory(*Buffer, *CommandDataCrypt, SizeReal)
+      
+      Network_SendData(*This\Socket, *CommandDataCrypt, SizeReal)
+      FreeMemory(*CommandDataCrypt)
+    EndIf
+    
+    If Size < 16
+      FreeMemory(*Buffer)
+    EndIf
+  EndIf
+  
+EndProcedure
+
+
+
+Procedure Network_Send(*This.Network_Communication, *Command.CommandInfo, *CommandData)
+  
+  ; Note: We no longer do any disconnect detection when sending, because if the
+  ;   exe closes normally while we send something, we do not want a "fatal error"
+  ;   but rather the normal end message which we get when we get to read the COMMAND_End
+  ;   from the exe later
+  ;
+  If *This\Connected And *This\EndReceived = 0
+    
+    If *This\EncryptStream
+      Network_SendCrypt(*This, *Command, *CommandData)
+    Else
+      
+      Network_SendData(*This\Socket, *Command, SizeOf(CommandInfo))
+      
+      If *Command\DataSize > 0 And *CommandData
+        Network_SendData(*This\Socket, *CommandData, *Command\DataSize)
+      EndIf
+      
+    EndIf
+    
+  EndIf
+  
+EndProcedure
+
+
+Procedure Network_Receive(*This.Network_Communication, *Command.CommandInfo, *pCommandData.INTEGER)
+  Result = 0
+  
+  CompilerIf #NOTHREAD = 0
+    
+    LockMutex(*This\StackMutex)
+    
+    If *This\StackCount > 0
+      CopyMemory(@*This\Stack[0]\command, *Command, SizeOf(CommandInfo))
+      *pCommandData\i = *This\Stack[0]\commanddata
+      
+      ; remove this command from the stack
+      *This\StackCount - 1
+      If *This\StackCount > 0
+        MoveMemory(@*This\Stack[1], @*This\Stack[0], SizeOf(CommandStackStruct) * *This\StackCount)
+      EndIf
+      
+      Result = 1
+    EndIf
+    
+    UnlockMutex(*This\StackMutex)
+    
+    
+  CompilerElse
+    
+    If *This\Connected And *This\EndReceived = 0 And *This\IsFatalError = 0
+      Select Network_CheckData(*This\Socket)
+        Case 1
+          If Not Network_ReadCommand(*This, *Command, *pCommandData)
+            If *This\EndReceived = 0
+              Network_FatalError(*This, *Command, #ERROR_NetworkFail)
+              Result = 1
+            EndIf
+          Else
+            *This\CommandReceived = 1
+            
+            If *Command\Command = #COMMAND_End
+              *This\EndReceived = 1
+            EndIf
+            Result = 1
+          EndIf
+          
+          
+        Case 2
+          If *This\EndReceived = 0
+            Network_FatalError(*This, *Command, #ERROR_NetworkFail)
+            Result = 1
+          EndIf
+          
+      EndSelect
+    EndIf
+    
+  CompilerEndIf
+  
+  ProcedureReturn Result
+EndProcedure
+
+
+Procedure Network_CheckErrors(*This.Network_Communication, *Command.CommandInfo, ProcessObject)
+  
+  If *This\EndReceived
+    ; COMMAND_End was received. Fire no errors anymore
+    ProcedureReturn #False
+    
+  ElseIf *This\CommandReceived = 0 And ElapsedMilliseconds() - *This\CommandTimeout > DebuggerTimeout
+    *Command\Command   = #COMMAND_FatalError
+    *Command\Value1    = #ERROR_Timeout
+    *Command\Value2    = 0
+    *Command\TimeStamp = Date()
+    *This\IsFatalError = #True
+    ProcedureReturn #True
+    
+  Else
+    ProcedureReturn #False
+    
+  EndIf
+  
+EndProcedure
+
+
+
+Procedure Network_Close(*This.Network_Communication)
+  LockMutex(Network_Mutex)
+  Network_CloseSocket(*This\Socket)
+  
+  ; clear stack, if any data left
+  For i = 0 To *This\StackCount-1
+    If *This\Stack[i]\CommandData
+      FreeMemory(*This\Stack[i]\CommandData)
+    EndIf
+  Next i
+  
+  ; when we hold the global mutex, this is save
+  FreeMutex(Network_Data()\StackMutex)
+  
+  ChangeCurrentElement(Network_Data(), *This)
+  DeleteElement(Network_Data())
+  UnlockMutex(Network_Mutex)
+EndProcedure
+
+;- ----> Initialisation
+
+; Mode: 1=client, 2=server (ignores Host$)
+;
+Procedure CreateNetworkCommunication(Mode, Host$, Port, Password$)
+  *Result = 0
+  
+  ; Initialize just once for all network stuff
+  ;
+  If Network_Initialized = 0
+    Network_Initialized = Network_Initialize()
+  EndIf
+  
+  If Network_Initialized
+    
+    ; there is only 1 thread for everything
+    CompilerIf #NOTHREAD = 0
+      If Network_Thread = 0
+        Network_Thread = CreateThread(@Network_ReceiveThread(), 0)
+      EndIf
+      
+      If Network_Thread
       CompilerEndIf
       
-    EndIf
+      LockMutex(Network_Mutex)
+      
+      AddElement(Network_Data())
+      If Mode = 1
+        Network_Data()\Vtbl = ?NetworkClient_Vtbl ; client mode
+      Else
+        Network_Data()\Vtbl = ?NetworkServer_Vtbl ; server mode
+      EndIf
+      Network_Data()\Host$      = Host$
+      Network_Data()\Port       = Port
+      Network_Data()\Password$  = Password$
+      Network_Data()\StackMutex = CreateMutex()
+      Network_Data()\Socket     = Network_CreateSocket()
+      
+      If Network_Data()\Socket <> #INVALID_SOCKET
+        *Result = @Network_Data()
+      Else
+        DeleteElement(Network_Data())
+      EndIf
+      
+      UnlockMutex(Network_Mutex)
+      
+      CompilerIf #NOTHREAD = 0
+      EndIf
+    CompilerEndIf
     
-    If *Result = 0
-      ; we have to notify the user here
-      MessageRequester("PureBasic Debugger", Language("NetworkDebugger","Unavailable"), #FLAG_Error)
-    EndIf
-    
-    ProcedureReturn *Result
-  EndProcedure
+  EndIf
+  
+  If *Result = 0
+    ; we have to notify the user here
+    MessageRequester("PureBasic Debugger", Language("NetworkDebugger","Unavailable"), #FLAG_Error)
+  EndIf
+  
+  ProcedureReturn *Result
+EndProcedure
+
+
+
+DataSection
+  
+  NetworkClient_Vtbl:
+  Data.i @Network_GetInfo()
+  Data.i @Network_ConnectClient()
+  Data.i @Network_Disconnect()
+  Data.i @Network_Send()
+  Data.i @Network_Receive()
+  Data.i @Network_CheckErrors()
+  Data.i @Network_Close()
+  
+  NetworkServer_Vtbl:
+  Data.i @Network_GetInfo()
+  Data.i @Network_ConnectServer()
+  Data.i @Network_Disconnect()
+  Data.i @Network_Send()
+  Data.i @Network_Receive()
+  Data.i @Network_CheckErrors()
+  Data.i @Network_Close()
   
   
-  
-  DataSection
-    
-    NetworkClient_Vtbl:
-    Data.i @Network_GetInfo()
-    Data.i @Network_ConnectClient()
-    Data.i @Network_Disconnect()
-    Data.i @Network_Send()
-    Data.i @Network_Receive()
-    Data.i @Network_CheckErrors()
-    Data.i @Network_Close()
-    
-    NetworkServer_Vtbl:
-    Data.i @Network_GetInfo()
-    Data.i @Network_ConnectServer()
-    Data.i @Network_Disconnect()
-    Data.i @Network_Send()
-    Data.i @Network_Receive()
-    Data.i @Network_CheckErrors()
-    Data.i @Network_Close()
-    
-    
-  EndDataSection
-  
-  
+EndDataSection
+
+

--- a/PureBasicIDE/CompilerInterface.pb
+++ b/PureBasicIDE/CompilerInterface.pb
@@ -538,7 +538,7 @@ Procedure CompilerCleanup()
   CompilerEndIf
   
   If ExamineDirectory(0, TempPath$, "*")
-    Protected CompilerType.i
+    Protected CompilerType
     CompilerIf #CompileMac
       CompilerType = #PB_DirectoryEntry_Directory ; a .app is a directory!
     CompilerElse

--- a/PureBasicIDE/CompilerInterface.pb
+++ b/PureBasicIDE/CompilerInterface.pb
@@ -538,1867 +538,1870 @@ Procedure CompilerCleanup()
   CompilerEndIf
   
   If ExamineDirectory(0, TempPath$, "*")
+    Protected CompilerType.i
+    CompilerIf #CompileMac
+      CompilerType = #PB_DirectoryEntry_Directory ; a .app is a directory!
+    CompilerElse
+      CompilerType = #PB_DirectoryEntry_File
+    CompilerEndIf
+    
     While NextDirectoryEntry(0)
-      CompilerIf #CompileMac
-        If DirectoryEntryType(0) = #PB_DirectoryEntry_Directory ; a .app is a directory!
-        CompilerElse
-          If DirectoryEntryType(0) = #PB_DirectoryEntry_File
-          CompilerEndIf
-          
-          File$ = DirectoryEntryName(0)
-          
-          CompilerIf #CompileWindows
-            If Left(File$, 21) = "PureBasic_Compilation" And Right(File$, 4) = ".exe"
-              DeleteFile(TempPath$ + File$)
-            EndIf
-          CompilerEndIf
-          
-          CompilerIf #CompileLinux
-            If Left(File$, 21) = "purebasic_compilation" And Right(File$, 4) = ".out"
-              DeleteFile(TempPath$ + File$)
-            EndIf
-          CompilerEndIf
-          
-          CompilerIf #CompileMac
-            If Left(File$, 10) = "PureBasic." And Right(File$, 4) = ".app"
-              ; a .app is a directory!
-              DeleteDirectory(TempPath$ + File$, "*", #PB_FileSystem_Recursive|#PB_FileSystem_Force)
-            EndIf
-          CompilerEndIf
-          
-        EndIf
-      Wend
-    EndIf
-    
-  EndProcedure
+      If DirectoryEntryType(0) = CompilerType
+        
+        File$ = DirectoryEntryName(0)
+        
+        CompilerIf #CompileWindows
+          If Left(File$, 21) = "PureBasic_Compilation" And Right(File$, 4) = ".exe"
+            DeleteFile(TempPath$ + File$)
+          EndIf
+        CompilerEndIf
+        
+        CompilerIf #CompileLinux
+          If Left(File$, 21) = "purebasic_compilation" And Right(File$, 4) = ".out"
+            DeleteFile(TempPath$ + File$)
+          EndIf
+        CompilerEndIf
+        
+        CompilerIf #CompileMac
+          If Left(File$, 10) = "PureBasic." And Right(File$, 4) = ".app"
+            ; a .app is a directory!
+            DeleteDirectory(TempPath$ + File$, "*", #PB_FileSystem_Recursive|#PB_FileSystem_Force)
+          EndIf
+        CompilerEndIf
+        
+      EndIf
+    Wend
+  EndIf
   
+EndProcedure
+
+
+Procedure RestartCompiler(*Compiler.Compiler, NoReadyCall = 0)
   
-  Procedure RestartCompiler(*Compiler.Compiler, NoReadyCall = 0)
+  ; Does not check CompilerBusy anymore, as it is called during compilation
+  ; to switch unicode mode!
+  ;
+  KillCompiler()
+  
+  If CommandlineBuild = 0 And IsMenu(#MENU)
+    DisableMenuItem(#MENU, #MENU_StructureViewer, 1)
+    DisableMenuItem(#MENU, #MENU_CompileRun, 1)
+    DisableMenuItem(#MENU, #MENU_SyntaxCheck, 1)
+    DisableMenuItem(#MENU, #MENU_CreateExecutable, 1)
+  EndIf
+  
+  If CommandlineBuild = 0
+    DisableToolBarButton(#TOOLBAR, #MENU_CompileRun, 1)
+  EndIf
+  
+  CompilerProgram = 0
+  
+  StartCompiler(*Compiler)
+  WaitForCompilerReady(NoReadyCall)
+  
+EndProcedure
+
+Procedure ForceDefaultCompiler()
+  If *CurrentCompiler <> @DefaultCompiler
+    RestartCompiler(@DefaultCompiler, #False)
+  EndIf
+EndProcedure
+
+
+Procedure TokenizeCompilerVersion(Version$, *Version.INTEGER, *Beta.INTEGER, *OS.INTEGER, *Processor.INTEGER)
+  Version$ = Trim(UCase(Version$))
+  
+  If StringField(Version$, 1, " ") = UCase(#ProductName$)
     
-    ; Does not check CompilerBusy anymore, as it is called during compilation
-    ; to switch unicode mode!
+    ; remove the LTS indicator
+    Version$ = ReplaceString(Version$, " LTS ", " ")
+    
+    *Version\i = Val(LSet(RemoveString(StringField(Version$, 2, " "), "."), 3, "0"))
+    
+    ; *Beta\i is a bitmask: AlphaVersion | BetaVersion << 8
+    ; For Finals, *Beta\i is $FFFF (so higher than all alpha/beta values)
     ;
-    KillCompiler()
-    
-    If CommandlineBuild = 0 And IsMenu(#MENU)
-      DisableMenuItem(#MENU, #MENU_StructureViewer, 1)
-      DisableMenuItem(#MENU, #MENU_CompileRun, 1)
-      DisableMenuItem(#MENU, #MENU_SyntaxCheck, 1)
-      DisableMenuItem(#MENU, #MENU_CreateExecutable, 1)
-    EndIf
-    
-    If CommandlineBuild = 0
-      DisableToolBarButton(#TOOLBAR, #MENU_CompileRun, 1)
-    EndIf
-    
-    CompilerProgram = 0
-    
-    StartCompiler(*Compiler)
-    WaitForCompilerReady(NoReadyCall)
-    
-  EndProcedure
-  
-  Procedure ForceDefaultCompiler()
-    If *CurrentCompiler <> @DefaultCompiler
-      RestartCompiler(@DefaultCompiler, #False)
-    EndIf
-  EndProcedure
-  
-  
-  Procedure TokenizeCompilerVersion(Version$, *Version.INTEGER, *Beta.INTEGER, *OS.INTEGER, *Processor.INTEGER)
-    Version$ = Trim(UCase(Version$))
-    
-    If StringField(Version$, 1, " ") = UCase(#ProductName$)
-      
-      ; remove the LTS indicator
-      Version$ = ReplaceString(Version$, " LTS ", " ")
-      
-      *Version\i = Val(LSet(RemoveString(StringField(Version$, 2, " "), "."), 3, "0"))
-      
-      ; *Beta\i is a bitmask: AlphaVersion | BetaVersion << 8
-      ; For Finals, *Beta\i is $FFFF (so higher than all alpha/beta values)
-      ;
-      If StringField(Version$, 3, " ") = "ALPHA"
-        *Beta\i = Val(StringField(Version$, 4, " "))
-      ElseIf StringField(Version$, 3, " ") = "BETA"
-        *Beta\i = Val(StringField(Version$, 4, " ")) << 8
-      Else
-        *Beta\i = $FFFF
-      EndIf
-      
-      If FindString(Version$, "WINDOWS", 1)
-        *OS\i = #PB_OS_Windows
-      ElseIf FindString(Version$, "LINUX", 1)
-        *OS\i = #PB_OS_Linux
-      ElseIf FindString(Version$, "MACOS", 1)
-        *OS\i = #PB_OS_MacOS
-      Else
-        *OS\i = #PB_OS_AmigaOS  ; unlikely :)
-      EndIf
-      
-      If FindString(Version$, "X86", 1)
-        *Processor\i = #PB_Processor_x86
-      ElseIf FindString(Version$, "X64", 1)
-        *Processor\i = #PB_Processor_x64
-      ElseIf FindString(Version$, "POWERPC", 1)
-        *Processor\i = #PB_Processor_PowerPC
-      Else
-        *Processor\i = #PB_Processor_mc68000 ; also unlikely
-      EndIf
-      
-      ProcedureReturn #True
+    If StringField(Version$, 3, " ") = "ALPHA"
+      *Beta\i = Val(StringField(Version$, 4, " "))
+    ElseIf StringField(Version$, 3, " ") = "BETA"
+      *Beta\i = Val(StringField(Version$, 4, " ")) << 8
     Else
-      ProcedureReturn #False
-    EndIf
-  EndProcedure
-  
-  Procedure MatchCompilerVersion(Version1$, Version2$, Flags = #MATCH_Exact)
-    
-    If TokenizeCompilerVersion(Version1$, @Version1, @Beta1, @OS1, @Processor1) = #False
-      ProcedureReturn #False
+      *Beta\i = $FFFF
     EndIf
     
-    If TokenizeCompilerVersion(Version2$, @Version2, @Beta2, @OS2, @Processor2) = #False
-      ProcedureReturn #False
+    If FindString(Version$, "WINDOWS", 1)
+      *OS\i = #PB_OS_Windows
+    ElseIf FindString(Version$, "LINUX", 1)
+      *OS\i = #PB_OS_Linux
+    ElseIf FindString(Version$, "MACOS", 1)
+      *OS\i = #PB_OS_MacOS
+    Else
+      *OS\i = #PB_OS_AmigaOS  ; unlikely :)
     EndIf
     
-    If Flags & #MATCH_OS And OS1 <> OS2
-      ProcedureReturn #False
-    EndIf
-    
-    If Flags & #MATCH_Version And Version1 <> Version2
-      ProcedureReturn #False
-    EndIf
-    
-    If Flags & #MATCH_VersionUp
-      Base1 = Version1 - (Version1 % 10)
-      Base2 = Version2 - (Version2 % 10)
-      
-      If Base1 <> Base2 Or Version1 > Version2 ; 4.40 -> 4.41 etc is ok
-        ProcedureReturn #False
-      EndIf
-    EndIf
-    
-    If Flags & #MATCH_Beta And Beta1 <> Beta2
-      ProcedureReturn #False
-    EndIf
-    
-    If Flags & #MATCH_BetaUp And Beta1 > Beta2
-      ProcedureReturn #False
-    EndIf
-    
-    If Flags & #MATCH_Processor And Processor1 <> Processor2
-      ProcedureReturn #False
+    If FindString(Version$, "X86", 1)
+      *Processor\i = #PB_Processor_x86
+    ElseIf FindString(Version$, "X64", 1)
+      *Processor\i = #PB_Processor_x64
+    ElseIf FindString(Version$, "POWERPC", 1)
+      *Processor\i = #PB_Processor_PowerPC
+    Else
+      *Processor\i = #PB_Processor_mc68000 ; also unlikely
     EndIf
     
     ProcedureReturn #True
-  EndProcedure
+  Else
+    ProcedureReturn #False
+  EndIf
+EndProcedure
+
+Procedure MatchCompilerVersion(Version1$, Version2$, Flags = #MATCH_Exact)
   
-  Procedure SortCompilers()
+  If TokenizeCompilerVersion(Version1$, @Version1, @Beta1, @OS1, @Processor1) = #False
+    ProcedureReturn #False
+  EndIf
+  
+  If TokenizeCompilerVersion(Version2$, @Version2, @Beta2, @OS2, @Processor2) = #False
+    ProcedureReturn #False
+  EndIf
+  
+  If Flags & #MATCH_OS And OS1 <> OS2
+    ProcedureReturn #False
+  EndIf
+  
+  If Flags & #MATCH_Version And Version1 <> Version2
+    ProcedureReturn #False
+  EndIf
+  
+  If Flags & #MATCH_VersionUp
+    Base1 = Version1 - (Version1 % 10)
+    Base2 = Version2 - (Version2 % 10)
+    
+    If Base1 <> Base2 Or Version1 > Version2 ; 4.40 -> 4.41 etc is ok
+      ProcedureReturn #False
+    EndIf
+  EndIf
+  
+  If Flags & #MATCH_Beta And Beta1 <> Beta2
+    ProcedureReturn #False
+  EndIf
+  
+  If Flags & #MATCH_BetaUp And Beta1 > Beta2
+    ProcedureReturn #False
+  EndIf
+  
+  If Flags & #MATCH_Processor And Processor1 <> Processor2
+    ProcedureReturn #False
+  EndIf
+  
+  ProcedureReturn #True
+EndProcedure
+
+Procedure SortCompilers()
+  ForEach Compilers()
+    If Compilers()\Validated And TokenizeCompilerVersion(Compilers()\VersionString$, @Version, @Beta, @OS, @Processor)
+      Compilers()\SortIndex = Processor << 28 | Version << 16 | Beta  ; ignore OS, as all should have the same anyway
+    Else
+      Compilers()\SortIndex = -1
+    EndIf
+  Next Compilers()
+  
+  SortStructuredList(Compilers(), #PB_Sort_Descending, OffsetOf(Compiler\SortIndex), #PB_Long)
+EndProcedure
+
+Procedure FindCompiler(Version$)
+  ;
+  ; We ignore the OS in our matches to have better crossplatform compatibility
+  ; (you won't find several different OS compilers on the same OS anyway)
+  ;
+  
+  ; Look for an exact match first
+  ;
+  If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_Version|#MATCH_Beta|#MATCH_Processor)
+    ProcedureReturn @DefaultCompiler
+  Else
     ForEach Compilers()
-      If Compilers()\Validated And TokenizeCompilerVersion(Compilers()\VersionString$, @Version, @Beta, @OS, @Processor)
-        Compilers()\SortIndex = Processor << 28 | Version << 16 | Beta  ; ignore OS, as all should have the same anyway
-      Else
-        Compilers()\SortIndex = -1
+      If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_Version|#MATCH_Beta|#MATCH_Processor)
+        ProcedureReturn @Compilers()
       EndIf
     Next Compilers()
-    
-    SortStructuredList(Compilers(), #PB_Sort_Descending, OffsetOf(Compiler\SortIndex), #PB_Long)
-  EndProcedure
+  EndIf
   
-  Procedure FindCompiler(Version$)
-    ;
-    ; We ignore the OS in our matches to have better crossplatform compatibility
-    ; (you won't find several different OS compilers on the same OS anyway)
-    ;
-    
-    ; Look for an exact match first
-    ;
-    If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_Version|#MATCH_Beta|#MATCH_Processor)
-      ProcedureReturn @DefaultCompiler
-    Else
-      ForEach Compilers()
-        If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_Version|#MATCH_Beta|#MATCH_Processor)
-          ProcedureReturn @Compilers()
-        EndIf
-      Next Compilers()
-    EndIf
-    
-    ; Look for another alpha/beta version now
-    ;
-    If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_Version|#MATCH_BetaUp|#MATCH_Processor)
-      ProcedureReturn @DefaultCompiler
-    Else
-      ForEach Compilers()
-        If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_Version|#MATCH_BetaUp|#MATCH_Processor)
-          ProcedureReturn @Compilers()
-        EndIf
-      Next Compilers()
-    EndIf
-    
-    ; Now look for another higher minor version
-    ;
-    If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_VersionUp|#MATCH_Processor)
-      ProcedureReturn @DefaultCompiler
-    Else
-      ForEach Compilers()
-        If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_VersionUp|#MATCH_Processor)
-          ProcedureReturn @Compilers()
-        EndIf
-      Next Compilers()
-    EndIf
-    
-    ; No match found
-    ProcedureReturn 0
-  EndProcedure
+  ; Look for another alpha/beta version now
+  ;
+  If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_Version|#MATCH_BetaUp|#MATCH_Processor)
+    ProcedureReturn @DefaultCompiler
+  Else
+    ForEach Compilers()
+      If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_Version|#MATCH_BetaUp|#MATCH_Processor)
+        ProcedureReturn @Compilers()
+      EndIf
+    Next Compilers()
+  EndIf
   
+  ; Now look for another higher minor version
+  ;
+  If MatchCompilerVersion(Version$, DefaultCompiler\VersionString$, #MATCH_VersionUp|#MATCH_Processor)
+    ProcedureReturn @DefaultCompiler
+  Else
+    ForEach Compilers()
+      If Compilers()\Validated And MatchCompilerVersion(Version$, Compilers()\VersionString$, #MATCH_VersionUp|#MATCH_Processor)
+        ProcedureReturn @Compilers()
+      EndIf
+    Next Compilers()
+  EndIf
   
-  Procedure GetCompilerVersion(Executable$, *Compiler.Compiler)
-    *Compiler\Executable$ = Executable$
-    *Compiler\Validated   = #False
-    Result = #False
+  ; No match found
+  ProcedureReturn 0
+EndProcedure
+
+
+Procedure GetCompilerVersion(Executable$, *Compiler.Compiler)
+  *Compiler\Executable$ = Executable$
+  *Compiler\Validated   = #False
+  Result = #False
+  
+  Compiler = RunProgram(Executable$, #COMPILER_VERSION, GetPathPart(Executable$), #PB_Program_Hide|#PB_Program_Open|#PB_Program_Read)
+  If Compiler
     
-    Compiler = RunProgram(Executable$, #COMPILER_VERSION, GetPathPart(Executable$), #PB_Program_Hide|#PB_Program_Open|#PB_Program_Read)
-    If Compiler
+    Timeout.q = ElapsedMilliseconds() + 2000
+    While ElapsedMilliseconds() < Timeout And AvailableProgramOutput(Compiler) = 0
+      Delay(10)
+    Wend
+    
+    If AvailableProgramOutput(Compiler) > 0
+      Version$ = ReadProgramString(Compiler)
       
-      Timeout.q = ElapsedMilliseconds() + 2000
-      While ElapsedMilliseconds() < Timeout And AvailableProgramOutput(Compiler) = 0
-        Delay(10)
-      Wend
-      
-      If AvailableProgramOutput(Compiler) > 0
-        Version$ = ReadProgramString(Compiler)
+      If Left(Version$, 10) = #ProductName$ + " "
+        copy = FindString(Version$, "- (c)", 1) ; cut the copyright statement
+        If copy > 0
+          Version$ = RTrim(Left(Version$, copy-1))
+        EndIf
         
-        If Left(Version$, 10) = #ProductName$ + " "
-          copy = FindString(Version$, "- (c)", 1) ; cut the copyright statement
-          If copy > 0
-            Version$ = RTrim(Left(Version$, copy-1))
-          EndIf
-          
-          *Compiler\Executable$    = Executable$
-          *Compiler\MD5$           = FileFingerprint(Executable$, #PB_Cipher_MD5)
-          *Compiler\VersionString$ = Version$
-          *Compiler\VersionNumber  = Val(LSet(RemoveString(StringField(Version$, 2, " "), "."), 3, "0"))
-          
-          ; 3.94 and 4.00 both know the /VERSION switch, but they do not have the
-          ; communication interface, so we cannot accept them
-          ;
-          If *Compiler\VersionNumber >= 410
-            *Compiler\Validated = #True
-            Result = #True
-          EndIf
-          
-          ; purge any remaining output (should be nothing more)
-          While ProgramRunning(Compiler)
-            ReadProgramString(Compiler)
-          Wend
-          
-        Else
-          ; probably not a PB compiler, so kill it (we do not know how much output follows)
-          KillProgram(Compiler)
+        *Compiler\Executable$    = Executable$
+        *Compiler\MD5$           = FileFingerprint(Executable$, #PB_Cipher_MD5)
+        *Compiler\VersionString$ = Version$
+        *Compiler\VersionNumber  = Val(LSet(RemoveString(StringField(Version$, 2, " "), "."), 3, "0"))
+        
+        ; 3.94 and 4.00 both know the /VERSION switch, but they do not have the
+        ; communication interface, so we cannot accept them
+        ;
+        If *Compiler\VersionNumber >= 410
+          *Compiler\Validated = #True
+          Result = #True
         EndIf
+        
+        ; purge any remaining output (should be nothing more)
+        While ProgramRunning(Compiler)
+          ReadProgramString(Compiler)
+        Wend
+        
       Else
-        ; timeout. probably not a PureBasic compiler
+        ; probably not a PB compiler, so kill it (we do not know how much output follows)
         KillProgram(Compiler)
       EndIf
-      
-      CloseProgram(Compiler)
-    EndIf
-    
-    ProcedureReturn Result
-  EndProcedure
-  
-  
-  ; ----------------------------------------------------------------------
-  
-  
-  Procedure Compiler_SetCompiler(*Target.CompileTarget)
-    
-    ; Find a matching compiler
-    ;
-    If *Target\CustomCompiler = #False
-      *Compiler.Compiler = @DefaultCompiler
     Else
-      *Compiler.Compiler = FindCompiler(*Target\CompilerVersion$)
-      
-      If *Compiler = 0
-        If CommandlineBuild
-          PrintN(Language("Compiler","CompilerNotFound")+": "+*Target\CompilerVersion$)
-        ElseIf UseProjectBuildWindow
-          BuildLogEntry(Language("Compiler","CompilerNotFound")+": "+*Target\CompilerVersion$)
-        Else
-          MessageRequester(#ProductName$, Language("Compiler","CompilerNotFound")+":"+#NewLine+*Target\CompilerVersion$)
-        EndIf
-        
-        ProcedureReturn #False
-      EndIf
+      ; timeout. probably not a PureBasic compiler
+      KillProgram(Compiler)
     EndIf
     
-    If *Compiler <> @DefaultCompiler
-      If UseProjectBuildWindow And CommandlineBuild = 0
-        BuildLogEntry(Language("Compiler","BuildUseCompiler")+": "+*Compiler\VersionString$)
-      ElseIf CommandlineBuild And QuietBuild = 0
-        Print(Language("Compiler","BuildUseCompiler")+": "+*Compiler\VersionString$)
+    CloseProgram(Compiler)
+  EndIf
+  
+  ProcedureReturn Result
+EndProcedure
+
+
+; ----------------------------------------------------------------------
+
+
+Procedure Compiler_SetCompiler(*Target.CompileTarget)
+  
+  ; Find a matching compiler
+  ;
+  If *Target\CustomCompiler = #False
+    *Compiler.Compiler = @DefaultCompiler
+  Else
+    *Compiler.Compiler = FindCompiler(*Target\CompilerVersion$)
+    
+    If *Compiler = 0
+      If CommandlineBuild
+        PrintN(Language("Compiler","CompilerNotFound")+": "+*Target\CompilerVersion$)
+      ElseIf UseProjectBuildWindow
+        BuildLogEntry(Language("Compiler","CompilerNotFound")+": "+*Target\CompilerVersion$)
+      Else
+        MessageRequester(#ProductName$, Language("Compiler","CompilerNotFound")+":"+#NewLine+*Target\CompilerVersion$)
       EndIf
+      
+      ProcedureReturn #False
+    EndIf
+  EndIf
+  
+  If *Compiler <> @DefaultCompiler
+    If UseProjectBuildWindow And CommandlineBuild = 0
+      BuildLogEntry(Language("Compiler","BuildUseCompiler")+": "+*Compiler\VersionString$)
+    ElseIf CommandlineBuild And QuietBuild = 0
+      Print(Language("Compiler","BuildUseCompiler")+": "+*Compiler\VersionString$)
+    EndIf
+  EndIf
+  
+  If *Compiler <> *CurrentCompiler Or CompilerProgram = 0 Or *Target\SubSystem$ <> Compiler_SubSystem$
+    Compiler_SubSystem$  = *Target\SubSystem$
+    
+    If CommandlineBuild = 0
+      FlushEvents() ; process all waiting messages
     EndIf
     
-    If *Compiler <> *CurrentCompiler Or CompilerProgram = 0 Or *Target\SubSystem$ <> Compiler_SubSystem$
-      Compiler_SubSystem$  = *Target\SubSystem$
+    
+    ; a compiler restart is required
+    RestartCompiler(*Compiler, #True) ; set #true to not call CompilerReady(), as it re-highlights all code!
+    
+    ; no need to wait for the compiler, as RestartCompiler()
+    ; calls WaitForCompilerReady()
+    ;
+    If CompilerReady ; if 0, restart failed
       
+      ; do the needed stuff for CompilerReady() as it is not called here
       If CommandlineBuild = 0
-        FlushEvents() ; process all waiting messages
+        DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
+        DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
+        DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
+        DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
       EndIf
       
+      ProcedureReturn #True
       
-      ; a compiler restart is required
+    Else
+      HideCompilerWindow()
+      
+      ; Try to start the compiler again without any subsystem or unicode
+      ; (this is for the case where a subsystem cannot be found)
+      Compiler_SubSystem$  = ""
+      CompilerBusy = 0       ; disable the "compiler is busy" requester
       RestartCompiler(*Compiler, #True) ; set #true to not call CompilerReady(), as it re-highlights all code!
+                                        ; do not set Busy flag again as the compilation is aborted
       
-      ; no need to wait for the compiler, as RestartCompiler()
-      ; calls WaitForCompilerReady()
+      If CompilerReady ; if 0, restart failed
+                       ; do the needed stuff for CompilerReady() as it is not called here
+        If CommandlineBuild = 0
+          DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
+          DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
+          DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
+          DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
+        EndIf
+      Else
+        
+        ; all failed, force the default compiler
+        ForceDefaultCompiler()
+        
+        ; This is fatal also in build mode, as we cannot continue the build without a compiler!
+        ; So show this requester in all cases
+        ;
+        If CommandlineBuild
+          PrintN(Language("Compiler","StartError")+": "+*Compiler\VersionString$)
+        ElseIf UseProjectBuildWindow
+          BuildLogEntry(Language("Compiler","StartError")+": "+*Compiler\VersionString$)
+        Else
+          MessageRequester(#ProductName$, Language("Compiler","StartError")+": "+*Compiler\VersionString$, #FLAG_Error)
+        EndIf
+      EndIf
+      
+      ProcedureReturn #False; abort the compilation in any case (for subsystem problems)
+      
+    EndIf
+    
+  EndIf
+  
+  ProcedureReturn #True ; no change needed, so all ok
+EndProcedure
+
+; Handle the error and progress display
+;
+Procedure Compiler_HandleCompilerResponse(*Target.CompileTarget)
+  Protected NewList MacroLines.s()
+  
+  CompilationAborted = #False ; clear the flag
+  WarningCount       = 0
+  
+  ; handle any PROGRESS messages
+  ;
+  Repeat
+    If CommandlineBuild = 0
+      FlushEvents() ; flush at least once the events even if data is waiting
+    EndIf
+    
+    ; wait for data to be ready
+    While ProgramRunning(CompilerProgram) And AvailableProgramOutput(CompilerProgram) = 0
+      If CommandlineBuild = 0
+        While DispatchEvent(WaitWindowEvent(10))
+          EventLoopCallback()
+        Wend
+      Else
+        Delay(50)
+      EndIf
+    Wend
+    
+    If ProgramRunning(CompilerProgram) = 0
+      ; hide the window, so the requester cannot get stuck behind it as it is topmost
+      ; the window will be closed by the restart code below.
+      If CommandlineBuild
+        Message$ = Language("Compiler","CompilerCrash") ; this is a multiline message
+        If FindString(Message$, #NewLine, 1)
+          Message$ = Left(Message$, FindString(Message$, #NewLine, 1)-1)
+        EndIf
+        PrintN(Message$)
+      ElseIf UseProjectBuildWindow
+        Message$ = Language("Compiler","CompilerCrash") ; this is a multiline message
+        If FindString(Message$, #NewLine, 1)
+          Message$ = Left(Message$, FindString(Message$, #NewLine, 1)-1)
+        EndIf
+        BuildLogEntry(Message$)
+      Else
+        HideWindow(#WINDOW_Compiler, #True)
+      EndIf
+      
+      ; Again, this is treated as a fatal error, so even the build mode gets a requester
+      If CommandlineBuild = 0
+        MessageRequester(#ProductName$, Language("Compiler","CompilerCrash"), #FLAG_Error)
+      EndIf
+      CompilationAborted = #True ; causes a compiler restart and ensures a proper compilation abort
+    EndIf
+    
+    ; Handle the event that the user aborted the compilation
+    ; We can only safely abort a compilation by restarting the compiler, as else
+    ; the Compiler-IDE communication is out of sync!
+    ;
+    If CompilationAborted And CommandlineBuild = 0 ; not possible in commandline mode
+      If UseProjectBuildWindow
+        BuildLogEntry(Language("Compiler","Aborting"))
+      Else
+        SetGadgetText(#GADGET_Compiler_Text, Language("Compiler","Aborting"))
+        AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Aborting"))
+        SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
+      EndIf
+      
+      DisableMenuItem(#MENU, #MENU_StructureViewer, 1)
+      DisableMenuItem(#MENU, #MENU_CreateExecutable, 1)
+      DisableMenuAndToolbarItem(#MENU_CompileRun, 1)
+      DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 1)
+      
+      FlushEvents() ; ensure a proper display
+      
+      ; do this only if the compiler did not crash!
       ;
+      If ProgramRunning(CompilerProgram)
+        ; give the compiler a chance to quit itself with proper cleanup
+        ; (will only work if compilation finishes in this time anyway)
+        ;
+        CompilerWrite("END")
+        Timeout.q = ElapsedMilliseconds() + 2000
+        
+        While Timeout.q > ElapsedMilliseconds()
+          FlushEvents()
+          If WaitProgram(CompilerProgram, 10)
+            Break
+          EndIf
+          
+          If AvailableProgramOutput(CompilerProgram) > 0
+            ReadProgramString(CompilerProgram) ; we need to read any available input as the compiler will lock else
+          EndIf
+        Wend
+        
+        ; Kill it if it is still running (which is probably true, as people will mostly use this if the compiler hangs)
+        If ProgramRunning(CompilerProgram)
+          KillProgram(CompilerProgram)
+        EndIf
+      EndIf
+      CloseProgram(CompilerProgram)
+      
+      CompilerProgram = 0
+      CompilerReady   = 0
+      
+      StartCompiler(*CurrentCompiler)
+      WaitForCompilerReady(NoReadyCall)
+      
       If CompilerReady ; if 0, restart failed
         
         ; do the needed stuff for CompilerReady() as it is not called here
-        If CommandlineBuild = 0
-          DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
-          DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
-          DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
-          DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
-        EndIf
-        
-        ProcedureReturn #True
-        
+        DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
+        DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
+        DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
+        DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
       Else
-        HideCompilerWindow()
-        
-        ; Try to start the compiler again without any subsystem or unicode
-        ; (this is for the case where a subsystem cannot be found)
-        Compiler_SubSystem$  = ""
-        CompilerBusy = 0       ; disable the "compiler is busy" requester
-        RestartCompiler(*Compiler, #True) ; set #true to not call CompilerReady(), as it re-highlights all code!
-                                          ; do not set Busy flag again as the compilation is aborted
-        
-        If CompilerReady ; if 0, restart failed
-                         ; do the needed stuff for CompilerReady() as it is not called here
-          If CommandlineBuild = 0
-            DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
-            DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
-            DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
-            DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
-          EndIf
-        Else
-          
-          ; all failed, force the default compiler
-          ForceDefaultCompiler()
-          
-          ; This is fatal also in build mode, as we cannot continue the build without a compiler!
-          ; So show this requester in all cases
-          ;
-          If CommandlineBuild
-            PrintN(Language("Compiler","StartError")+": "+*Compiler\VersionString$)
-          ElseIf UseProjectBuildWindow
-            BuildLogEntry(Language("Compiler","StartError")+": "+*Compiler\VersionString$)
-          Else
-            MessageRequester(#ProductName$, Language("Compiler","StartError")+": "+*Compiler\VersionString$, #FLAG_Error)
-          EndIf
-        EndIf
-        
-        ProcedureReturn #False; abort the compilation in any case (for subsystem problems)
-        
+        MessageRequester(#ProductName$, Language("Compiler","RestartError"), #FLAG_Error)
       EndIf
       
+      HideCompilerWindow()
+      
+      ; in build mode, the window stays open, so do not do this
+      If UseProjectBuildWindow = 0
+        ActivateMainWindow()
+      EndIf
+      
+      ProcedureReturn #False ; compilation aborted
     EndIf
     
-    ProcedureReturn #True ; no change needed, so all ok
-  EndProcedure
-  
-  ; Handle the error and progress display
-  ;
-  Procedure Compiler_HandleCompilerResponse(*Target.CompileTarget)
-    Protected NewList MacroLines.s()
     
-    CompilationAborted = #False ; clear the flag
-    WarningCount       = 0
+    Response$ = CompilerRead() ; read compiler response
     
-    ; handle any PROGRESS messages
-    ;
-    Repeat
-      If CommandlineBuild = 0
-        FlushEvents() ; flush at least once the events even if data is waiting
-      EndIf
+    If Left(Response$, 9) = "PROGRESS"+Chr(9)  ; progress response
       
-      ; wait for data to be ready
-      While ProgramRunning(CompilerProgram) And AvailableProgramOutput(CompilerProgram) = 0
-        If CommandlineBuild = 0
-          While DispatchEvent(WaitWindowEvent(10))
-            EventLoopCallback()
-          Wend
-        Else
-          Delay(50)
-        EndIf
-      Wend
-      
-      If ProgramRunning(CompilerProgram) = 0
-        ; hide the window, so the requester cannot get stuck behind it as it is topmost
-        ; the window will be closed by the restart code below.
-        If CommandlineBuild
-          Message$ = Language("Compiler","CompilerCrash") ; this is a multiline message
-          If FindString(Message$, #NewLine, 1)
-            Message$ = Left(Message$, FindString(Message$, #NewLine, 1)-1)
-          EndIf
-          PrintN(Message$)
-        ElseIf UseProjectBuildWindow
-          Message$ = Language("Compiler","CompilerCrash") ; this is a multiline message
-          If FindString(Message$, #NewLine, 1)
-            Message$ = Left(Message$, FindString(Message$, #NewLine, 1)-1)
-          EndIf
-          BuildLogEntry(Message$)
-        Else
-          HideWindow(#WINDOW_Compiler, #True)
-        EndIf
-        
-        ; Again, this is treated as a fatal error, so even the build mode gets a requester
-        If CommandlineBuild = 0
-          MessageRequester(#ProductName$, Language("Compiler","CompilerCrash"), #FLAG_Error)
-        EndIf
-        CompilationAborted = #True ; causes a compiler restart and ensures a proper compilation abort
-      EndIf
-      
-      ; Handle the event that the user aborted the compilation
-      ; We can only safely abort a compilation by restarting the compiler, as else
-      ; the Compiler-IDE communication is out of sync!
-      ;
-      If CompilationAborted And CommandlineBuild = 0 ; not possible in commandline mode
-        If UseProjectBuildWindow
-          BuildLogEntry(Language("Compiler","Aborting"))
-        Else
-          SetGadgetText(#GADGET_Compiler_Text, Language("Compiler","Aborting"))
-          AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Aborting"))
-          SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
-        EndIf
-        
-        DisableMenuItem(#MENU, #MENU_StructureViewer, 1)
-        DisableMenuItem(#MENU, #MENU_CreateExecutable, 1)
-        DisableMenuAndToolbarItem(#MENU_CompileRun, 1)
-        DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 1)
-        
-        FlushEvents() ; ensure a proper display
-        
-        ; do this only if the compiler did not crash!
-        ;
-        If ProgramRunning(CompilerProgram)
-          ; give the compiler a chance to quit itself with proper cleanup
-          ; (will only work if compilation finishes in this time anyway)
-          ;
-          CompilerWrite("END")
-          Timeout.q = ElapsedMilliseconds() + 2000
+      Select StringField(Response$, 2, Chr(9))
           
-          While Timeout.q > ElapsedMilliseconds()
-            FlushEvents()
-            If WaitProgram(CompilerProgram, 10)
-              Break
-            EndIf
-            
-            If AvailableProgramOutput(CompilerProgram) > 0
-              ReadProgramString(CompilerProgram) ; we need to read any available input as the compiler will lock else
-            EndIf
-          Wend
+        Case "CREATINGAPP" ; SpiderBasic only
+          Purcents = Val(StringField(Response$, 3, Chr(9)))
           
-          ; Kill it if it is still running (which is probably true, as people will mostly use this if the compiler hangs)
-          If ProgramRunning(CompilerProgram)
-            KillProgram(CompilerProgram)
-          EndIf
-        EndIf
-        CloseProgram(CompilerProgram)
-        
-        CompilerProgram = 0
-        CompilerReady   = 0
-        
-        StartCompiler(*CurrentCompiler)
-        WaitForCompilerReady(NoReadyCall)
-        
-        If CompilerReady ; if 0, restart failed
+          Log$ = Language("App","Creating") + ": "+ Purcents +" %"
           
-          ; do the needed stuff for CompilerReady() as it is not called here
-          DisableMenuItem(#MENU, #MENU_StructureViewer, 0)
-          DisableMenuItem(#MENU, #MENU_CreateExecutable, 0)
-          DisableMenuAndToolbarItem(#MENU_CompileRun, 0)
-          DisableMenuAndToolbarItem(#MENU_SyntaxCheck, 0)
-        Else
-          MessageRequester(#ProductName$, Language("Compiler","RestartError"), #FLAG_Error)
-        EndIf
-        
-        HideCompilerWindow()
-        
-        ; in build mode, the window stays open, so do not do this
-        If UseProjectBuildWindow = 0
-          ActivateMainWindow()
-        EndIf
-        
-        ProcedureReturn #False ; compilation aborted
-      EndIf
-      
-      
-      Response$ = CompilerRead() ; read compiler response
-      
-      If Left(Response$, 9) = "PROGRESS"+Chr(9)  ; progress response
-        
-        Select StringField(Response$, 2, Chr(9))
-            
-          Case "CREATINGAPP" ; SpiderBasic only
-            Purcents = Val(StringField(Response$, 3, Chr(9)))
-            
-            Log$ = Language("App","Creating") + ": "+ Purcents +" %"
-            
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(Log$)
-              EndIf
-            ElseIf UseProjectBuildWindow
-              BuildLogEntry(Log$)
-            Else
-              If Purcents = 20 ; Only add it once
-                AddGadgetItem(#GADGET_Compiler_List, -1, Language("App","Creating") + "...")
-                SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
-              EndIf
-              
-              SetGadgetText(#GADGET_Compiler_Text, Log$)
+          If CommandlineBuild
+            If QuietBuild = 0
+              PrintN(Log$)
             EndIf
-            
-          Case "DOWNLOADINGTEMPLATE" ; SpiderBasic only
-            Log$ = Language("App", "DownloadingTemplate")
-            
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(Log$)
-              EndIf
-            ElseIf UseProjectBuildWindow
-              BuildLogEntry(Log$)
-            Else
-              AddGadgetItem(#GADGET_Compiler_List, -1, Log$)
-              SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
-              
-              SetGadgetText(#GADGET_Compiler_Text, Log$)
-            EndIf
-            
-          Case "DEPLOYINGAPP" ; SpiderBasic only
-            Log$ = Language("App","Deploying")
-            
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(Log$)
-              EndIf
-            ElseIf UseProjectBuildWindow
-              BuildLogEntry(Log$)
-            Else
-              AddGadgetItem(#GADGET_Compiler_List, -1, Log$)
-              SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
-              
-              SetGadgetText(#GADGET_Compiler_Text, Log$)
-            EndIf
-            
-          Case "LINES"
-            Lines = Val(StringField(Response$, 3, Chr(9)))
-            
-            If UseProjectBuildWindow = 0 And CommandlineBuild = 0
-              SetGadgetText(#GADGET_Compiler_Text, Language("Compiler","Compiling") + "  ("+Str(Lines)+" "+Language("Compiler","Lines")+")")
-              
-              ; do not show the progressbar info if we have no old total value
-              If *Target\LastCompiledLines <> 0
-                If Lines < *Target\LastCompiledLines
-                  SetGadgetState(#GADGET_Compiler_Progress, (1000*Lines)/*Target\LastCompiledLines)
-                Else
-                  SetGadgetState(#GADGET_Compiler_Progress, 1000)
-                EndIf
-              EndIf
-            EndIf
-            
-            ; store the last known value (total lines) for the next compilation
-            *Target\LastCompiledLines = Lines
-            
-          Case "INCLUDES"
-            Include$ = StringField(Response$, 3, Chr(9))
-            If *Target\FileName$ <> ""
-              Include$ = CreateRelativePath(GetPathPart(*Target\FileName$), Include$)
-            EndIf
-            
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(Language("Compiler","Including")+": "+Include$)
-              EndIf
-            ElseIf UseProjectBuildWindow
-              BuildLogEntry(Language("Compiler","Including")+": "+Include$)
-            Else
-              AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Including")+": "+Include$)
+          ElseIf UseProjectBuildWindow
+            BuildLogEntry(Log$)
+          Else
+            If Purcents = 20 ; Only add it once
+              AddGadgetItem(#GADGET_Compiler_List, -1, Language("App","Creating") + "...")
               SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
             EndIf
             
-          Case "ASSEMBLING"
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(LanguagePattern("Compiler", "LinesCompiled", "%count%", Str(Lines)))
-                PrintN(Language("Compiler","Finishing"))
-              EndIf
-            ElseIf UseProjectBuildWindow
-              BuildLogEntry(LanguagePattern("Compiler", "LinesCompiled", "%count%", Str(Lines)))
-              BuildLogEntry(Language("Compiler","Finishing"))
-            Else
-              AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Finishing"))
-              SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
-              SetGadgetState(#GADGET_Compiler_Progress, 1000)
-            EndIf
-            
-            ; Case "LINKING" ; ignore that one for now
-        EndSelect
-        
-      ElseIf Left(Response$, 8) = "WARNING"+Chr(9)  ; warning message
-        File$ = *Target\FileName$
-        Line  = Val(StringField(Response$, 2, Chr(9)))
-        Message$ = ""
-        
-        ; Read all warning related information
-        ;
-        Repeat
-          Response$ = CompilerRead()
-          
-          If Left(Response$, 8) = "MESSAGE"+Chr(9)
-            Message$ = Right(Response$, Len(Response$)-8)
-            
-          ElseIf Left(Response$, 12) = "INCLUDEFILE"+Chr(9)
-            File$ = ResolveRelativePath(GetPathPart(*Target\FileName$), StringField(Response$, 2, Chr(9)))
-            Line  = Val(StringField(Response$, 3, Chr(9)))
+            SetGadgetText(#GADGET_Compiler_Text, Log$)
           EndIf
           
-        Until Response$ = "OUTPUT" + Chr(9) + "COMPLETE"
-        
-        If UseProjectBuildWindow Or CommandlineBuild
-          ; add message to warning list for the build window
-          AddElement(BuildInfo())
-          BuildInfo()\IsWarning = #True
-          BuildInfo()\File$     = File$
-          BuildInfo()\Line      = Line
+        Case "DOWNLOADINGTEMPLATE" ; SpiderBasic only
+          Log$ = Language("App", "DownloadingTemplate")
           
-          ; add the log messages (with the warning index attached)
-          If Not IsEqualFile(File$, *Target\FileName$)
-            If CommandlineBuild
-              If QuietBuild = 0
-                PrintN(Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$))
-              EndIf
-            Else
-              BuildLogEntry(Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$), ListIndex(BuildInfo()))
+          If CommandlineBuild
+            If QuietBuild = 0
+              PrintN(Log$)
             EndIf
+          ElseIf UseProjectBuildWindow
+            BuildLogEntry(Log$)
+          Else
+            AddGadgetItem(#GADGET_Compiler_List, -1, Log$)
+            SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
+            
+            SetGadgetText(#GADGET_Compiler_Text, Log$)
+          EndIf
+          
+        Case "DEPLOYINGAPP" ; SpiderBasic only
+          Log$ = Language("App","Deploying")
+          
+          If CommandlineBuild
+            If QuietBuild = 0
+              PrintN(Log$)
+            EndIf
+          ElseIf UseProjectBuildWindow
+            BuildLogEntry(Log$)
+          Else
+            AddGadgetItem(#GADGET_Compiler_List, -1, Log$)
+            SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
+            
+            SetGadgetText(#GADGET_Compiler_Text, Log$)
+          EndIf
+          
+        Case "LINES"
+          Lines = Val(StringField(Response$, 3, Chr(9)))
+          
+          If UseProjectBuildWindow = 0 And CommandlineBuild = 0
+            SetGadgetText(#GADGET_Compiler_Text, Language("Compiler","Compiling") + "  ("+Str(Lines)+" "+Language("Compiler","Lines")+")")
+            
+            ; do not show the progressbar info if we have no old total value
+            If *Target\LastCompiledLines <> 0
+              If Lines < *Target\LastCompiledLines
+                SetGadgetState(#GADGET_Compiler_Progress, (1000*Lines)/*Target\LastCompiledLines)
+              Else
+                SetGadgetState(#GADGET_Compiler_Progress, 1000)
+              EndIf
+            EndIf
+          EndIf
+          
+          ; store the last known value (total lines) for the next compilation
+          *Target\LastCompiledLines = Lines
+          
+        Case "INCLUDES"
+          Include$ = StringField(Response$, 3, Chr(9))
+          If *Target\FileName$ <> ""
+            Include$ = CreateRelativePath(GetPathPart(*Target\FileName$), Include$)
           EndIf
           
           If CommandlineBuild
             If QuietBuild = 0
-              PrintN(Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$)
+              PrintN(Language("Compiler","Including")+": "+Include$)
             EndIf
+          ElseIf UseProjectBuildWindow
+            BuildLogEntry(Language("Compiler","Including")+": "+Include$)
           Else
-            BuildLogEntry(Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$, ListIndex(BuildInfo()))
+            AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Including")+": "+Include$)
+            SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
           EndIf
           
-        Else
-          ; add message to warning list (for warning window)
-          ; (the list is emptied when opening the compiling window)
-          AddElement(Warnings())
-          Warnings()\File$         = File$
-          Warnings()\RelativeFile$ = CreateRelativePath(GetPathPart(*Target\FileName$), File$)
-          Warnings()\Line          = Line
-          Warnings()\Message$      = Message$
-          
-          ; add message to log
-          If Not IsEqualFile(File$, *Target\FileName$)
-            Debugger_AddLog_BySource(*ActiveSource, Language("Compiler","LogCompiler")+" "+Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$), Date())
+        Case "ASSEMBLING"
+          If CommandlineBuild
+            If QuietBuild = 0
+              PrintN(LanguagePattern("Compiler", "LinesCompiled", "%count%", Str(Lines)))
+              PrintN(Language("Compiler","Finishing"))
+            EndIf
+          ElseIf UseProjectBuildWindow
+            BuildLogEntry(LanguagePattern("Compiler", "LinesCompiled", "%count%", Str(Lines)))
+            BuildLogEntry(Language("Compiler","Finishing"))
+          Else
+            AddGadgetItem(#GADGET_Compiler_List, -1, Language("Compiler","Finishing"))
+            SetGadgetState(#GADGET_Compiler_List, CountGadgetItems(#GADGET_Compiler_List)-1)
+            SetGadgetState(#GADGET_Compiler_Progress, 1000)
           EndIf
           
-          Debugger_AddLog_BySource(*ActiveSource, Language("Compiler","LogCompiler")+" "+Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$, Date())
+          ; Case "LINKING" ; ignore that one for now
+      EndSelect
+      
+    ElseIf Left(Response$, 8) = "WARNING"+Chr(9)  ; warning message
+      File$ = *Target\FileName$
+      Line  = Val(StringField(Response$, 2, Chr(9)))
+      Message$ = ""
+      
+      ; Read all warning related information
+      ;
+      Repeat
+        Response$ = CompilerRead()
+        
+        If Left(Response$, 8) = "MESSAGE"+Chr(9)
+          Message$ = Right(Response$, Len(Response$)-8)
           
+        ElseIf Left(Response$, 12) = "INCLUDEFILE"+Chr(9)
+          File$ = ResolveRelativePath(GetPathPart(*Target\FileName$), StringField(Response$, 2, Chr(9)))
+          Line  = Val(StringField(Response$, 3, Chr(9)))
         EndIf
         
-        WarningCount + 1
+      Until Response$ = "OUTPUT" + Chr(9) + "COMPLETE"
+      
+      If UseProjectBuildWindow Or CommandlineBuild
+        ; add message to warning list for the build window
+        AddElement(BuildInfo())
+        BuildInfo()\IsWarning = #True
+        BuildInfo()\File$     = File$
+        BuildInfo()\Line      = Line
         
-      Else ; compilation finished
+        ; add the log messages (with the warning index attached)
+        If Not IsEqualFile(File$, *Target\FileName$)
+          If CommandlineBuild
+            If QuietBuild = 0
+              PrintN(Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$))
+            EndIf
+          Else
+            BuildLogEntry(Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$), ListIndex(BuildInfo()))
+          EndIf
+        EndIf
+        
+        If CommandlineBuild
+          If QuietBuild = 0
+            PrintN(Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$)
+          EndIf
+        Else
+          BuildLogEntry(Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$, ListIndex(BuildInfo()))
+        EndIf
+        
+      Else
+        ; add message to warning list (for warning window)
+        ; (the list is emptied when opening the compiling window)
+        AddElement(Warnings())
+        Warnings()\File$         = File$
+        Warnings()\RelativeFile$ = CreateRelativePath(GetPathPart(*Target\FileName$), File$)
+        Warnings()\Line          = Line
+        Warnings()\Message$      = Message$
+        
+        ; add message to log
+        If Not IsEqualFile(File$, *Target\FileName$)
+          Debugger_AddLog_BySource(*ActiveSource, Language("Compiler","LogCompiler")+" "+Language("Misc","File")+": "+CreateRelativePath(GetPathPart(*Target\FileName$), File$), Date())
+        EndIf
+        
+        Debugger_AddLog_BySource(*ActiveSource, Language("Compiler","LogCompiler")+" "+Language("Compiler","ErrorLine")+" "+Str(Line)+": "+Language("Compiler","Warning")+": "+Message$, Date())
+        
+      EndIf
+      
+      WarningCount + 1
+      
+    Else ; compilation finished
+      Break
+      
+    EndIf
+  ForEver
+  
+  If CommandlineBuild = 0
+    HideCompilerWindow()
+  EndIf
+  
+  If Response$ = "SUCCESS"
+    
+    If WarningCount > 0
+      If CommandlineBuild
+        If QuietBuild = 0
+          PrintN(LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)))
+        EndIf
+      ElseIf UseProjectBuildWindow
+        BuildLogEntry(LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)))
+      Else
+        Debugger_AddLog_BySource(*ActiveSource, LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)), Date())
+        
+        ; display the warning window now
+        DisplayCompilerWarnings()
+      EndIf
+    EndIf
+    
+    ; compilation succeeded
+    ProcedureReturn #True
+    
+  ElseIf Left(Response$, 13) = "ERROR"+Chr(9)+"SYNTAX"+Chr(9) ; syntax error
+    ErrorLine    = Val(StringField(Response$, 3, Chr(9)))
+    IncludeLine  = -1
+    
+    ; Read all the information from the compiler
+    ;
+    Repeat
+      Response$ = CompilerRead()
+      
+      If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
         Break
+        
+      ElseIf Left(Response$, 8) = "MESSAGE"+Chr(9)
+        Message$ = Right(Response$, Len(Response$)-8)
+        
+      ElseIf Left(Response$, 12) = "INCLUDEFILE"+Chr(9)
+        IncludeName$ = StringField(Response$, 2, Chr(9))
+        IncludeLine  = Val(StringField(Response$, 3, Chr(9)))
+        
+        
+      ElseIf Left(Response$, 6) = "MACRO"+Chr(9)
+        MacroLine  = Val(StringField(Response$, 2, Chr(9)))
+        LinesCount = Val(StringField(Response$, 3, Chr(9)))
+        IsMacroError = 1
+        
+        ; get the while macro
+        Repeat
+          Response$ = CompilerRead()
+          
+          If Response$ = "OUTPUT"+Chr(9)+"COMPLETE" ; should not happen here actually
+            Break 2
+            
+          ElseIf Response$ = "MACRO"+Chr(9)+"COMPLETE" And ListSize(MacroLines()) = LinesCount; macro finished
+            Break
+            
+          Else
+            AddElement(MacroLines())
+            MacroLines() = Response$
+          EndIf
+        ForEver
         
       EndIf
     ForEver
     
-    If CommandlineBuild = 0
-      HideCompilerWindow()
-    EndIf
-    
-    If Response$ = "SUCCESS"
-      
-      If WarningCount > 0
-        If CommandlineBuild
-          If QuietBuild = 0
-            PrintN(LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)))
-          EndIf
-        ElseIf UseProjectBuildWindow
-          BuildLogEntry(LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)))
-        Else
-          Debugger_AddLog_BySource(*ActiveSource, LanguagePattern("Compiler","WarningTotals", "%warnings%", Str(WarningCount)), Date())
-          
-          ; display the warning window now
-          DisplayCompilerWarnings()
-        EndIf
+    ; Process the information
+    ;
+    If IncludeName$ = "" ; main file
+      If ErrorLine = -1
+        Line$ = Message$
+      Else
+        Line$ = Language("Compiler","ErrorLine")+" "+Str(ErrorLine)+": "+Message$
       EndIf
       
-      ; compilation succeeded
-      ProcedureReturn #True
+      If *Target\UseMainFile = 0  ; it is this source, so no problem
+        ErrorFile$ = *Target\FileName$
+        
+      Else    ; it is the main file, so switch to it
+        ErrorFile$ = ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\MainFile$)
+        Line$ = Language("Compiler","ErrorMainFile")+" '"+*Target\MainFile$ +"'"+ #NewLine + Line$
+        
+      EndIf
       
-    ElseIf Left(Response$, 13) = "ERROR"+Chr(9)+"SYNTAX"+Chr(9) ; syntax error
-      ErrorLine    = Val(StringField(Response$, 3, Chr(9)))
-      IncludeLine  = -1
+    Else ; includefile
+      If IncludeLine = -1
+        Line$ = Message$
+      Else
+        Line$ = Language("Compiler","ErrorLine")+" "+Str(IncludeLine)+": "+Message$
+      EndIf
       
-      ; Read all the information from the compiler
-      ;
+      ; switch to the included file
+      If *Target\UseMainFile = 0
+        ErrorFile$ = ResolveRelativePath(GetPathPart(*Target\FileName$), IncludeName$)
+      Else
+        ErrorFile$ = ResolveRelativePath(GetPathPart(ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\MainFile$)), IncludeName$)
+      EndIf
+      ErrorLine = IncludeLine
+      
+    EndIf
+    
+    ; Display info to the user
+    ;
+    If CommandlineBuild
+      
+      ; errors are displayed also in quiet mode
+      ; Macro errors are not displayed in this mode
+      PrintN(Language("Misc", "Error") + ": " + ErrorFile$)
+      PrintN(Line$)
+      
+    ElseIf UseProjectBuildWindow
+      ; Project build mode
+      ; Add an entry to the info list so the log entries are clickable
+      If ErrorFile$ <> "" And ErrorLine <> -1
+        AddElement(BuildInfo())
+        BuildInfo()\IsWarning = #False
+        BuildInfo()\File$     = ErrorFile$
+        BuildInfo()\Line      = ErrorLine
+        InfoIndex = ListIndex(BuildInfo())
+      Else
+        InfoIndex = -1
+      EndIf
+      
+      LogLine$ = Line$
+      While FindString(LogLine$, #NewLine, 1) <> 0
+        pos = FindString(LogLine$, #NewLine, 1)
+        Part$ = Left(LogLine$, pos-1)
+        LogLine$ = Right(LogLine$, Len(LogLine$)-pos-(Len(#NewLine)-1))
+        
+        BuildLogEntry(Part$, InfoIndex)
+      Wend
+      BuildLogEntry(LogLine$, InfoIndex)
+      
+      ; Macro errors are not displayed in this mode
+      
+    Else
+      ; Normal compile mode
+      
+      If ErrorFile$
+        LoadSourceFile(ErrorFile$) ; will simply switch, if the file is open
+      EndIf
+      
+      If ErrorLine <> -1  ; highlight the error line
+        ChangeActiveLine(ErrorLine, -5)
+        SetSelection(ErrorLine, 1, ErrorLine, -1)
+      EndIf
+      
+      ; add the error to the log:
+      LogLine$ = Line$
+      While FindString(LogLine$, #NewLine, 1) <> 0
+        pos = FindString(LogLine$, #NewLine, 1)
+        Part$ = Left(LogLine$, pos-1)
+        LogLine$ = Right(LogLine$, Len(LogLine$)-pos-(Len(#NewLine)-1))
+        
+        Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+Part$, Date())
+      Wend
+      Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+LogLine$, Date())
+      
+      ; display the macro window
+      If IsMacroError
+        DisplayMacroError(MacroLine, MacroLines())
+      EndIf
+      
+      ; now the message
+      If DisplayErrorWindow
+        MessageRequester(#ProductName$, Line$, #FLAG_Error)
+      EndIf
+      
+      If IsWindow(#WINDOW_MacroError)
+        SetActiveWindow(#WINDOW_MacroError)
+        SetActiveGadget(#GADGET_MacroError_Close)
+      Else
+        ActivateMainWindow() ; to show selection
+      EndIf
+    EndIf
+    
+  ElseIf Left(Response$, 6) = "ERROR"+Chr(9) ; assembler, linker or resource error
+    Select StringField(Response$, 2, Chr(9))
+      Case "ASSEMBLER": Type$ = "Assembler error"
+      Case "LINKER"   : Type$ = "Linker error"
+      Case "RESOURCE" : Type$ = "Resource error"
+    EndSelect
+    
+    
+    If CommandlineBuild
+      PrintN(Type$)
       Repeat
         Response$ = CompilerRead()
         
         If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
           Break
-          
-        ElseIf Left(Response$, 8) = "MESSAGE"+Chr(9)
-          Message$ = Right(Response$, Len(Response$)-8)
-          
-        ElseIf Left(Response$, 12) = "INCLUDEFILE"+Chr(9)
-          IncludeName$ = StringField(Response$, 2, Chr(9))
-          IncludeLine  = Val(StringField(Response$, 3, Chr(9)))
-          
-          
-        ElseIf Left(Response$, 6) = "MACRO"+Chr(9)
-          MacroLine  = Val(StringField(Response$, 2, Chr(9)))
-          LinesCount = Val(StringField(Response$, 3, Chr(9)))
-          IsMacroError = 1
-          
-          ; get the while macro
-          Repeat
-            Response$ = CompilerRead()
-            
-            If Response$ = "OUTPUT"+Chr(9)+"COMPLETE" ; should not happen here actually
-              Break 2
-              
-            ElseIf Response$ = "MACRO"+Chr(9)+"COMPLETE" And ListSize(MacroLines()) = LinesCount; macro finished
-              Break
-              
-            Else
-              AddElement(MacroLines())
-              MacroLines() = Response$
-            EndIf
-          ForEver
-          
+        Else
+          PrintN(Response$)
         EndIf
       ForEver
       
-      ; Process the information
-      ;
-      If IncludeName$ = "" ; main file
-        If ErrorLine = -1
-          Line$ = Message$
-        Else
-          Line$ = Language("Compiler","ErrorLine")+" "+Str(ErrorLine)+": "+Message$
-        EndIf
-        
-        If *Target\UseMainFile = 0  ; it is this source, so no problem
-          ErrorFile$ = *Target\FileName$
-          
-        Else    ; it is the main file, so switch to it
-          ErrorFile$ = ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\MainFile$)
-          Line$ = Language("Compiler","ErrorMainFile")+" '"+*Target\MainFile$ +"'"+ #NewLine + Line$
-          
-        EndIf
-        
-      Else ; includefile
-        If IncludeLine = -1
-          Line$ = Message$
-        Else
-          Line$ = Language("Compiler","ErrorLine")+" "+Str(IncludeLine)+": "+Message$
-        EndIf
-        
-        ; switch to the included file
-        If *Target\UseMainFile = 0
-          ErrorFile$ = ResolveRelativePath(GetPathPart(*Target\FileName$), IncludeName$)
-        Else
-          ErrorFile$ = ResolveRelativePath(GetPathPart(ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\MainFile$)), IncludeName$)
-        EndIf
-        ErrorLine = IncludeLine
-        
-      EndIf
+    ElseIf UseProjectBuildWindow
+      BuildLogEntry(Type$)
       
-      ; Display info to the user
-      ;
-      If CommandlineBuild
+      Repeat
+        Response$ = CompilerRead()
         
-        ; errors are displayed also in quiet mode
-        ; Macro errors are not displayed in this mode
-        PrintN(Language("Misc", "Error") + ": " + ErrorFile$)
-        PrintN(Line$)
-        
-      ElseIf UseProjectBuildWindow
-        ; Project build mode
-        ; Add an entry to the info list so the log entries are clickable
-        If ErrorFile$ <> "" And ErrorLine <> -1
-          AddElement(BuildInfo())
-          BuildInfo()\IsWarning = #False
-          BuildInfo()\File$     = ErrorFile$
-          BuildInfo()\Line      = ErrorLine
-          InfoIndex = ListIndex(BuildInfo())
+        If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
+          Break
         Else
-          InfoIndex = -1
+          BuildLogEntry(Response$)
         EndIf
-        
-        LogLine$ = Line$
-        While FindString(LogLine$, #NewLine, 1) <> 0
-          pos = FindString(LogLine$, #NewLine, 1)
-          Part$ = Left(LogLine$, pos-1)
-          LogLine$ = Right(LogLine$, Len(LogLine$)-pos-(Len(#NewLine)-1))
-          
-          BuildLogEntry(Part$, InfoIndex)
-        Wend
-        BuildLogEntry(LogLine$, InfoIndex)
-        
-        ; Macro errors are not displayed in this mode
-        
-      Else
-        ; Normal compile mode
-        
-        If ErrorFile$
-          LoadSourceFile(ErrorFile$) ; will simply switch, if the file is open
-        EndIf
-        
-        If ErrorLine <> -1  ; highlight the error line
-          ChangeActiveLine(ErrorLine, -5)
-          SetSelection(ErrorLine, 1, ErrorLine, -1)
-        EndIf
-        
-        ; add the error to the log:
-        LogLine$ = Line$
-        While FindString(LogLine$, #NewLine, 1) <> 0
-          pos = FindString(LogLine$, #NewLine, 1)
-          Part$ = Left(LogLine$, pos-1)
-          LogLine$ = Right(LogLine$, Len(LogLine$)-pos-(Len(#NewLine)-1))
-          
-          Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+Part$, Date())
-        Wend
-        Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+LogLine$, Date())
-        
-        ; display the macro window
-        If IsMacroError
-          DisplayMacroError(MacroLine, MacroLines())
-        EndIf
-        
-        ; now the message
-        If DisplayErrorWindow
-          MessageRequester(#ProductName$, Line$, #FLAG_Error)
-        EndIf
-        
-        If IsWindow(#WINDOW_MacroError)
-          SetActiveWindow(#WINDOW_MacroError)
-          SetActiveGadget(#GADGET_MacroError_Close)
-        Else
-          ActivateMainWindow() ; to show selection
-        EndIf
-      EndIf
+      ForEver
       
-    ElseIf Left(Response$, 6) = "ERROR"+Chr(9) ; assembler, linker or resource error
-      Select StringField(Response$, 2, Chr(9))
-        Case "ASSEMBLER": Type$ = "Assembler error"
-        Case "LINKER"   : Type$ = "Linker error"
-        Case "RESOURCE" : Type$ = "Resource error"
-      EndSelect
-      
-      
-      If CommandlineBuild
-        PrintN(Type$)
-        Repeat
-          Response$ = CompilerRead()
-          
-          If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
-            Break
-          Else
-            PrintN(Response$)
-          EndIf
-        ForEver
-        
-      ElseIf UseProjectBuildWindow
-        BuildLogEntry(Type$)
-        
-        Repeat
-          Response$ = CompilerRead()
-          
-          If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
-            Break
-          Else
-            BuildLogEntry(Response$)
-          EndIf
-        ForEver
-        
-      Else
-        Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+Type$+"!", Date())
-        
-        NbLines = 0
-        Message$ = ""
-        Repeat
-          Response$ = CompilerRead()
-          
-          If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
-            Break
-          Else
-            NbLines + 1
-            If NbLines < 8 ; Max 8 lines or it can be too big to display for the MessageRequester()
-              Message$ + Response$ + #NewLine
-            EndIf
-            
-            LastLine$ = Response$
-          EndIf
-        ForEver
-        
-        If NbLines > 8
-          Message$ + "..." + #NewLine + LastLine$ ; Add the last line if it has been truncated, as it can be useful
-        EndIf
-        
-        MessageRequester(#ProductName$ + " - "+Type$, Message$, #FLAG_ERROR)
-        ActivateMainWindow()
-      EndIf
-      
-    EndIf
-    
-    ProcedureReturn #False
-  EndProcedure
-  
-  Procedure.s Compiler_BuildCommandFlags(*Target.CompileTarget, CheckSyntax, CreateExe)
-    If *CurrentCompiler\VersionNumber >= 430 Or #SpiderBasic
-      Command$ = "COMPILE"+Chr(9)+"PROGRESS"+Chr(9)+"WARNINGS" ; use the progress and warnings flag always
     Else
-      Command$ = "COMPILE"+Chr(9)+"PROGRESS"  ; no warning support on older compilers
-    EndIf
-    
-    If *Target\EnableThread  : Command$ + Chr(9) + "THREAD"    : EndIf
-    
-    CompilerIf #SpiderBasic
-      If *Target\OptimizeJS  : Command$ + Chr(9) + "OPTIMIZEJS" : EndIf
+      Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] "+Type$+"!", Date())
       
-      Select *Target\AppFormat
-        Case #AppFormatWeb ; Can be also when using Compile/Run
-          If CreateExe
-            If *Target\WebAppEnableDebugger
-              Command$ + Chr(9) + "DEBUGGER"
-            EndIf
-          Else
-            If (*Target\Debugger | ForceDebugger) & ~ForceNoDebugger ; Handle the special 'Compile with Debugger' and 'Compile without debugger' menus
-              Command$ + Chr(9) + "DEBUGGER"
-            EndIf
+      NbLines = 0
+      Message$ = ""
+      Repeat
+        Response$ = CompilerRead()
+        
+        If Response$ = "OUTPUT"+Chr(9)+"COMPLETE"
+          Break
+        Else
+          NbLines + 1
+          If NbLines < 8 ; Max 8 lines or it can be too big to display for the MessageRequester()
+            Message$ + Response$ + #NewLine
           EndIf
           
-          
-        Case #AppFormatiOS
-          Command$ + Chr(9) + "IOS" ; Tell the compiler we are compiler and android package
-          
-          If *Target\iOSAppFullScreen : Command$ + Chr(9) + "FULLSCREEN" : EndIf
-          If *Target\iOSAppAutoUpload : Command$ + Chr(9) + "DEPLOY" : EndIf
-          If *Target\iOSAppGeolocation : Command$ + Chr(9) + "GEOLOCATION" : EndIf
-          If *Target\iOSAppEnableDebugger : Command$ + Chr(9) + "DEBUGGER" : EndIf
-          
-        Case #AppFormatAndroid
-          Command$ + Chr(9) + "ANDROID" ; Tell the compiler we are compiler and android package
-          
-          If *Target\AndroidAppFullScreen : Command$ + Chr(9) + "FULLSCREEN" : EndIf
-          If *Target\AndroidAppAutoUpload : Command$ + Chr(9) + "DEPLOY" : EndIf
-          If *Target\AndroidAppGeolocation : Command$ + Chr(9) + "GEOLOCATION" : EndIf
-          If *Target\AndroidAppEnableDebugger : Command$ + Chr(9) + "DEBUGGER" : EndIf
-          
-      EndSelect
+          LastLine$ = Response$
+        EndIf
+      ForEver
       
-    CompilerEndIf
-    
-    If *Target\EnableOnError
-      If #CompileWindows Or *CurrentCompiler\VersionNumber >= 430
-        ; Windows only before 4.30
-        Command$ + Chr(9) + "ONERROR"
+      If NbLines > 8
+        Message$ + "..." + #NewLine + LastLine$ ; Add the last line if it has been truncated, as it can be useful
       EndIf
+      
+      MessageRequester(#ProductName$ + " - "+Type$, Message$, #FLAG_ERROR)
+      ActivateMainWindow()
     EndIf
     
-    CompilerIf #CompileWindows
-      If *Target\EnableXP           : Command$ + Chr(9) + "XPSKIN"  : EndIf
-      If *Target\ExecutableFormat=1 : Command$ + Chr(9) + "CONSOLE" : EndIf
-      If *Target\DPIAware           : Command$ + Chr(9) + "DPIAWARE" : EndIf
-      
-      If *Target\EnableAdmin
-        Command$ + Chr(9) + "ADMINISTRATOR"
-      ElseIf *Target\EnableUser ; both at once is impossible
-        Command$ + Chr(9) + "USER"
-      EndIf
-    CompilerEndIf
+  EndIf
+  
+  ProcedureReturn #False
+EndProcedure
+
+Procedure.s Compiler_BuildCommandFlags(*Target.CompileTarget, CheckSyntax, CreateExe)
+  If *CurrentCompiler\VersionNumber >= 430 Or #SpiderBasic
+    Command$ = "COMPILE"+Chr(9)+"PROGRESS"+Chr(9)+"WARNINGS" ; use the progress and warnings flag always
+  Else
+    Command$ = "COMPILE"+Chr(9)+"PROGRESS"  ; no warning support on older compilers
+  EndIf
+  
+  If *Target\EnableThread  : Command$ + Chr(9) + "THREAD"    : EndIf
+  
+  CompilerIf #SpiderBasic
+    If *Target\OptimizeJS  : Command$ + Chr(9) + "OPTIMIZEJS" : EndIf
     
-    CompilerIf Not #SpiderBasic
-      If (*Target\Debugger|ForceDebugger)&~ForceNoDebugger
-        Command$ + Chr(9) + "DEBUGGER"
-        IsDebuggerUsed = 1
-        
-        If *Target\EnablePurifier
-          Command$ + Chr(9) + "PURIFIER"
+    Select *Target\AppFormat
+      Case #AppFormatWeb ; Can be also when using Compile/Run
+        If CreateExe
+          If *Target\WebAppEnableDebugger
+            Command$ + Chr(9) + "DEBUGGER"
+          EndIf
+        Else
+          If (*Target\Debugger | ForceDebugger) & ~ForceNoDebugger ; Handle the special 'Compile with Debugger' and 'Compile without debugger' menus
+            Command$ + Chr(9) + "DEBUGGER"
+          EndIf
         EndIf
-      Else
-        IsDebuggerUsed = 0
-      EndIf
-    CompilerEndIf
-    
-    Select *Target\CPU
-      Case 1
-        Command$ + Chr(9) + "DYNAMICCPU"
-      Case 2
-        Command$ + Chr(9) + "MMX"
-      Case 3
-        Command$ + Chr(9) + "3DNOW"
-      Case 4
-        Command$ + Chr(9) + "SSE"
-      Case 5
-        Command$ + Chr(9) + "SSE2"
+        
+        
+      Case #AppFormatiOS
+        Command$ + Chr(9) + "IOS" ; Tell the compiler we are compiler and android package
+        
+        If *Target\iOSAppFullScreen : Command$ + Chr(9) + "FULLSCREEN" : EndIf
+        If *Target\iOSAppAutoUpload : Command$ + Chr(9) + "DEPLOY" : EndIf
+        If *Target\iOSAppGeolocation : Command$ + Chr(9) + "GEOLOCATION" : EndIf
+        If *Target\iOSAppEnableDebugger : Command$ + Chr(9) + "DEBUGGER" : EndIf
+        
+      Case #AppFormatAndroid
+        Command$ + Chr(9) + "ANDROID" ; Tell the compiler we are compiler and android package
+        
+        If *Target\AndroidAppFullScreen : Command$ + Chr(9) + "FULLSCREEN" : EndIf
+        If *Target\AndroidAppAutoUpload : Command$ + Chr(9) + "DEPLOY" : EndIf
+        If *Target\AndroidAppGeolocation : Command$ + Chr(9) + "GEOLOCATION" : EndIf
+        If *Target\AndroidAppEnableDebugger : Command$ + Chr(9) + "DEBUGGER" : EndIf
+        
     EndSelect
     
-    If CheckSyntax
-      Command$ + Chr(9) + "CHECKSYNTAX"
-    EndIf
-    
-    ProcedureReturn Command$
-  EndProcedure
+  CompilerEndIf
   
+  If *Target\EnableOnError
+    If #CompileWindows Or *CurrentCompiler\VersionNumber >= 430
+      ; Windows only before 4.30
+      Command$ + Chr(9) + "ONERROR"
+    EndIf
+  EndIf
   
-  Procedure Compiler_SetConstants(*Target.CompileTarget, CreateExe)
+  CompilerIf #CompileWindows
+    If *Target\EnableXP           : Command$ + Chr(9) + "XPSKIN"  : EndIf
+    If *Target\ExecutableFormat=1 : Command$ + Chr(9) + "CONSOLE" : EndIf
+    If *Target\DPIAware           : Command$ + Chr(9) + "DPIAWARE" : EndIf
     
-    ; Do the IDE build constants
-    ;
-    If *Target\UseCreateExe
-      If CreateExe
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CreateExecutable=1")
-      Else
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CreateExecutable=0")
+    If *Target\EnableAdmin
+      Command$ + Chr(9) + "ADMINISTRATOR"
+    ElseIf *Target\EnableUser ; both at once is impossible
+      Command$ + Chr(9) + "USER"
+    EndIf
+  CompilerEndIf
+  
+  CompilerIf Not #SpiderBasic
+    If (*Target\Debugger|ForceDebugger)&~ForceNoDebugger
+      Command$ + Chr(9) + "DEBUGGER"
+      IsDebuggerUsed = 1
+      
+      If *Target\EnablePurifier
+        Command$ + Chr(9) + "PURIFIER"
       EndIf
+    Else
+      IsDebuggerUsed = 0
     EndIf
-    
-    ; Note: the increment for these counts is done after successful compilation only
-    ;       (in CompilerWindow.pb, where MainFile etc are handled)
-    If *Target\UseCompileCount
-      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CompileCount=" + Str(*Target\CompileCount))
+  CompilerEndIf
+  
+  Select *Target\CPU
+    Case 1
+      Command$ + Chr(9) + "DYNAMICCPU"
+    Case 2
+      Command$ + Chr(9) + "MMX"
+    Case 3
+      Command$ + Chr(9) + "3DNOW"
+    Case 4
+      Command$ + Chr(9) + "SSE"
+    Case 5
+      Command$ + Chr(9) + "SSE2"
+  EndSelect
+  
+  If CheckSyntax
+    Command$ + Chr(9) + "CHECKSYNTAX"
+  EndIf
+  
+  ProcedureReturn Command$
+EndProcedure
+
+
+Procedure Compiler_SetConstants(*Target.CompileTarget, CreateExe)
+  
+  ; Do the IDE build constants
+  ;
+  If *Target\UseCreateExe
+    If CreateExe
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CreateExecutable=1")
+    Else
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CreateExecutable=0")
     EndIf
-    
-    If *Target\UseBuildCount
-      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_BuildCount=" + Str(*Target\BuildCount))
+  EndIf
+  
+  ; Note: the increment for these counts is done after successful compilation only
+  ;       (in CompilerWindow.pb, where MainFile etc are handled)
+  If *Target\UseCompileCount
+    CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CompileCount=" + Str(*Target\CompileCount))
+  EndIf
+  
+  If *Target\UseBuildCount
+    CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_BuildCount=" + Str(*Target\BuildCount))
+  EndIf
+  
+  CompilerIf #CompileWindows
+    If *Target\VersionInfo
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileVersionNumeric="     + ReplaceVersionInfo(*Target\VersionField$[0], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductVersionNumeric="  + ReplaceVersionInfo(*Target\VersionField$[1], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CompanyName="            + ReplaceVersionInfo(*Target\VersionField$[2], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductName="            + ReplaceVersionInfo(*Target\VersionField$[3], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductVersion="         + ReplaceVersionInfo(*Target\VersionField$[4], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileVersion="            + ReplaceVersionInfo(*Target\VersionField$[5], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileDescription="        + ReplaceVersionInfo(*Target\VersionField$[6], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_InternalName="           + ReplaceVersionInfo(*Target\VersionField$[7], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_OriginalFilename="       + ReplaceVersionInfo(*Target\VersionField$[8], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_LegalCopyright="         + ReplaceVersionInfo(*Target\VersionField$[9], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_LegalTrademarks="        + ReplaceVersionInfo(*Target\VersionField$[10], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_PrivateBuild="           + ReplaceVersionInfo(*Target\VersionField$[11], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_SpecialBuild="           + ReplaceVersionInfo(*Target\VersionField$[12], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_Email="                  + ReplaceVersionInfo(*Target\VersionField$[13], *Target), #PB_UTF8)
+      CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_Website="                + ReplaceVersionInfo(*Target\VersionField$[14], *Target), #PB_UTF8)
     EndIf
-    
-    CompilerIf #CompileWindows
-      If *Target\VersionInfo
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileVersionNumeric="     + ReplaceVersionInfo(*Target\VersionField$[0], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductVersionNumeric="  + ReplaceVersionInfo(*Target\VersionField$[1], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_CompanyName="            + ReplaceVersionInfo(*Target\VersionField$[2], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductName="            + ReplaceVersionInfo(*Target\VersionField$[3], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_ProductVersion="         + ReplaceVersionInfo(*Target\VersionField$[4], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileVersion="            + ReplaceVersionInfo(*Target\VersionField$[5], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_FileDescription="        + ReplaceVersionInfo(*Target\VersionField$[6], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_InternalName="           + ReplaceVersionInfo(*Target\VersionField$[7], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_OriginalFilename="       + ReplaceVersionInfo(*Target\VersionField$[8], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_LegalCopyright="         + ReplaceVersionInfo(*Target\VersionField$[9], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_LegalTrademarks="        + ReplaceVersionInfo(*Target\VersionField$[10], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_PrivateBuild="           + ReplaceVersionInfo(*Target\VersionField$[11], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_SpecialBuild="           + ReplaceVersionInfo(*Target\VersionField$[12], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_Email="                  + ReplaceVersionInfo(*Target\VersionField$[13], *Target), #PB_UTF8)
-        CompilerWrite("CONSTANT"+Chr(9)+"PB_Editor_Website="                + ReplaceVersionInfo(*Target\VersionField$[14], *Target), #PB_UTF8)
-      EndIf
-    CompilerEndIf
-    
-    ; Do custom constants. All constants are written in UTF-8 format to preserve complex string value (https://www.purebasic.fr/english/viewtopic.php?f=4&t=63159&sid=0f541e4670f96083c28f005df6f8d2b7)
-    ;
-    For i = 0 To *Target\NbConstants-1
-      If *Target\ConstantEnabled[i]
-        Original$ = *Target\Constant$[i]
-        Constant$ = ""
-        
-        ; Replace all $XXX with environment variables
-        ;
-        *Pointer.Character = @Original$
-        While *Pointer\c
-          If *Pointer\c = '$'
+  CompilerEndIf
+  
+  ; Do custom constants. All constants are written in UTF-8 format to preserve complex string value (https://www.purebasic.fr/english/viewtopic.php?f=4&t=63159&sid=0f541e4670f96083c28f005df6f8d2b7)
+  ;
+  For i = 0 To *Target\NbConstants-1
+    If *Target\ConstantEnabled[i]
+      Original$ = *Target\Constant$[i]
+      Constant$ = ""
+      
+      ; Replace all $XXX with environment variables
+      ;
+      *Pointer.Character = @Original$
+      While *Pointer\c
+        If *Pointer\c = '$'
+          *Pointer + SizeOf(Character)
+          Name$ = ""
+          While *Pointer\c < $FF And ValidCharacters(*Pointer\c)
+            Name$ + Chr(*Pointer\c)
             *Pointer + SizeOf(Character)
-            Name$ = ""
-            While *Pointer\c < $FF And ValidCharacters(*Pointer\c)
-              Name$ + Chr(*Pointer\c)
-              *Pointer + SizeOf(Character)
-            Wend
-            
-            Constant$ + GetEnvironmentVariable(Name$)
-          Else
-            Constant$ + Chr(*Pointer\c)
-            *Pointer  + SizeOf(Character)
-          EndIf
-        Wend
-        
-        ; Now cut the # at the start (not expected by the compiler) and any
-        ; space before the name or =
-        ;
-        equal = FindString(Constant$, "=", 1)
-        If equal > 0
-          Constant$ = Trim(RemoveString(Left(Constant$, equal-1), "#")) + "=" + Trim(LTrim(Right(Constant$, Len(Constant$)-equal)), #DQUOTE$) ; Also remove the "" around, as expected by the compiler (https://www.purebasic.fr/english/viewtopic.php?f=4&t=59430)
+          Wend
           
-          CompilerWrite("CONSTANT"+Chr(9)+Constant$, #PB_UTF8)
+          Constant$ + GetEnvironmentVariable(Name$)
+        Else
+          Constant$ + Chr(*Pointer\c)
+          *Pointer  + SizeOf(Character)
         EndIf
+      Wend
+      
+      ; Now cut the # at the start (not expected by the compiler) and any
+      ; space before the name or =
+      ;
+      equal = FindString(Constant$, "=", 1)
+      If equal > 0
+        Constant$ = Trim(RemoveString(Left(Constant$, equal-1), "#")) + "=" + Trim(LTrim(Right(Constant$, Len(Constant$)-equal)), #DQUOTE$) ; Also remove the "" around, as expected by the compiler (https://www.purebasic.fr/english/viewtopic.php?f=4&t=59430)
+        
+        CompilerWrite("CONSTANT"+Chr(9)+Constant$, #PB_UTF8)
+      EndIf
+    EndIf
+  Next i
+  
+EndProcedure
+
+; ---------------------------------------------------------------------
+
+CompilerIf #SpiderBasic
+  Procedure.l GetIPByHost(Host$="")
+    Result.l=0
+    
+    If Host$=""
+      Host$=Hostname()
+    EndIf
+    
+    SelfLoop=OpenNetworkConnection(Host$,0,#PB_Network_UDP)
+    If SelfLoop
+      Result=GetClientIP(SelfLoop)
+      CloseNetworkConnection(SelfLoop)
+    EndIf
+    
+    ProcedureReturn Result
+  EndProcedure
+CompilerEndIf
+
+; ---------------------------------------------------------------------
+
+Procedure Compiler_Run(*Target.CompileTarget, IsFirstRun)
+  CompilerIf #CompileLinux
+    Shared DetectedGUITerminal$, GUITerminalParameters$ ; for the debugger (shared from LinuxMisc.pb)
+  CompilerEndIf
+  
+  CompilerIf #CompileMac And Not #SpiderBasic
+    If *Target\ExecutableFormat = 1 ; Console
+      Executable$ = *Target\RunExecutable$
+    Else
+      Executable$ = *Target\RunExecutable$ + "/Contents/MacOS/" + Left(GetFilePart(*Target\RunExecutable$), Len(GetFilePart(*Target\RunExecutable$))-4)
+    EndIf
+  CompilerElse
+    Executable$ = *Target\RunExecutable$
+  CompilerEndIf
+  
+  ; Check if the executable is still present
+  ;
+  If FileSize(Executable$) <= 0
+    Debug "NOT FOUND "+FileSize(Executable$)
+    ; recompile the whole thing, but only if we did not just do so to
+    ; avoid a possible endless compilation loop (unlikely)
+    If IsFirstRun = #False
+      If *Target\IsProject
+        CompileRunProject(#False) ; call the CompilerWindow.pb one which does all handling correctly (also the compilecount)
+      Else
+        CompileRun(#False)
+      EndIf
+    EndIf
+    ProcedureReturn
+  EndIf
+  
+  ; get the current directory for the exe
+  ;
+  If *Target\CurrentDirectory$ <> "" ; a special one has been selected
+    If *Target\IsProject
+      Directory$ = ResolveRelativePath(GetPathPart(ProjectFile$), *Target\CurrentDirectory$)
+    ElseIf *Target\FileName$ = ""
+      Directory$ = ResolveRelativePath(CurrentDirectory$, *Target\CurrentDirectory$)
+    Else
+      Directory$ = ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\CurrentDirectory$)
+    EndIf
+  Else
+    If *Target\FileName$ = ""
+      Directory$ = CurrentDirectory$
+    Else
+      Directory$ = GetPathPart(*Target\FileName$)
+    EndIf
+  EndIf
+  
+  ; Add the Compiler directory to the (library-)path, so the 3D engine and other
+  ; libraries can be loaded by the exe
+  ;
+  CompilerIf #CompileWindows
+    PreviousPath$ = GetEnvironmentVariable("PATH")
+    SetEnvironmentVariable("PATH", *Target\RunCompilerPath$+";"+PreviousPath$)
+  CompilerEndIf
+  
+  CompilerIf #CompileLinux
+    PreviousPath$ = GetEnvironmentVariable("LD_LIBRARY_PATH")
+    SetEnvironmentVariable("LD_LIBRARY_PATH", *Target\RunCompilerPath$+":"+PreviousPath$)
+  CompilerEndIf
+  
+  CompilerIf #CompileMac
+    PreviousPath$ = GetEnvironmentVariable("DYLD_LIBRARY_PATH")
+    SetEnvironmentVariable("DYLD_LIBRARY_PATH", *Target\RunCompilerPath$+":"+PreviousPath$)
+  CompilerEndIf
+  
+  Debug "----"
+  Debug "Filename   = " + *ActiveSource\Filename$
+  Debug "CurrentDir = " + *ActiveSource\CurrentDirectory$
+  Debug "Directory  = " + Directory$
+  Debug "----"
+  
+  CompilerIf #SpiderBasic
+    Static NewMap WebLaunchedServers.s()
+    Static WebServerPortIndex = 0
+    
+    RootPath$ = GetPathPart(Executable$)
+    If Right(RootPath$, 1) = "\" ; mongoose doesn't like path terminated with "\"
+      RootPath$ = Left(RootPath$, Len(RootPath$)-1)
+    EndIf
+    
+    If WebLaunchedServers(RootPath$) = "" Or (*Target\WebServerAddress$ And WebLaunchedServers(RootPath$) <> *Target\WebServerAddress$) ; Not yet launched or the server port has been changed in the target
+      
+      If *Target\WebServerAddress$
+        WebServerAddress$ = *Target\WebServerAddress$
+        MongooseAddress$ = WebServerAddress$
+        
+        ; We need to resolve the hostname, as sbmongoose only access real IP address, not hostname
+        ;
+        If FindString(WebServerAddress$, ":")
+          ServerName$ = StringField(WebServerAddress$, 1, ":")
+          IP = GetIPByHost(ServerName$) ; works with IP as well
+          If IP
+            MongooseAddress$ = IPString(IP)
+            Port$ = StringField(WebServerAddress$, 2, ":")
+            If Port$
+              MongooseAddress$ + ":" + Port$
+            EndIf
+          EndIf
+        Else
+          MessageRequester("Error", "Invalid server address ("+ WebServerAddress$ + "). It should be specified as 'address:port'", #FLAG_Error)
+          Error = #True
+        EndIf
+        
+      Else
+        WebServerAddress$ = "127.0.0.1:" + Str(OptionWebServerPort + WebServerPortIndex)
+        MongooseAddress$ = WebServerAddress$
+        WebServerPortIndex+1
+      EndIf
+      
+      If Error = #False
+        AddElement(OpenedWebServers())
+        
+        Debug MongooseAddress$
+        
+        OpenedWebServers() = RunProgram(PureBasicPath$ + "compilers/sbmongoose", " -listening_ports " + MongooseAddress$ +
+                                                                                 " -document_root "+#DQUOTE$+RootPath$+#DQUOTE$ +
+                                                                                 " -spiderbasic_root "+#DQUOTE$+ReplaceString(PureBasicPath$, "\", "/")+#DQUOTE$, "", #PB_Program_Open | #PB_Program_Hide)
+        Delay(500)
+        WebLaunchedServers(RootPath$) = WebServerAddress$
+      EndIf
+    EndIf
+    
+    
+    If Error = #False
+      
+      Url$ = "http://"+WebLaunchedServers(RootPath$)+"/" + GetFilePart(Executable$)
+      
+      CompilerIf #CompileWindows
+        If OptionWebBrowser$
+          RunProgram(OptionWebBrowser$, Url$, "")
+        Else
+          RunProgram(Url$) ; Will launch the default browser
+        EndIf
+        
+      CompilerElseIf #CompileLinux
+        If OptionWebBrowser$
+          RunProgram(OptionWebBrowser$, Url$, "")
+        Else
+          RunProgram("xdg-open", Url$, "") ; Will launch the default browser
+        EndIf
+        
+      CompilerElseIf #CompileMac
+        If OptionWebBrowser$
+          RunProgram("open", "-a " + OptionWebBrowser$ + " " + Url$, "")
+        Else
+          RunProgram("open", Url$, "") ; Will launch the default browser
+        EndIf
+      CompilerEndIf
+      
+    EndIf
+    
+  CompilerElse
+    ; now execute the executable with the selected debugger (if any)
+    If *Target\RunDebuggerMode
+      
+      ; get the correct debugger type
+      ;
+      If *Target\CustomDebugger
+        LocalDebuggerMode = *Target\DebuggerType
+      Else
+        LocalDebuggerMode = DebuggerMode
+      EndIf
+      
+      ; With the multiple compiler support, we can only use the IDE debugger if
+      ; the Version matches (we ignore alpha/beta version), as otherwise the debugger
+      ; communication is probably incompatible (use the external debugger then)
+      ;
+      If LocalDebuggerMode = 1 And *Target\RunCompilerVersion <> DefaultCompiler\VersionNumber
+        LocalDebuggerMode = 2 ; standalone
+      EndIf
+      
+      ; get correct gui debugger (may also be needed as fallback for IDE debugger!)
+      ;
+      CompilerIf #CompileWindows
+        If *Target\RunCompilerVersion < 530 ; since 5.30 the main debugger is unicode
+          DebuggerExe$ = *Target\RunCompilerPath$+"pbdebuggerunicode.exe"
+        Else
+          DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger.exe"
+        EndIf
+        DebuggerParams$ = ""
+      CompilerEndIf
+      
+      CompilerIf #CompileLinux
+        If *Target\RunCompilerVersion < 530 ; since 5.30 the main debugger is unicode
+          DebuggerExe$ = *Target\RunCompilerPath$+"pbdebuggerunicode"
+        Else
+          DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger"
+        EndIf
+        
+        If *Target\RunExeFormat = 1 And DetectedGUITerminal$ <> ""  ; this is for the standalone debugger
+          DebuggerParams$ = GUITerminalParameters$ + DebuggerExe$
+          DebuggerExe$ = DetectedGUITerminal$
+        Else
+          DebuggerParams$ = ""
+        EndIf
+      CompilerEndIf
+      
+      CompilerIf #CompileMac
+        DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger.app/Contents/MacOS/pbdebugger"
+        
+        ;       If LocalDebuggerMode <> 2 And LocalDebuggerMode <> 3 ; OSX-debug
+        ;         LocalDebuggerMode = 2 ; there is no integrated debugger on OSX, so ensure that it cannot be called
+        ;       EndIf
+        
+        If *Target\ExecutableFormat = 1 ; this is for the Standalone Debugger
+          DebuggerParams$ = "-a Terminal.app " +#DQUOTE$+ DebuggerExe$ +#DQUOTE$
+          DebuggerExe$ = "open"
+        Else
+          DebuggerParams$ = ""
+        EndIf
+      CompilerEndIf
+      
+      Select LocalDebuggerMode
+          
+        Case 1 ; ide debugger
+          
+          ; Vista admin tools must run in the standalone debugger
+          ;
+          CompilerIf #CompileWindows
+            If *Target\RunEnableAdmin And OSVersion() >= #PB_OS_Windows_Vista And IsAdmin() = 0 ; Fallback only if we are not admin (https://www.purebasic.fr/english/viewtopic.php?f=4&t=50571&p=385348#p385348)
+              ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
+              ProcedureReturn
+            EndIf
+          CompilerEndIf
+          
+          *OldDebugger.DebuggerData = GetDebuggerForFile(*ActiveSource) ; use the *ActiveSource here (also handles projects properly)
+          If *OldDebugger And *OldDebugger\CanDestroy = 0
+            If MessageRequester(#ProductName$,Language("Debugger","IsRunning")+#NewLine+Language("Debugger","IsRunning2"), #PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
+              ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
+            EndIf
+          Else
+            ; do remove the old debugger, if it had finished executing...
+            If *OldDebugger And *OldDebugger\CanDestroy
+              Debugger_ForceDestroy(*OldDebugger)
+            EndIf
+            
+            CompilerIf #CompileWindows
+              *Debugger.DebuggerData = Debugger_ExecuteProgram(Executable$, *Target\CommandLine$, Directory$)
+              
+            CompilerElse
+              If *Target\RunExeFormat = 1
+                DebuggerUseFIFO = 1
+                CompilerIf #CompileLinux
+                  *Debugger.DebuggerData = Debugger_ExecuteProgram(DetectedGUITerminal$, GUITerminalParameters$+Executable$+" " + *Target\CommandLine$, Directory$)
+                CompilerElse
+                  *Debugger.DebuggerData = Debugger_ExecuteProgram("open", "-a Terminal.app "+#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
+                CompilerEndIf
+              Else
+                DebuggerUseFIFO = 0
+                *Debugger.DebuggerData = Debugger_ExecuteProgram(Executable$, *Target\CommandLine$, Directory$)
+              EndIf
+            CompilerEndIf
+            
+            If *Debugger = 0
+              MessageRequester(#ProductName$,Language("Debugger","ExecuteError"), #FLAG_Error)
+            Else
+              ; link the debugger with the source (only if no mainfile was used!)
+              If *Target\IsProject
+                *Debugger\SourceID        = 0
+                *Debugger\TriggerTargetID = *Target\ID
+                ProjectDebuggerID         = *Debugger\ID
+                
+              ElseIf *Target\RunMainFileUsed = 0
+                *Debugger\SourceID        = *ActiveSource\ID
+                *Debugger\TriggerTargetID = *ActiveSource\ID
+                *ActiveSource\DebuggerID  = *Debugger\ID
+              Else
+                *Debugger\SourceID        = 0
+                *Debugger\TriggerTargetID = *ActiveSource\ID
+                *ActiveSource\DebuggerID  = 0
+              EndIf
+              
+              *Debugger\FileName$ = *Target\RunSourceFileName$
+              ChangeStatus(Language("Debugger","Waiting"), -1)
+              Debugger_AddLog(*Debugger, Language("Debugger","Waiting"), Date())
+              SetDebuggerMenuStates()
+              
+              If IsDebuggerTimer = 0 ; Was no debugger before, activate the timer to check incoming commands
+                Debug "[Activate debugger timer]"
+                AddWindowTimer(#WINDOW_Main, #TIMER_DebuggerProcessing, 20) ; check every 20 ms
+                IsDebuggerTimer = 1
+              EndIf
+              
+            EndIf
+          EndIf
+          
+        Case 2 ; standalone debugger
+          ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
+          
+        Case 3 ; console debugger
+          CompilerIf #CompileWindows
+            RunProgram(Executable$, *Target\CommandLine$, Directory$)
+          CompilerEndIf
+          
+          CompilerIf #CompileLinux
+            RunProgram(DetectedGUITerminal$, GUITerminalParameters$ + Executable$ +" " + *Target\CommandLine$, Directory$)
+          CompilerEndIf
+          
+          CompilerIf #CompileMac
+            RunProgram("open", "-a Terminal.app " +#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
+          CompilerEndIf
+          
+      EndSelect
+      
+    Else  ; normal execute of the program
+      
+      CompilerIf #CompileWindows
+        RunProgram(Executable$, *Target\CommandLine$, Directory$)
+      CompilerEndIf
+      
+      CompilerIf #CompileLinux
+        If *Target\RunExeFormat = 1 And DetectedGUITerminal$ <> ""
+          RunProgram(DetectedGUITerminal$, GUITerminalParameters$ + Executable$ +" " + *Target\CommandLine$, Directory$)
+        Else
+          RunProgram(Executable$, *Target\CommandLine$, Directory$)
+        EndIf
+      CompilerEndIf
+      
+      CompilerIf #CompileMac
+        ; On OS X, "open" launch automatically the 'Terminal' application, which is just perfect in our case
+        If *Target\ExecutableFormat = 1
+          RunProgram("open", "-a Terminal.app "+#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
+        Else
+          RunProgram(Executable$, *Target\CommandLine$, Directory$)
+        EndIf
+      CompilerEndIf
+      
+    EndIf
+    
+  CompilerEndIf
+  
+  ; Reset the modified PATH environment variable, else we add a new compiler path
+  ; every time a program is compiled
+  ;
+  CompilerIf #CompileWindows
+    SetEnvironmentVariable("PATH", PreviousPath$)
+  CompilerEndIf
+  
+  CompilerIf #CompileLinux
+    SetEnvironmentVariable("LD_LIBRARY_PATH", PreviousPath$)
+  CompilerEndIf
+  
+  CompilerIf #CompileMac
+    SetEnvironmentVariable("DYLD_LIBRARY_PATH", PreviousPath$)
+  CompilerEndIf
+  
+EndProcedure
+
+; Generate a proper temporary filename for the target
+;
+Procedure.s Compiler_TemporaryFilename(*Target.CompileTarget)
+  TargetFileName$ = ""
+  
+  If *Target\TemporaryExePlace And *Target\FileName$ <> ""
+    BasePath$ = GetPathPart(*Target\FileName$)
+  Else
+    BasePath$ = TempPath$
+  EndIf
+  
+  CompilerIf #SpiderBasic
+    For i = 0 To 10000
+      If FileSize(BasePath$+"SpiderBasic_Compilation"+Str(i)+".html") = -1
+        TargetFileName$ = BasePath$+"SpiderBasic_Compilation"+Str(i)+".html"
+        Break
       EndIf
     Next i
     
-  EndProcedure
-  
-  ; ---------------------------------------------------------------------
-  
-  CompilerIf #SpiderBasic
-    Procedure.l GetIPByHost(Host$="")
-      Result.l=0
-      
-      If Host$=""
-        Host$=Hostname()
+  CompilerElseIf #CompileWindows
+    For i = 0 To 10000
+      If FileSize(BasePath$+"PureBasic_Compilation"+Str(i)+".exe") = -1
+        TargetFileName$ = BasePath$+"PureBasic_Compilation"+Str(i)+".exe"
+        Break
       EndIf
-      
-      SelfLoop=OpenNetworkConnection(Host$,0,#PB_Network_UDP)
-      If SelfLoop
-        Result=GetClientIP(SelfLoop)
-        CloseNetworkConnection(SelfLoop)
+    Next i
+    
+  CompilerElseIf #CompileLinux
+    For i = 0 To 10000
+      If FileSize(BasePath$+"purebasic_compilation"+Str(i)+".out") = -1
+        TargetFileName$ = BasePath$+"purebasic_compilation"+Str(i)+".out"
+        Break
       EndIf
-      
-      ProcedureReturn Result
-    EndProcedure
+    Next i
+    
+  CompilerElseIf #CompileMac
+    For i = 0 To 10000
+      ; this also shows in the menubar of the executed program, so choose a nicer name here :)
+      If FileSize(BasePath$+"PureBasic."+Str(i)+".app") = -1
+        TargetFileName$ = BasePath$+"PureBasic."+Str(i)
+        If *Target\ExecutableFormat = 0 ; Application format
+          TargetFileName$ + ".app"
+        EndIf
+        Break
+      EndIf
+    Next i
   CompilerEndIf
   
-  ; ---------------------------------------------------------------------
+  ProcedureReturn TargetFileName$
+EndProcedure
+
+Procedure Compiler_CompileRun(SourceFileName$, *Source.SourceFile, CheckSyntax)
   
-  Procedure Compiler_Run(*Target.CompileTarget, IsFirstRun)
-    CompilerIf #CompileLinux
-      Shared DetectedGUITerminal$, GUITerminalParameters$ ; for the debugger (shared from LinuxMisc.pb)
-    CompilerEndIf
-    
-    CompilerIf #CompileMac And Not #SpiderBasic
-      If *Target\ExecutableFormat = 1 ; Console
-        Executable$ = *Target\RunExecutable$
-      Else
-        Executable$ = *Target\RunExecutable$ + "/Contents/MacOS/" + Left(GetFilePart(*Target\RunExecutable$), Len(GetFilePart(*Target\RunExecutable$))-4)
-      EndIf
-    CompilerElse
-      Executable$ = *Target\RunExecutable$
-    CompilerEndIf
-    
-    ; Check if the executable is still present
-    ;
-    If FileSize(Executable$) <= 0
-      Debug "NOT FOUND "+FileSize(Executable$)
-      ; recompile the whole thing, but only if we did not just do so to
-      ; avoid a possible endless compilation loop (unlikely)
-      If IsFirstRun = #False
-        If *Target\IsProject
-          CompileRunProject(#False) ; call the CompilerWindow.pb one which does all handling correctly (also the compilecount)
-        Else
-          CompileRun(#False)
-        EndIf
-      EndIf
-      ProcedureReturn
-    EndIf
-    
-    ; get the current directory for the exe
-    ;
-    If *Target\CurrentDirectory$ <> "" ; a special one has been selected
-      If *Target\IsProject
-        Directory$ = ResolveRelativePath(GetPathPart(ProjectFile$), *Target\CurrentDirectory$)
-      ElseIf *Target\FileName$ = ""
-        Directory$ = ResolveRelativePath(CurrentDirectory$, *Target\CurrentDirectory$)
-      Else
-        Directory$ = ResolveRelativePath(GetPathPart(*Target\FileName$), *Target\CurrentDirectory$)
-      EndIf
-    Else
-      If *Target\FileName$ = ""
-        Directory$ = CurrentDirectory$
-      Else
-        Directory$ = GetPathPart(*Target\FileName$)
-      EndIf
-    EndIf
-    
-    ; Add the Compiler directory to the (library-)path, so the 3D engine and other
-    ; libraries can be loaded by the exe
-    ;
-    CompilerIf #CompileWindows
-      PreviousPath$ = GetEnvironmentVariable("PATH")
-      SetEnvironmentVariable("PATH", *Target\RunCompilerPath$+";"+PreviousPath$)
-    CompilerEndIf
-    
-    CompilerIf #CompileLinux
-      PreviousPath$ = GetEnvironmentVariable("LD_LIBRARY_PATH")
-      SetEnvironmentVariable("LD_LIBRARY_PATH", *Target\RunCompilerPath$+":"+PreviousPath$)
-    CompilerEndIf
-    
-    CompilerIf #CompileMac
-      PreviousPath$ = GetEnvironmentVariable("DYLD_LIBRARY_PATH")
-      SetEnvironmentVariable("DYLD_LIBRARY_PATH", *Target\RunCompilerPath$+":"+PreviousPath$)
-    CompilerEndIf
-    
-    Debug "----"
-    Debug "Filename   = " + *ActiveSource\Filename$
-    Debug "CurrentDir = " + *ActiveSource\CurrentDirectory$
-    Debug "Directory  = " + Directory$
-    Debug "----"
-    
-    CompilerIf #SpiderBasic
-      Static NewMap WebLaunchedServers.s()
-      Static WebServerPortIndex = 0
-      
-      RootPath$ = GetPathPart(Executable$)
-      If Right(RootPath$, 1) = "\" ; mongoose doesn't like path terminated with "\"
-        RootPath$ = Left(RootPath$, Len(RootPath$)-1)
-      EndIf
-      
-      If WebLaunchedServers(RootPath$) = "" Or (*Target\WebServerAddress$ And WebLaunchedServers(RootPath$) <> *Target\WebServerAddress$) ; Not yet launched or the server port has been changed in the target
-        
-        If *Target\WebServerAddress$
-          WebServerAddress$ = *Target\WebServerAddress$
-          MongooseAddress$ = WebServerAddress$
-          
-          ; We need to resolve the hostname, as sbmongoose only access real IP address, not hostname
-          ;
-          If FindString(WebServerAddress$, ":")
-            ServerName$ = StringField(WebServerAddress$, 1, ":")
-            IP = GetIPByHost(ServerName$) ; works with IP as well
-            If IP
-              MongooseAddress$ = IPString(IP)
-              Port$ = StringField(WebServerAddress$, 2, ":")
-              If Port$
-                MongooseAddress$ + ":" + Port$
-              EndIf
-            EndIf
-          Else
-            MessageRequester("Error", "Invalid server address ("+ WebServerAddress$ + "). It should be specified as 'address:port'", #FLAG_Error)
-            Error = #True
-          EndIf
-          
-        Else
-          WebServerAddress$ = "127.0.0.1:" + Str(OptionWebServerPort + WebServerPortIndex)
-          MongooseAddress$ = WebServerAddress$
-          WebServerPortIndex+1
-        EndIf
-        
-        If Error = #False
-          AddElement(OpenedWebServers())
-          
-          Debug MongooseAddress$
-          
-          OpenedWebServers() = RunProgram(PureBasicPath$ + "compilers/sbmongoose", " -listening_ports " + MongooseAddress$ +
-                                                                                   " -document_root "+#DQUOTE$+RootPath$+#DQUOTE$ +
-                                                                                   " -spiderbasic_root "+#DQUOTE$+ReplaceString(PureBasicPath$, "\", "/")+#DQUOTE$, "", #PB_Program_Open | #PB_Program_Hide)
-          Delay(500)
-          WebLaunchedServers(RootPath$) = WebServerAddress$
-        EndIf
-      EndIf
-      
-      
-      If Error = #False
-        
-        Url$ = "http://"+WebLaunchedServers(RootPath$)+"/" + GetFilePart(Executable$)
-        
-        CompilerIf #CompileWindows
-          If OptionWebBrowser$
-            RunProgram(OptionWebBrowser$, Url$, "")
-          Else
-            RunProgram(Url$) ; Will launch the default browser
-          EndIf
-          
-        CompilerElseIf #CompileLinux
-          If OptionWebBrowser$
-            RunProgram(OptionWebBrowser$, Url$, "")
-          Else
-            RunProgram("xdg-open", Url$, "") ; Will launch the default browser
-          EndIf
-          
-        CompilerElseIf #CompileMac
-          If OptionWebBrowser$
-            RunProgram("open", "-a " + OptionWebBrowser$ + " " + Url$, "")
-          Else
-            RunProgram("open", Url$, "") ; Will launch the default browser
-          EndIf
-        CompilerEndIf
-        
-      EndIf
-      
-    CompilerElse
-      ; now execute the executable with the selected debugger (if any)
-      If *Target\RunDebuggerMode
-        
-        ; get the correct debugger type
-        ;
-        If *Target\CustomDebugger
-          LocalDebuggerMode = *Target\DebuggerType
-        Else
-          LocalDebuggerMode = DebuggerMode
-        EndIf
-        
-        ; With the multiple compiler support, we can only use the IDE debugger if
-        ; the Version matches (we ignore alpha/beta version), as otherwise the debugger
-        ; communication is probably incompatible (use the external debugger then)
-        ;
-        If LocalDebuggerMode = 1 And *Target\RunCompilerVersion <> DefaultCompiler\VersionNumber
-          LocalDebuggerMode = 2 ; standalone
-        EndIf
-        
-        ; get correct gui debugger (may also be needed as fallback for IDE debugger!)
-        ;
-        CompilerIf #CompileWindows
-          If *Target\RunCompilerVersion < 530 ; since 5.30 the main debugger is unicode
-            DebuggerExe$ = *Target\RunCompilerPath$+"pbdebuggerunicode.exe"
-          Else
-            DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger.exe"
-          EndIf
-          DebuggerParams$ = ""
-        CompilerEndIf
-        
-        CompilerIf #CompileLinux
-          If *Target\RunCompilerVersion < 530 ; since 5.30 the main debugger is unicode
-            DebuggerExe$ = *Target\RunCompilerPath$+"pbdebuggerunicode"
-          Else
-            DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger"
-          EndIf
-          
-          If *Target\RunExeFormat = 1 And DetectedGUITerminal$ <> ""  ; this is for the standalone debugger
-            DebuggerParams$ = GUITerminalParameters$ + DebuggerExe$
-            DebuggerExe$ = DetectedGUITerminal$
-          Else
-            DebuggerParams$ = ""
-          EndIf
-        CompilerEndIf
-        
-        CompilerIf #CompileMac
-          DebuggerExe$ = *Target\RunCompilerPath$+"pbdebugger.app/Contents/MacOS/pbdebugger"
-          
-          ;       If LocalDebuggerMode <> 2 And LocalDebuggerMode <> 3 ; OSX-debug
-          ;         LocalDebuggerMode = 2 ; there is no integrated debugger on OSX, so ensure that it cannot be called
-          ;       EndIf
-          
-          If *Target\ExecutableFormat = 1 ; this is for the Standalone Debugger
-            DebuggerParams$ = "-a Terminal.app " +#DQUOTE$+ DebuggerExe$ +#DQUOTE$
-            DebuggerExe$ = "open"
-          Else
-            DebuggerParams$ = ""
-          EndIf
-        CompilerEndIf
-        
-        Select LocalDebuggerMode
-            
-          Case 1 ; ide debugger
-            
-            ; Vista admin tools must run in the standalone debugger
-            ;
-            CompilerIf #CompileWindows
-              If *Target\RunEnableAdmin And OSVersion() >= #PB_OS_Windows_Vista And IsAdmin() = 0 ; Fallback only if we are not admin (https://www.purebasic.fr/english/viewtopic.php?f=4&t=50571&p=385348#p385348)
-                ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
-                ProcedureReturn
-              EndIf
-            CompilerEndIf
-            
-            *OldDebugger.DebuggerData = GetDebuggerForFile(*ActiveSource) ; use the *ActiveSource here (also handles projects properly)
-            If *OldDebugger And *OldDebugger\CanDestroy = 0
-              If MessageRequester(#ProductName$,Language("Debugger","IsRunning")+#NewLine+Language("Debugger","IsRunning2"), #PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
-                ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
-              EndIf
-            Else
-              ; do remove the old debugger, if it had finished executing...
-              If *OldDebugger And *OldDebugger\CanDestroy
-                Debugger_ForceDestroy(*OldDebugger)
-              EndIf
-              
-              CompilerIf #CompileWindows
-                *Debugger.DebuggerData = Debugger_ExecuteProgram(Executable$, *Target\CommandLine$, Directory$)
-                
-              CompilerElse
-                If *Target\RunExeFormat = 1
-                  DebuggerUseFIFO = 1
-                  CompilerIf #CompileLinux
-                    *Debugger.DebuggerData = Debugger_ExecuteProgram(DetectedGUITerminal$, GUITerminalParameters$+Executable$+" " + *Target\CommandLine$, Directory$)
-                  CompilerElse
-                    *Debugger.DebuggerData = Debugger_ExecuteProgram("open", "-a Terminal.app "+#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
-                  CompilerEndIf
-                Else
-                  DebuggerUseFIFO = 0
-                  *Debugger.DebuggerData = Debugger_ExecuteProgram(Executable$, *Target\CommandLine$, Directory$)
-                EndIf
-              CompilerEndIf
-              
-              If *Debugger = 0
-                MessageRequester(#ProductName$,Language("Debugger","ExecuteError"), #FLAG_Error)
-              Else
-                ; link the debugger with the source (only if no mainfile was used!)
-                If *Target\IsProject
-                  *Debugger\SourceID        = 0
-                  *Debugger\TriggerTargetID = *Target\ID
-                  ProjectDebuggerID         = *Debugger\ID
-                  
-                ElseIf *Target\RunMainFileUsed = 0
-                  *Debugger\SourceID        = *ActiveSource\ID
-                  *Debugger\TriggerTargetID = *ActiveSource\ID
-                  *ActiveSource\DebuggerID  = *Debugger\ID
-                Else
-                  *Debugger\SourceID        = 0
-                  *Debugger\TriggerTargetID = *ActiveSource\ID
-                  *ActiveSource\DebuggerID  = 0
-                EndIf
-                
-                *Debugger\FileName$ = *Target\RunSourceFileName$
-                ChangeStatus(Language("Debugger","Waiting"), -1)
-                Debugger_AddLog(*Debugger, Language("Debugger","Waiting"), Date())
-                SetDebuggerMenuStates()
-                
-                If IsDebuggerTimer = 0 ; Was no debugger before, activate the timer to check incoming commands
-                  Debug "[Activate debugger timer]"
-                  AddWindowTimer(#WINDOW_Main, #TIMER_DebuggerProcessing, 20) ; check every 20 ms
-                  IsDebuggerTimer = 1
-                EndIf
-                
-              EndIf
-            EndIf
-            
-          Case 2 ; standalone debugger
-            ExecuteStandaloneDebugger(*Target, DebuggerExe$, Executable$, Directory$, DebuggerParams$)
-            
-          Case 3 ; console debugger
-            CompilerIf #CompileWindows
-              RunProgram(Executable$, *Target\CommandLine$, Directory$)
-            CompilerEndIf
-            
-            CompilerIf #CompileLinux
-              RunProgram(DetectedGUITerminal$, GUITerminalParameters$ + Executable$ +" " + *Target\CommandLine$, Directory$)
-            CompilerEndIf
-            
-            CompilerIf #CompileMac
-              RunProgram("open", "-a Terminal.app " +#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
-            CompilerEndIf
-            
-        EndSelect
-        
-      Else  ; normal execute of the program
-        
-        CompilerIf #CompileWindows
-          RunProgram(Executable$, *Target\CommandLine$, Directory$)
-        CompilerEndIf
-        
-        CompilerIf #CompileLinux
-          If *Target\RunExeFormat = 1 And DetectedGUITerminal$ <> ""
-            RunProgram(DetectedGUITerminal$, GUITerminalParameters$ + Executable$ +" " + *Target\CommandLine$, Directory$)
-          Else
-            RunProgram(Executable$, *Target\CommandLine$, Directory$)
-          EndIf
-        CompilerEndIf
-        
-        CompilerIf #CompileMac
-          ; On OS X, "open" launch automatically the 'Terminal' application, which is just perfect in our case
-          If *Target\ExecutableFormat = 1
-            RunProgram("open", "-a Terminal.app "+#DQUOTE$+ Executable$ +#DQUOTE$+ " " + *Target\CommandLine$, Directory$)
-          Else
-            RunProgram(Executable$, *Target\CommandLine$, Directory$)
-          EndIf
-        CompilerEndIf
-        
-      EndIf
-      
-    CompilerEndIf
-    
-    ; Reset the modified PATH environment variable, else we add a new compiler path
-    ; every time a program is compiled
-    ;
-    CompilerIf #CompileWindows
-      SetEnvironmentVariable("PATH", PreviousPath$)
-    CompilerEndIf
-    
-    CompilerIf #CompileLinux
-      SetEnvironmentVariable("LD_LIBRARY_PATH", PreviousPath$)
-    CompilerEndIf
-    
-    CompilerIf #CompileMac
-      SetEnvironmentVariable("DYLD_LIBRARY_PATH", PreviousPath$)
-    CompilerEndIf
-    
-  EndProcedure
-  
-  ; Generate a proper temporary filename for the target
+  ; Load the correct compiler + unicode mode and subsystem
   ;
-  Procedure.s Compiler_TemporaryFilename(*Target.CompileTarget)
-    TargetFileName$ = ""
-    
-    If *Target\TemporaryExePlace And *Target\FileName$ <> ""
-      BasePath$ = GetPathPart(*Target\FileName$)
-    Else
-      BasePath$ = TempPath$
-    EndIf
-    
-    CompilerIf #SpiderBasic
-      For i = 0 To 10000
-        If FileSize(BasePath$+"SpiderBasic_Compilation"+Str(i)+".html") = -1
-          TargetFileName$ = BasePath$+"SpiderBasic_Compilation"+Str(i)+".html"
-          Break
-        EndIf
-      Next i
-      
-    CompilerElseIf #CompileWindows
-      For i = 0 To 10000
-        If FileSize(BasePath$+"PureBasic_Compilation"+Str(i)+".exe") = -1
-          TargetFileName$ = BasePath$+"PureBasic_Compilation"+Str(i)+".exe"
-          Break
-        EndIf
-      Next i
-      
-    CompilerElseIf #CompileLinux
-      For i = 0 To 10000
-        If FileSize(BasePath$+"purebasic_compilation"+Str(i)+".out") = -1
-          TargetFileName$ = BasePath$+"purebasic_compilation"+Str(i)+".out"
-          Break
-        EndIf
-      Next i
-      
-    CompilerElseIf #CompileMac
-      For i = 0 To 10000
-        ; this also shows in the menubar of the executed program, so choose a nicer name here :)
-        If FileSize(BasePath$+"PureBasic."+Str(i)+".app") = -1
-          TargetFileName$ = BasePath$+"PureBasic."+Str(i)
-          If *Target\ExecutableFormat = 0 ; Application format
-            TargetFileName$ + ".app"
-          EndIf
-          Break
-        EndIf
-      Next i
-    CompilerEndIf
-    
-    ProcedureReturn TargetFileName$
-  EndProcedure
+  If Compiler_SetCompiler(*Source) = 0
+    HideCompilerWindow()
+    ActivateMainWindow()
+    ProcedureReturn #False
+  EndIf
   
-  Procedure Compiler_CompileRun(SourceFileName$, *Source.SourceFile, CheckSyntax)
-    
-    ; Load the correct compiler + unicode mode and subsystem
-    ;
-    If Compiler_SetCompiler(*Source) = 0
-      HideCompilerWindow()
-      ActivateMainWindow()
-      ProcedureReturn #False
-    EndIf
-    
-    ; Select a proper output filename
-    ; Note: we do not let the compiler choose one, as we need the full control
-    ;       over the files even if the compiler is restarted.
-    ;
-    ; Ckean the *ActiveSource here for the MainFile option!
-    ; This is for non-project only, so this is ok
-    ;
-    If *ActiveSource\RunExecutable$
-      CompilerIf #SpiderBasic
-        DeleteFile(*ActiveSource\RunExecutable$) ; An html file on all plateforms
+  ; Select a proper output filename
+  ; Note: we do not let the compiler choose one, as we need the full control
+  ;       over the files even if the compiler is restarted.
+  ;
+  ; Ckean the *ActiveSource here for the MainFile option!
+  ; This is for non-project only, so this is ok
+  ;
+  If *ActiveSource\RunExecutable$
+    CompilerIf #SpiderBasic
+      DeleteFile(*ActiveSource\RunExecutable$) ; An html file on all plateforms
+    CompilerElse
+      CompilerIf #CompileMac
+        DeleteDirectory(*ActiveSource\RunExecutable$, "*", #PB_FileSystem_Recursive) ; a .app is a directory!
       CompilerElse
-        CompilerIf #CompileMac
-          DeleteDirectory(*ActiveSource\RunExecutable$, "*", #PB_FileSystem_Recursive) ; a .app is a directory!
-        CompilerElse
-          DeleteFile(*ActiveSource\RunExecutable$)
-        CompilerEndIf
-      CompilerEndIf
-      *ActiveSource\RunExecutable$ = ""
-    EndIf
-    
-    TargetFileName$ = Compiler_TemporaryFilename(*Source)
-    
-    If TargetFileName$ = ""
-      HideCompilerWindow()
-      ActivateMainWindow()
-      ProcedureReturn #False
-    EndIf
-    
-    ; We register for deletion even though it gets automatically deleted on
-    ; recompilation/source close. Because if you compile the same code twice
-    ; (while the first instance runs, with external debugger), we get two files
-    ; with only one in our variable for deletion
-    ;
-    ; This has a protection against double filenames, so the list does not grow
-    ; forever. (as we usually reuse the same name)
-    ;
-    RegisterDeleteFile(TargetFileName$)
-    
-    CompilerWrite("SOURCE"+Chr(9)+SourceFileName$)
-    CompilerWrite("TARGET"+Chr(9)+TargetFileName$)
-    
-    If *Source\FileName$ <> ""
-      CompilerWrite("INCLUDEPATH"+Chr(9)+GetPathPart(*Source\FileName$))
-      
-      If *Source\FileName$ <> SourceFileName$
-        CompilerWrite("SOURCEALIAS"+Chr(9)+*Source\FileName$)
-      EndIf
-    EndIf
-    
-    If *Source\LinkerOptions$ <> ""
-      CompilerWrite("LINKER"+Chr(9)+ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\LinkerOptions$))
-    EndIf
-    
-    CompilerIf #CompileWindows
-      ResourceFile$ = CreateResourceFile(*Source)
-      If ResourceFile$
-        CompilerWrite("RESOURCE"+Chr(9)+ResourceFile$)
-      EndIf
-    CompilerEndIf
-    
-    CompilerIf Not #SpiderBasic
-      CompilerIf #CompileWindows | #CompileMac
-        If *Source\UseIcon
-          CompilerWrite("ICON"+Chr(9)+ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\IconName$))
-        EndIf
+        DeleteFile(*ActiveSource\RunExecutable$)
       CompilerEndIf
     CompilerEndIf
-    
-    CompilerIf #SpiderBasic
-      *Source\AppFormat = #AppFormatWeb ; Reset the app format to Web to avoid app creation if we use compile/run after creating an app
-      
-      CompilerWriteStringValue("APPNAME", *Source\WebAppName$)
-      CompilerWriteStringValue("WINDOWTHEME", *Source\WindowTheme$)
-      CompilerWriteStringValue("GADGETTHEME", *Source\GadgetTheme$)
-      
-      If *Source\WebAppIcon$
-        CompilerWriteStringValue("ICON", ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\WebAppIcon$))
-      EndIf
-    CompilerEndIf
-    
-    Compiler_SetConstants(*Source, #False)
-    
-    CompilerWrite(Compiler_BuildCommandFlags(*Source, CheckSyntax, #False))
-    
-    ; Handles the error and progress display
-    ; do not use *Source here as it might be the MainFile dummy!
-    ; also hides the compiler window when done
-    ;
-    If Compiler_HandleCompilerResponse(*Source)
-      ; set the run information, then simply call the run command from here to reduce code
-      *ActiveSource\RunExecutable$     = TargetFileName$
-      *ActiveSource\RunExeFormat       = *Source\ExecutableFormat
-      *ActiveSource\RunDebuggerMode    = (*Source\Debugger|ForceDebugger)&~ForceNoDebugger
-      *ActiveSource\RunEnableAdmin     = *Source\EnableAdmin
-      *ActiveSource\RunSourceFileName$ = *Source\FileName$
-      *ActiveSource\RunCompilerPath$   = GetPathPart(*CurrentCompiler\Executable$)
-      *ActiveSource\RunCompilerVersion = *CurrentCompiler\VersionNumber
-      
-      If *Source = @CompileFile ; if this is true, the mainfile option is used
-        *ActiveSource\RunMainFileUsed = 1
-      Else
-        *ActiveSource\RunMainFileUsed = 0
-      EndIf
-      
-      ; execute any external tools
-      AddTools_ExecutableName$ = TargetFileName$
-      AddTools_Execute(#TRIGGER_AfterCompile, *ActiveSource)
-      
-      If CheckSyntax = #False
-        Compiler_Run(*ActiveSource, #True) ; run the file
-      Else
-        Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] Syntax check finished ("+Str(*ActiveSource\LastCompiledLines)+" lines)", Date())
-      EndIf
-      
-      ProcedureReturn #True
-    Else
-      ProcedureReturn #False
-    EndIf
-    
-  EndProcedure
+    *ActiveSource\RunExecutable$ = ""
+  EndIf
   
+  TargetFileName$ = Compiler_TemporaryFilename(*Source)
   
-  ; Used for "Create Executable" and project targets
+  If TargetFileName$ = ""
+    HideCompilerWindow()
+    ActivateMainWindow()
+    ProcedureReturn #False
+  EndIf
+  
+  ; We register for deletion even though it gets automatically deleted on
+  ; recompilation/source close. Because if you compile the same code twice
+  ; (while the first instance runs, with external debugger), we get two files
+  ; with only one in our variable for deletion
   ;
-  Procedure Compiler_BuildTarget(SourceFileName$, TargetFileName$, *Target.CompileTarget, CreateExe, CheckSyntax)
+  ; This has a protection against double filenames, so the list does not grow
+  ; forever. (as we usually reuse the same name)
+  ;
+  RegisterDeleteFile(TargetFileName$)
+  
+  CompilerWrite("SOURCE"+Chr(9)+SourceFileName$)
+  CompilerWrite("TARGET"+Chr(9)+TargetFileName$)
+  
+  If *Source\FileName$ <> ""
+    CompilerWrite("INCLUDEPATH"+Chr(9)+GetPathPart(*Source\FileName$))
     
-    ; Projects always resolve relative to the project file, not the main sourcefile
-    If *Target\IsProject
-      BasePath$ = GetPathPart(ProjectFile$)
-    Else
-      BasePath$ = GetPathPart(*Target\FileName$)
+    If *Source\FileName$ <> SourceFileName$
+      CompilerWrite("SOURCEALIAS"+Chr(9)+*Source\FileName$)
     EndIf
-    
-    ; Load the correct compiler + unicode mode and subsystem
-    ;
-    If Compiler_SetCompiler(*Target) = 0
-      If CommandlineBuild = 0
-        HideCompilerWindow()
-        
-        ; in build mode, the window stays open, so do not do this
-        If UseProjectBuildWindow = 0
-          ActivateMainWindow()
-        EndIf
+  EndIf
+  
+  If *Source\LinkerOptions$ <> ""
+    CompilerWrite("LINKER"+Chr(9)+ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\LinkerOptions$))
+  EndIf
+  
+  CompilerIf #CompileWindows
+    ResourceFile$ = CreateResourceFile(*Source)
+    If ResourceFile$
+      CompilerWrite("RESOURCE"+Chr(9)+ResourceFile$)
+    EndIf
+  CompilerEndIf
+  
+  CompilerIf Not #SpiderBasic
+    CompilerIf #CompileWindows | #CompileMac
+      If *Source\UseIcon
+        CompilerWrite("ICON"+Chr(9)+ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\IconName$))
       EndIf
-      
-      ProcedureReturn #False
+    CompilerEndIf
+  CompilerEndIf
+  
+  CompilerIf #SpiderBasic
+    *Source\AppFormat = #AppFormatWeb ; Reset the app format to Web to avoid app creation if we use compile/run after creating an app
+    
+    CompilerWriteStringValue("APPNAME", *Source\WebAppName$)
+    CompilerWriteStringValue("WINDOWTHEME", *Source\WindowTheme$)
+    CompilerWriteStringValue("GADGETTHEME", *Source\GadgetTheme$)
+    
+    If *Source\WebAppIcon$
+      CompilerWriteStringValue("ICON", ResolveRelativePath(GetPathPart(*Source\FileName$), *Source\WebAppIcon$))
+    EndIf
+  CompilerEndIf
+  
+  Compiler_SetConstants(*Source, #False)
+  
+  CompilerWrite(Compiler_BuildCommandFlags(*Source, CheckSyntax, #False))
+  
+  ; Handles the error and progress display
+  ; do not use *Source here as it might be the MainFile dummy!
+  ; also hides the compiler window when done
+  ;
+  If Compiler_HandleCompilerResponse(*Source)
+    ; set the run information, then simply call the run command from here to reduce code
+    *ActiveSource\RunExecutable$     = TargetFileName$
+    *ActiveSource\RunExeFormat       = *Source\ExecutableFormat
+    *ActiveSource\RunDebuggerMode    = (*Source\Debugger|ForceDebugger)&~ForceNoDebugger
+    *ActiveSource\RunEnableAdmin     = *Source\EnableAdmin
+    *ActiveSource\RunSourceFileName$ = *Source\FileName$
+    *ActiveSource\RunCompilerPath$   = GetPathPart(*CurrentCompiler\Executable$)
+    *ActiveSource\RunCompilerVersion = *CurrentCompiler\VersionNumber
+    
+    If *Source = @CompileFile ; if this is true, the mainfile option is used
+      *ActiveSource\RunMainFileUsed = 1
+    Else
+      *ActiveSource\RunMainFileUsed = 0
     EndIf
     
-    CompilerIf #SpiderBasic
-      If CreateExe
-        Select *Target\AppFormat
-            
-          Case #AppFormatWeb
-            
-            AppName$    = *Target\WebAppName$
-            Icon$       = *Target\WebAppIcon$
-            AppDebugger = *Target\WebAppEnableDebugger
-            
-            
-            CompilerWriteStringValue("JAVASCRIPTNAME", *Target\JavaScriptFilename$)
-            
+    ; execute any external tools
+    AddTools_ExecutableName$ = TargetFileName$
+    AddTools_Execute(#TRIGGER_AfterCompile, *ActiveSource)
+    
+    If CheckSyntax = #False
+      Compiler_Run(*ActiveSource, #True) ; run the file
+    Else
+      Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] Syntax check finished ("+Str(*ActiveSource\LastCompiledLines)+" lines)", Date())
+    EndIf
+    
+    ProcedureReturn #True
+  Else
+    ProcedureReturn #False
+  EndIf
+  
+EndProcedure
+
+
+; Used for "Create Executable" and project targets
+;
+Procedure Compiler_BuildTarget(SourceFileName$, TargetFileName$, *Target.CompileTarget, CreateExe, CheckSyntax)
+  
+  ; Projects always resolve relative to the project file, not the main sourcefile
+  If *Target\IsProject
+    BasePath$ = GetPathPart(ProjectFile$)
+  Else
+    BasePath$ = GetPathPart(*Target\FileName$)
+  EndIf
+  
+  ; Load the correct compiler + unicode mode and subsystem
+  ;
+  If Compiler_SetCompiler(*Target) = 0
+    If CommandlineBuild = 0
+      HideCompilerWindow()
+      
+      ; in build mode, the window stays open, so do not do this
+      If UseProjectBuildWindow = 0
+        ActivateMainWindow()
+      EndIf
+    EndIf
+    
+    ProcedureReturn #False
+  EndIf
+  
+  CompilerIf #SpiderBasic
+    If CreateExe
+      Select *Target\AppFormat
+          
+        Case #AppFormatWeb
+          
+          AppName$    = *Target\WebAppName$
+          Icon$       = *Target\WebAppIcon$
+          AppDebugger = *Target\WebAppEnableDebugger
+          
+          
+          CompilerWriteStringValue("JAVASCRIPTNAME", *Target\JavaScriptFilename$)
+          
+          If *Target\JavaScriptPath$
+            CompilerWrite("JAVASCRIPTLIBRARYPATH"+Chr(9)+*Target\JavaScriptPath$)
+          Else
+            CompilerWrite("JAVASCRIPTLIBRARYPATH"+Chr(9)+"spiderbasic") ; default is spiderbasic/
+          EndIf
+          
+          If *Target\CopyJavaScriptLibrary
             If *Target\JavaScriptPath$
-              CompilerWrite("JAVASCRIPTLIBRARYPATH"+Chr(9)+*Target\JavaScriptPath$)
+              CompilerWrite("COPYJAVASCRIPTLIBRARYPATH"+Chr(9)+*Target\JavaScriptPath$)
             Else
-              CompilerWrite("JAVASCRIPTLIBRARYPATH"+Chr(9)+"spiderbasic") ; default is spiderbasic/
+              CompilerWrite("COPYJAVASCRIPTLIBRARYPATH"+Chr(9)+"spiderbasic") ; default path is spiderbasic
             EndIf
-            
-            If *Target\CopyJavaScriptLibrary
-              If *Target\JavaScriptPath$
-                CompilerWrite("COPYJAVASCRIPTLIBRARYPATH"+Chr(9)+*Target\JavaScriptPath$)
-              Else
-                CompilerWrite("COPYJAVASCRIPTLIBRARYPATH"+Chr(9)+"spiderbasic") ; default path is spiderbasic
-              EndIf
-            EndIf
-            
-            If *Target\EnableResourceDirectory
-              ResourceDirectory$ = *Target\ResourceDirectory$
-            EndIf
-            
-          Case #AppFormatiOS
-            
-            TargetFileName$ = ResolveRelativePath(BasePath$, TargetFileName$) ; Ensures it's a fullpath
-            
-            AppName$      = *Target\iOSAppName$
-            Icon$         = *Target\iOSAppIcon$
-            AppVersion$   = *Target\iOSAppVersion$
-            PackageID$    = *Target\iOSAppPackageID$
-            StartupImage$ = *Target\iOSAppStartupImage$
-            AppDebugger   = *Target\iOSAppEnableDebugger
-            
-            Select *Target\iOSAppOrientation ; Default case is Any, and we don't need to send it to the compiler
-              Case 1
-                Orientation$ = "PORTRAIT"
-                
-              Case 2
-                Orientation$ = "LANDSCAPE"
-            EndSelect
-            
-            If *Target\iOSAppEnableResourceDirectory
-              ResourceDirectory$ = *Target\iOSAppResourceDirectory$
-            EndIf
-            
-          Case #AppFormatAndroid
-            
-            TargetFileName$ = ResolveRelativePath(BasePath$, TargetFileName$) ; Ensures it's a fullpath, or APK creation can fail (http://forums.spiderbasic.com/viewtopic.php?f=11&t=892)
-            
-            AppName$      = *Target\AndroidAppName$
-            Icon$         = *Target\AndroidAppIcon$
-            AppVersion$   = *Target\AndroidAppVersion$
-            PackageID$    = *Target\AndroidAppPackageID$
-            IAPKey$       = *Target\AndroidAppIAPKey$
-            StartupImage$ = *Target\AndroidAppStartupImage$
-            AppDebugger   = *Target\AndroidAppEnableDebugger
-            
-            Select *Target\AndroidAppOrientation ; Default case is Any, and we don't need to send it to the compiler
-              Case 1
-                Orientation$ = "PORTRAIT"
-                
-              Case 2
-                Orientation$ = "LANDSCAPE"
-            EndSelect
-            
-            If *Target\AndroidAppEnableResourceDirectory
-              ResourceDirectory$ = *Target\AndroidAppResourceDirectory$
-            EndIf
-            
-        EndSelect
-      Else
-        AppName$ = *Target\WebAppName$ ; We always use the webapp appname when compile/run the app
-        If *Target\WebAppIcon$
-          Icon$ = ResolveRelativePath(BasePath$, *Target\WebAppIcon$)
-        EndIf
-      EndIf
-      
-      CompilerWriteStringValue("WINDOWTHEME", *Target\WindowTheme$)
-      CompilerWriteStringValue("GADGETTHEME", *Target\GadgetTheme$)
-      
-      CompilerWriteStringValue("APPNAME", AppName$)
-      CompilerWriteStringValue("ICON", Icon$)
-      CompilerWriteStringValue("APPVERSION", AppVersion$)
-      CompilerWriteStringValue("PACKAGEID", PackageID$)
-      CompilerWriteStringValue("IAPKEY", IAPKey$)
-      CompilerWriteStringValue("STARTUPIMAGE", StartupImage$)
-      CompilerWriteStringValue("RESOURCEDIRECTORY", ResourceDirectory$)
-      CompilerWriteStringValue("ORIENTATION", Orientation$)
-      
-    CompilerEndIf
-    
-    CompilerWrite("SOURCE"+Chr(9)+SourceFileName$)
-    CompilerWrite("TARGET"+Chr(9)+TargetFileName$)
-    
-    If *Target\FileName$ <> ""
-      ; do not use the BasePath$ here. Includes are always relative to the main file, not the project
-      CompilerWrite("INCLUDEPATH"+Chr(9)+GetPathPart(*Target\FileName$))
-      
-      If *Target\FileName$ <> SourceFileName$
-        CompilerWrite("SOURCEALIAS"+Chr(9)+*Target\FileName$)
-      EndIf
-    EndIf
-    
-    If *Target\LinkerOptions$ <> ""
-      CompilerWrite("LINKER"+Chr(9)+ResolveRelativePath(BasePath$, *Target\LinkerOptions$))
-    EndIf
-    
-    CompilerIf #CompileWindows
-      ResourceFile$ = CreateResourceFile(*Target)
-      If ResourceFile$
-        CompilerWrite("RESOURCE"+Chr(9)+ResourceFile$)
-      EndIf
-    CompilerEndIf
-    
-    CompilerIf Not #SpiderBasic
-      CompilerIf #CompileWindows | #CompileMac
-        If *Target\UseIcon
-          CompilerWrite("ICON"+Chr(9)+ResolveRelativePath(BasePath$, *Target\IconName$))
-        EndIf
-      CompilerEndIf
-    CompilerEndIf
-    
-    Compiler_SetConstants(*Target, CreateExe)
-    
-    Command$ = Compiler_BuildCommandFlags(*Target, CheckSyntax, CreateExe)
-    
-    CompilerIf Not #SpiderBasic
-      If CreateExe Or *Target\ExecutableFormat = 2
-        Command$ = RemoveString(Command$, Chr(9)+"DEBUGGER") ; ensure the debug flag is not set
-      EndIf
-    CompilerEndIf
-    
-    If *Target\ExecutableFormat = 2
-      Command$ + Chr(9) + "DLL"
-    EndIf
-    
-    CompilerWrite(Command$)
-    
-    ; We need the *ActiveSource for HandleCompilerResponse if the mainfile option is set
-    If *Target = @CompileSource
-      *Target = *ActiveSource
-    EndIf
-    
-    ; Handles the error and progress display
-    ; We do not care here if the compilation succeeded
-    ;
-    If Compiler_HandleCompilerResponse(*Target)
-      
-      ; Project targets run the tool outside of this function, so do it only for non-project
-      ; (need to clean this up somewhen)
-      ;
-      If *Target\IsProject = 0
-        AddTools_ExecutableName$ = TargetFileName$
-        AddTools_Execute(#TRIGGER_AfterCreateExe, *Target)
-      EndIf
-      
-      If CheckSyntax
-        Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] Syntax check finished ("+Str(*Target\LastCompiledLines)+" lines)", Date())
-      EndIf
-      
-      ProcedureReturn #True
+          EndIf
+          
+          If *Target\EnableResourceDirectory
+            ResourceDirectory$ = *Target\ResourceDirectory$
+          EndIf
+          
+        Case #AppFormatiOS
+          
+          TargetFileName$ = ResolveRelativePath(BasePath$, TargetFileName$) ; Ensures it's a fullpath
+          
+          AppName$      = *Target\iOSAppName$
+          Icon$         = *Target\iOSAppIcon$
+          AppVersion$   = *Target\iOSAppVersion$
+          PackageID$    = *Target\iOSAppPackageID$
+          StartupImage$ = *Target\iOSAppStartupImage$
+          AppDebugger   = *Target\iOSAppEnableDebugger
+          
+          Select *Target\iOSAppOrientation ; Default case is Any, and we don't need to send it to the compiler
+            Case 1
+              Orientation$ = "PORTRAIT"
+              
+            Case 2
+              Orientation$ = "LANDSCAPE"
+          EndSelect
+          
+          If *Target\iOSAppEnableResourceDirectory
+            ResourceDirectory$ = *Target\iOSAppResourceDirectory$
+          EndIf
+          
+        Case #AppFormatAndroid
+          
+          TargetFileName$ = ResolveRelativePath(BasePath$, TargetFileName$) ; Ensures it's a fullpath, or APK creation can fail (http://forums.spiderbasic.com/viewtopic.php?f=11&t=892)
+          
+          AppName$      = *Target\AndroidAppName$
+          Icon$         = *Target\AndroidAppIcon$
+          AppVersion$   = *Target\AndroidAppVersion$
+          PackageID$    = *Target\AndroidAppPackageID$
+          IAPKey$       = *Target\AndroidAppIAPKey$
+          StartupImage$ = *Target\AndroidAppStartupImage$
+          AppDebugger   = *Target\AndroidAppEnableDebugger
+          
+          Select *Target\AndroidAppOrientation ; Default case is Any, and we don't need to send it to the compiler
+            Case 1
+              Orientation$ = "PORTRAIT"
+              
+            Case 2
+              Orientation$ = "LANDSCAPE"
+          EndSelect
+          
+          If *Target\AndroidAppEnableResourceDirectory
+            ResourceDirectory$ = *Target\AndroidAppResourceDirectory$
+          EndIf
+          
+      EndSelect
     Else
-      ProcedureReturn #False
+      AppName$ = *Target\WebAppName$ ; We always use the webapp appname when compile/run the app
+      If *Target\WebAppIcon$
+        Icon$ = ResolveRelativePath(BasePath$, *Target\WebAppIcon$)
+      EndIf
     EndIf
-  EndProcedure
+    
+    CompilerWriteStringValue("WINDOWTHEME", *Target\WindowTheme$)
+    CompilerWriteStringValue("GADGETTHEME", *Target\GadgetTheme$)
+    
+    CompilerWriteStringValue("APPNAME", AppName$)
+    CompilerWriteStringValue("ICON", Icon$)
+    CompilerWriteStringValue("APPVERSION", AppVersion$)
+    CompilerWriteStringValue("PACKAGEID", PackageID$)
+    CompilerWriteStringValue("IAPKEY", IAPKey$)
+    CompilerWriteStringValue("STARTUPIMAGE", StartupImage$)
+    CompilerWriteStringValue("RESOURCEDIRECTORY", ResourceDirectory$)
+    CompilerWriteStringValue("ORIENTATION", Orientation$)
+    
+  CompilerEndIf
+  
+  CompilerWrite("SOURCE"+Chr(9)+SourceFileName$)
+  CompilerWrite("TARGET"+Chr(9)+TargetFileName$)
+  
+  If *Target\FileName$ <> ""
+    ; do not use the BasePath$ here. Includes are always relative to the main file, not the project
+    CompilerWrite("INCLUDEPATH"+Chr(9)+GetPathPart(*Target\FileName$))
+    
+    If *Target\FileName$ <> SourceFileName$
+      CompilerWrite("SOURCEALIAS"+Chr(9)+*Target\FileName$)
+    EndIf
+  EndIf
+  
+  If *Target\LinkerOptions$ <> ""
+    CompilerWrite("LINKER"+Chr(9)+ResolveRelativePath(BasePath$, *Target\LinkerOptions$))
+  EndIf
+  
+  CompilerIf #CompileWindows
+    ResourceFile$ = CreateResourceFile(*Target)
+    If ResourceFile$
+      CompilerWrite("RESOURCE"+Chr(9)+ResourceFile$)
+    EndIf
+  CompilerEndIf
+  
+  CompilerIf Not #SpiderBasic
+    CompilerIf #CompileWindows | #CompileMac
+      If *Target\UseIcon
+        CompilerWrite("ICON"+Chr(9)+ResolveRelativePath(BasePath$, *Target\IconName$))
+      EndIf
+    CompilerEndIf
+  CompilerEndIf
+  
+  Compiler_SetConstants(*Target, CreateExe)
+  
+  Command$ = Compiler_BuildCommandFlags(*Target, CheckSyntax, CreateExe)
+  
+  CompilerIf Not #SpiderBasic
+    If CreateExe Or *Target\ExecutableFormat = 2
+      Command$ = RemoveString(Command$, Chr(9)+"DEBUGGER") ; ensure the debug flag is not set
+    EndIf
+  CompilerEndIf
+  
+  If *Target\ExecutableFormat = 2
+    Command$ + Chr(9) + "DLL"
+  EndIf
+  
+  CompilerWrite(Command$)
+  
+  ; We need the *ActiveSource for HandleCompilerResponse if the mainfile option is set
+  If *Target = @CompileSource
+    *Target = *ActiveSource
+  EndIf
+  
+  ; Handles the error and progress display
+  ; We do not care here if the compilation succeeded
+  ;
+  If Compiler_HandleCompilerResponse(*Target)
+    
+    ; Project targets run the tool outside of this function, so do it only for non-project
+    ; (need to clean this up somewhen)
+    ;
+    If *Target\IsProject = 0
+      AddTools_ExecutableName$ = TargetFileName$
+      AddTools_Execute(#TRIGGER_AfterCreateExe, *Target)
+    EndIf
+    
+    If CheckSyntax
+      Debugger_AddLog_BySource(*ActiveSource, "[COMPILER] Syntax check finished ("+Str(*Target\LastCompiledLines)+" lines)", Date())
+    EndIf
+    
+    ProcedureReturn #True
+  Else
+    ProcedureReturn #False
+  EndIf
+EndProcedure

--- a/PureBasicIDE/EditHistory.pb
+++ b/PureBasicIDE/EditHistory.pb
@@ -61,1596 +61,1619 @@ EndImport
 ;- Libmba stuff
 ;
 CompilerIf #CompileWindows
-  ImportC #BUILD_DIRECTORY + "libmba/libmba.lib"
-  CompilerElse
-    ImportC #BUILD_DIRECTORY + "libmba/libmba.a"
-    CompilerEndIf
-    
-    diff.l(*a, aoff.l, n.l, *b, boff.l, m.l, *idx_fn, *cmp_fn, *context, dmax.l, *ses, *sn.LONG, *buf)
-    
-    varray_new(membsize, *al)
-    varray_del.l(*va)
-    varray_get(*va, idx)
-    
-  EndImport
+  #Diff_Library = "libmba/libmba.lib"
+CompilerElse
+  #Diff_Library = "libmba/libmba.a"
+CompilerEndIf
+
+ImportC #BUILD_DIRECTORY + #Diff_Library
   
-  Enumeration
-    #DIFF_MATCH = 1
-    #DIFF_DELETE
-    #DIFF_INSERT
-  EndEnumeration
+  diff.l(*a, aoff.l, n.l, *b, boff.l, m.l, *idx_fn, *cmp_fn, *context, dmax.l, *ses, *sn.LONG, *buf)
   
-  Structure diff_edit Align #PB_Structure_AlignC
-    op.u
-    __padding.b[2]  ; on all os
-    off.l           ; /* off into s1 if MATCH or DELETE but s2 if INSERT */
-    len.l
-  EndStructure
+  varray_new(membsize, *al)
+  varray_del.l(*va)
+  varray_get(*va, idx)
   
-  ;- Data types in history
-  ;
-  Enumeration 1
-    #DATA_Empty ; data is null. the file is empty
-    #DATA_Same  ; data is null. the file is the same as on the previous event
-    #DATA_Diff  ; data is a diff since the previous event
-    #DATA_Full  ; data is the full file content (this is the case for new files in a session that are not empty)
-    #DATA_DiffZ ; data is a diff (zlib compressed)
-    #DATA_FullZ ; data is full file (zlib compressed)
-  EndEnumeration
+EndImport
+
+Enumeration
+  #DIFF_MATCH = 1
+  #DIFF_DELETE
+  #DIFF_INSERT
+EndEnumeration
+
+Structure diff_edit Align #PB_Structure_AlignC
+  op.u
+  __padding.b[2]  ; on all os
+  off.l           ; /* off into s1 if MATCH or DELETE but s2 if INSERT */
+  len.l
+EndStructure
+
+;- Data types in history
+;
+Enumeration 1
+  #DATA_Empty ; data is null. the file is empty
+  #DATA_Same  ; data is null. the file is the same as on the previous event
+  #DATA_Diff  ; data is a diff since the previous event
+  #DATA_Full  ; data is the full file content (this is the case for new files in a session that are not empty)
+  #DATA_DiffZ ; data is a diff (zlib compressed)
+  #DATA_FullZ ; data is full file (zlib compressed)
+EndEnumeration
+
+; asynchronous handling of events for speed
+Structure HistoryEvent
+  *QueueNext.HistoryEvent ; next event in queue
+  *ProcessedNext.HistoryEvent ; next in list of processed events
+  SourceID.i                  ; id of the originating source
+  HistoryName.s               ; filename or unique name for new files
+  Encoding.l
+  Event.l
+  Time.l
+  *Content      ; 0 if size=0
+  Size.l
+  Checksum.l
+  FreshFile.l   ; has the file been saved?
+  DiffCount.l   ; number of diffs written since the last full source (updated when the event is written)
+  EventID.l     ; this is known after the event is written and used by the followup event
+EndStructure
+
+Structure EventSource
+  EventID.l
+  Encoding.l
+  *Buffer   ; never #null (0-size event sources are not cached)
+  Size.l
+EndStructure
+
+Global NewList EventSourceCache.EventSource()
+
+Global OSSessionID$, SessionID
+Global CurrentHistoryFile$, CurrentHistorySource
+Global CompilerVersionWritten = #False
+Global StartOfDay
+Global CurrentUser$ = UserName()
+Global NewMap HistoryFirstLines.i() ; map of first displayed lines for each file
+
+Global NewList *HistoryEvents.HistoryEvent()
+Global *HistoryMutex = CreateMutex()
+Global *HistorySemaphore = CreateSemaphore()
+
+; Note: cannot use a LinkedList as it is not threadsafe
+Global *HistoryQueueHead.HistoryEvent = 0
+Global *HistoryQueueTail.HistoryEvent = 0
+
+; List of already processed events (one per file) managed by the thread only
+Global *HistoryFirstProcessed.HistoryEvent = 0
+
+Declare History_EventThread(*Dummy)
+
+Procedure.s SqlEscape(String$)
+  ProcedureReturn ReplaceString(String$, "'", "''")
+EndProcedure
+
+CompilerIf #PB_Compiler_Debugger
   
-  ; asynchronous handling of events for speed
-  Structure HistoryEvent
-    *QueueNext.HistoryEvent ; next event in queue
-    *ProcessedNext.HistoryEvent ; next in list of processed events
-    SourceID.i                  ; id of the originating source
-    HistoryName.s               ; filename or unique name for new files
-    Encoding.l
-    Event.l
-    Time.l
-    *Content      ; 0 if size=0
-    Size.l
-    Checksum.l
-    FreshFile.l   ; has the file been saved?
-    DiffCount.l   ; number of diffs written since the last full source (updated when the event is written)
-    EventID.l     ; this is known after the event is written and used by the followup event
-  EndStructure
-  
-  Structure EventSource
-    EventID.l
-    Encoding.l
-    *Buffer   ; never #null (0-size event sources are not cached)
-    Size.l
-  EndStructure
-  
-  Global NewList EventSourceCache.EventSource()
-  
-  Global OSSessionID$, SessionID
-  Global CurrentHistoryFile$, CurrentHistorySource
-  Global CompilerVersionWritten = #False
-  Global StartOfDay
-  Global CurrentUser$ = UserName()
-  Global NewMap HistoryFirstLines.i() ; map of first displayed lines for each file
-  
-  Global NewList *HistoryEvents.HistoryEvent()
-  Global *HistoryMutex = CreateMutex()
-  Global *HistorySemaphore = CreateSemaphore()
-  
-  ; Note: cannot use a LinkedList as it is not threadsafe
-  Global *HistoryQueueHead.HistoryEvent = 0
-  Global *HistoryQueueTail.HistoryEvent = 0
-  
-  ; List of already processed events (one per file) managed by the thread only
-  Global *HistoryFirstProcessed.HistoryEvent = 0
-  
-  Declare History_EventThread(*Dummy)
-  
-  Procedure.s SqlEscape(String$)
-    ProcedureReturn ReplaceString(String$, "'", "''")
-  EndProcedure
-  
-  CompilerIf #PB_Compiler_Debugger
-    
-    Procedure DatabaseUpdate_DEBUG(db, sql$)
-      Debug "[DB UPDATE] " + sql$
-      r = DatabaseUpdate(db, sql$)
-      If r = 0
-        Debug "[DB FAILURE] " + DatabaseError()
-        CallDebugger
-      EndIf
-      ProcedureReturn r
-    EndProcedure
-    
-    Macro DatabaseUpdate(db, sql)
-      DatabaseUpdate_DEBUG(db, sql)
-    EndMacro
-    
-    Procedure DatabaseQuery_DEBUG(db, sql$)
-      Debug "[DB QUERY] " + sql$
-      r = DatabaseQuery(db, sql$)
-      If r = 0
-        Debug "[DB FAILURE] " + DatabaseError()
-        CallDebugger
-      EndIf
-      ProcedureReturn r
-    EndProcedure
-    
-    Macro DatabaseQuery(db, sql)
-      DatabaseQuery_DEBUG(db, sql)
-    EndMacro
-    
-  CompilerEndIf
-  
-  
-  Procedure.s History_VersionString(CompilerVersion$)
-    Title$ = CompilerVersion$
-    Title$ = RemoveString(Title$, "Windows - ") ; remove the OS part as it is redundant information
-    Title$ = RemoveString(Title$, "Linux - ")
-    Title$ = RemoveString(Title$, "MacOS X - ")
-    Title$ = RemoveString(Title$, #ProductName$ + " ") ; also remove the prefix
-    ProcedureReturn Title$
-  EndProcedure
-  
-  Procedure.s History_GetOption(Key$)
-    Value$ = ""
-    If DatabaseQuery(#DB_History, "SELECT value FROM options WHERE key = '" + SqlEscape(Key$) + "'")
-      If NextDatabaseRow(#DB_History)
-        Value$ = GetDatabaseString(#DB_History, 0)
-      EndIf
-      FinishDatabaseQuery(#DB_History)
+  Procedure DatabaseUpdate_DEBUG(db, sql$)
+    Debug "[DB UPDATE] " + sql$
+    r = DatabaseUpdate(db, sql$)
+    If r = 0
+      Debug "[DB FAILURE] " + DatabaseError()
+      CallDebugger
     EndIf
-    ProcedureReturn Value$
+    ProcedureReturn r
   EndProcedure
   
-  Procedure History_SetOption(Key$, Value$)
-    ; the ON CONFLICT clause of the table causes any old value for the same key to be deleted
-    ; automatically
-    DatabaseUpdate(#DB_History, "INSERT INTO options (key, value) VALUES ('" + SqlEscape(Key$) + "', '" + SqlEscape(Value$) + "')")
+  Macro DatabaseUpdate(db, sql)
+    DatabaseUpdate_DEBUG(db, sql)
+  EndMacro
+  
+  Procedure DatabaseQuery_DEBUG(db, sql$)
+    Debug "[DB QUERY] " + sql$
+    r = DatabaseQuery(db, sql$)
+    If r = 0
+      Debug "[DB FAILURE] " + DatabaseError()
+      CallDebugger
+    EndIf
+    ProcedureReturn r
   EndProcedure
   
-  Procedure StartHistorySession()
+  Macro DatabaseQuery(db, sql)
+    DatabaseQuery_DEBUG(db, sql)
+  EndMacro
+  
+CompilerEndIf
+
+
+Procedure.s History_VersionString(CompilerVersion$)
+  Title$ = CompilerVersion$
+  Title$ = RemoveString(Title$, "Windows - ") ; remove the OS part as it is redundant information
+  Title$ = RemoveString(Title$, "Linux - ")
+  Title$ = RemoveString(Title$, "MacOS X - ")
+  Title$ = RemoveString(Title$, #ProductName$ + " ") ; also remove the prefix
+  ProcedureReturn Title$
+EndProcedure
+
+Procedure.s History_GetOption(Key$)
+  Value$ = ""
+  If DatabaseQuery(#DB_History, "SELECT value FROM options WHERE key = '" + SqlEscape(Key$) + "'")
+    If NextDatabaseRow(#DB_History)
+      Value$ = GetDatabaseString(#DB_History, 0)
+    EndIf
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  ProcedureReturn Value$
+EndProcedure
+
+Procedure History_SetOption(Key$, Value$)
+  ; the ON CONFLICT clause of the table causes any old value for the same key to be deleted
+  ; automatically
+  DatabaseUpdate(#DB_History, "INSERT INTO options (key, value) VALUES ('" + SqlEscape(Key$) + "', '" + SqlEscape(Value$) + "')")
+EndProcedure
+
+Procedure StartHistorySession()
+  
+  ; no setup if history is disabled
+  If EnableHistory = #False
+    ProcedureReturn
+  EndIf
+  
+  ; check threadsafety of sqlite (should be always on)
+  If sqlite3_threadsafe() = 0
+    MessageRequester(#ProductName$, "Critical: sqlite is not compiled threadsafe")
+    End
+  EndIf
+  
+  ; make sure the db file exists
+  If OpenFile(#FILE_Database, HistoryDatabaseFile$)
+    CloseFile(#FILE_Database)
+  EndIf
+  
+  ; open database
+  HistoryActive = OpenDatabase(#DB_History, HistoryDatabaseFile$, "", "", #PB_Database_SQLite)
+  
+  If HistoryActive
     
-    ; no setup if history is disabled
-    If EnableHistory = #False
+    ; Options table: stores unique key value pairs
+    ; This table is used for DB version checks, so do not modify it in the future!
+    DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS options(key TEXT UNIQUE ON CONFLICT REPLACE, value NOT NULL)")
+    
+    ; The minor version is increased when compatible changes are done.
+    ; I.e. a "1.1" IDE can still access a "1.5" database
+    ; The major version is increased when incompatible changes are made to
+    ; prevent corruption of a newer db or confusing old IDE versions
+    ;
+    ; Right now the version is "1.1" and this IDE will access any DB of version "1.X"
+    ;
+    Major$ = History_GetOption("version.major")
+    Minor$ = History_GetOption("version.minor")
+    
+    ; Check for compatible major version
+    If Major$ <> "" And Major$ <> "1"
+      MessageRequester(#ProductName$, LanguagePattern("History", "VersionError", "%filename%", HistoryDatabaseFile$))
+      CloseDatabase(#DB_History)
+      HistoryActive = 0
       ProcedureReturn
     EndIf
     
-    ; check threadsafety of sqlite (should be always on)
-    If sqlite3_threadsafe() = 0
-      MessageRequester(#ProductName$, "Critical: sqlite is not compiled threadsafe")
-      End
+    ; write version options if not present
+    If Major$ = ""
+      History_SetOption("version.major", "1")
+    EndIf
+    If Minor$ = ""
+      History_SetOption("version.minor", "1")
     EndIf
     
-    ; make sure the db file exists
-    If OpenFile(#FILE_Database, HistoryDatabaseFile$)
-      CloseFile(#FILE_Database)
-    EndIf
+    ; Session table:
+    ;   session_id : primary key of table
+    ;   os_id      : ID created by Session_Start() to detect dead instances. set to null for properly ended sessions
+    ;   version    : Compiler version (default compiler of the IDE)
+    ;   user       : OS user name
+    ;   start_time : session start time
+    ;   end_time   : session end time (0 for still running)
+    ;   warned     : 1 if a warning was displayed for a detected dead session
+    ;
+    DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS session(session_id INTEGER PRIMARY KEY, os_id STRING, version TEXT NOT NULL, user TEXT NOT NULL, start_time INTEGER NOT NULL, end_time INTEGER NOT NULL, warned INTEGER NOT NULL)")
     
-    ; open database
-    HistoryActive = OpenDatabase(#DB_History, HistoryDatabaseFile$, "", "", #PB_Database_SQLite)
+    ; Event table:
+    ;   event_id       : primary key
+    ;   session_id     : session id
+    ;   filename       : file name (for new files: "::unsaved::" + unique id + creation time stamp)
+    ;   event          : one of the #HISTORY_XXX values
+    ;   time           : event time stamp
+    ;   type           : one of the #DATA_XXX values
+    ;   previous_event : id of previous event for the file (if any)
+    ;   encoding       : encoding of source file
+    ;   data           : file data or null, depending on type
+    ;
+    DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS event(event_id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL, filename TEXT NOT NULL, event INTEGER NOT NULL, time INTEGER NOT NULL, type INTEGER NOT NULL, previous_event INTEGER, encoding INTEGER NOT NULL, data BLOB)")
     
-    If HistoryActive
-      
-      ; Options table: stores unique key value pairs
-      ; This table is used for DB version checks, so do not modify it in the future!
-      DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS options(key TEXT UNIQUE ON CONFLICT REPLACE, value NOT NULL)")
-      
-      ; The minor version is increased when compatible changes are done.
-      ; I.e. a "1.1" IDE can still access a "1.5" database
-      ; The major version is increased when incompatible changes are made to
-      ; prevent corruption of a newer db or confusing old IDE versions
-      ;
-      ; Right now the version is "1.1" and this IDE will access any DB of version "1.X"
-      ;
-      Major$ = History_GetOption("version.major")
-      Minor$ = History_GetOption("version.minor")
-      
-      ; Check for compatible major version
-      If Major$ <> "" And Major$ <> "1"
-        MessageRequester(#ProductName$, LanguagePattern("History", "VersionError", "%filename%", HistoryDatabaseFile$))
+    ; create indices for fast searching
+    DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_session1 ON session (start_time)")
+    DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_session2 ON session (end_time)")
+    DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_event1 ON event (session_id, filename)")
+    
+    ; get version string
+    ; note: this is probably empty still if the compiler is too slow to load so it will be updated later
+    Title$ = History_VersionString(DefaultCompiler\VersionString$)
+    
+    ; Setup detection of crashed sessions
+    ; The OSSessionID is only unique for currently running sessions
+    ; It is used to detect which unended session is still running and which is crashed
+    OSSessionID$ = Session_Start()
+    
+    DatabaseUpdate(#DB_History, "INSERT INTO session(os_id, version, user, start_time, end_time, warned) values ('" + OSSessionID$ + "', '" + SqlEscape(Title$) + "', '" + SqlEscape(UserName()) + "', " + Str(Date()) + ", 0, 0)")
+    SessionID = sqlite3_last_insert_rowid(DatabaseID(#DB_History))
+    
+    AddWindowTimer(#WINDOW_Main, #TIMER_History, HistoryTimer * 60000) ; value is in minutes
+    
+    ; create thread for asynchronous event writing
+    ; must disable the debugger here, because the thread proc is in DisableDebugger too,
+    ; so the debugger will complain that it does not know the procedure
+    CompilerIf #HISTORY_WRITE_ASYNC
+      DisableDebugger
+      If CreateThread(@History_EventThread(), 0) = 0
+        MessageRequester(#ProductName$, "Critical error: Cannot create thread for session history recording")
         CloseDatabase(#DB_History)
         HistoryActive = 0
-        ProcedureReturn
       EndIf
-      
-      ; write version options if not present
-      If Major$ = ""
-        History_SetOption("version.major", "1")
-      EndIf
-      If Minor$ = ""
-        History_SetOption("version.minor", "1")
-      EndIf
-      
-      ; Session table:
-      ;   session_id : primary key of table
-      ;   os_id      : ID created by Session_Start() to detect dead instances. set to null for properly ended sessions
-      ;   version    : Compiler version (default compiler of the IDE)
-      ;   user       : OS user name
-      ;   start_time : session start time
-      ;   end_time   : session end time (0 for still running)
-      ;   warned     : 1 if a warning was displayed for a detected dead session
-      ;
-      DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS session(session_id INTEGER PRIMARY KEY, os_id STRING, version TEXT NOT NULL, user TEXT NOT NULL, start_time INTEGER NOT NULL, end_time INTEGER NOT NULL, warned INTEGER NOT NULL)")
-      
-      ; Event table:
-      ;   event_id       : primary key
-      ;   session_id     : session id
-      ;   filename       : file name (for new files: "::unsaved::" + unique id + creation time stamp)
-      ;   event          : one of the #HISTORY_XXX values
-      ;   time           : event time stamp
-      ;   type           : one of the #DATA_XXX values
-      ;   previous_event : id of previous event for the file (if any)
-      ;   encoding       : encoding of source file
-      ;   data           : file data or null, depending on type
-      ;
-      DatabaseUpdate(#DB_History, "CREATE TABLE IF NOT EXISTS event(event_id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL, filename TEXT NOT NULL, event INTEGER NOT NULL, time INTEGER NOT NULL, type INTEGER NOT NULL, previous_event INTEGER, encoding INTEGER NOT NULL, data BLOB)")
-      
-      ; create indices for fast searching
-      DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_session1 ON session (start_time)")
-      DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_session2 ON session (end_time)")
-      DatabaseUpdate(#DB_History, "CREATE INDEX IF NOT EXISTS idx_event1 ON event (session_id, filename)")
-      
-      ; get version string
-      ; note: this is probably empty still if the compiler is too slow to load so it will be updated later
-      Title$ = History_VersionString(DefaultCompiler\VersionString$)
-      
-      ; Setup detection of crashed sessions
-      ; The OSSessionID is only unique for currently running sessions
-      ; It is used to detect which unended session is still running and which is crashed
-      OSSessionID$ = Session_Start()
-      
-      DatabaseUpdate(#DB_History, "INSERT INTO session(os_id, version, user, start_time, end_time, warned) values ('" + OSSessionID$ + "', '" + SqlEscape(Title$) + "', '" + SqlEscape(UserName()) + "', " + Str(Date()) + ", 0, 0)")
-      SessionID = sqlite3_last_insert_rowid(DatabaseID(#DB_History))
-      
-      AddWindowTimer(#WINDOW_Main, #TIMER_History, HistoryTimer * 60000) ; value is in minutes
-      
-      ; create thread for asynchronous event writing
-      ; must disable the debugger here, because the thread proc is in DisableDebugger too,
-      ; so the debugger will complain that it does not know the procedure
-      CompilerIf #HISTORY_WRITE_ASYNC
-        DisableDebugger
-        If CreateThread(@History_EventThread(), 0) = 0
-          MessageRequester(#ProductName$, "Critical error: Cannot create thread for session history recording")
-          CloseDatabase(#DB_History)
-          HistoryActive = 0
+      EnableDebugger
+    CompilerEndIf
+    
+  Else
+    MessageRequester(#ProductName$, LanguagePattern("History", "FileError", "%filename%", HistoryDatabaseFile$))
+  EndIf
+  
+EndProcedure
+
+Procedure HistoryCompilerLoaded()
+  If HistoryActive And CompilerVersionWritten = #False
+    Title$ = History_VersionString(DefaultCompiler\VersionString$)
+    DatabaseUpdate(#DB_History, "UPDATE session SET version = '" + SqlEscape(Title$) + "' WHERE session_id = " + Str(SessionID))
+    CompilerVersionWritten = #True
+  EndIf
+EndProcedure
+
+Procedure DetectCrashedHistorySession()
+  If HistoryActive
+    
+    NewList CrashedSID.i()
+    
+    ; get all sessions that are marked as not closed and not warned
+    ; display most recent if multiple crashes (could happen if multiple instances are running and the pc crashes)
+    sql$ = "SELECT session_id, os_id FROM session "
+    sql$ + "WHERE end_time = 0 AND warned = 0 "
+    sql$ + "ORDER BY start_time DESC"
+    
+    If DatabaseQuery(#DB_History, sql$)
+      ; check any hits against the running sessions
+      While NextDatabaseRow(#DB_History)
+        sid   = GetDatabaseLong(#DB_History, 0)
+        OSID$ = GetDatabaseString(#DB_History, 1)
+        
+        If sid <> SessionID And Session_IsRunning(OSID$) = #False
+          AddElement(CrashedSID())
+          CrashedSID() = sid
         EndIf
-        EnableDebugger
-      CompilerEndIf
+      Wend
       
-    Else
-      MessageRequester(#ProductName$, LanguagePattern("History", "FileError", "%filename%", HistoryDatabaseFile$))
+      FinishDatabaseQuery(#DB_History)
     EndIf
     
-  EndProcedure
-  
-  Procedure HistoryCompilerLoaded()
-    If HistoryActive And CompilerVersionWritten = #False
-      Title$ = History_VersionString(DefaultCompiler\VersionString$)
-      DatabaseUpdate(#DB_History, "UPDATE session SET version = '" + SqlEscape(Title$) + "' WHERE session_id = " + Str(SessionID))
-      CompilerVersionWritten = #True
+    If ListSize(CrashedSID()) > 0
+      
+      ; set the warned flag for all these sessions
+      DatabaseUpdate(#DB_History, "BEGIN TRANSACTION")
+      ForEach CrashedSID()
+        DatabaseUpdate(#DB_History, "UPDATE session SET warned = 1 WHERE session_id = " + Str(CrashedSID()))
+      Next CrashedSID()
+      DatabaseUpdate(#DB_History, "COMMIT TRANSACTION")
+      
+      ; ask if the session history should be shown
+      If MessageRequester(#ProductName$, Language("History", "CrashedInfo"), #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
+        FirstElement(CrashedSID())
+        OpenEditHistoryWindow(CrashedSID())
+      EndIf
+      
     EndIf
-  EndProcedure
+    
+    
+  EndIf
+EndProcedure
+
+Procedure History_FlushEvents()
+  CompilerIf #HISTORY_WRITE_ASYNC
+    
+    ; setup a window to display if the wait is too long (hidden)
+    Window.DialogWindow = OpenDialog(?Dialog_HistoryShutdown)
+    SetGadgetState(#GADGET_HistoryShutdown_Progress, #PB_ProgressBar_Unknown)
+    WaitStart.q = ElapsedMilliseconds()
+    Hidden = #True
+    
+    ; wait until the queue is clear
+    ; no need for any locking as it is just a simple check
+    While *HistoryQueueHead
+      WaitWindowEvent(50)
+      
+      If Hidden And (ElapsedMilliseconds() - WaitStart > 250)
+        HideWindow(#WINDOW_EditHistoryShutdown, #False)
+        Hidden = #False
+        
+        CompilerIf #CompileLinuxGtk2
+          gtk_window_set_position_(WindowID(#WINDOW_EditHistoryShutdown), #GTK_WIN_POS_CENTER_ALWAYS)
+        CompilerEndIf
+        
+        CompilerIf #CompileMacCocoa
+          PB_Gadget_CenterWindow(WindowID(#WINDOW_EditHistoryShutdown))
+        CompilerEndIf
+      EndIf
+      
+    Wend
+    
+    Window\Close(0)
+    
+  CompilerEndIf
+EndProcedure
+
+
+Procedure HistoryShutdownEvents()
   
-  Procedure DetectCrashedHistorySession()
-    If HistoryActive
+  If HistoryActive
+    
+    ; write a close event for any still open files
+    ; the ide only saves, but does not close each file on shutdown!
+    ForEach FileList()
+      HistoryEvent(@FileList(), #HISTORY_Close)
+    Next FileList()
+    
+  EndIf
+  
+EndProcedure
+
+
+Procedure EndHistorySession()
+  
+  If HistoryActive
+    
+    ; wait until all these events are written
+    ; the WriteShutdownEvents() procedure can write quite a lot of events, so this could take some time
+    History_FlushEvents()
+    
+    ; write that the session correctly ended
+    DatabaseUpdate(#DB_History, "UPDATE session SET os_id = null, end_time = " + Str(Date()) + " WHERE session_id = " + Str(SessionID))
+    
+    ; end detection of bad sessions
+    Session_End(OSSessionID$)
+    
+    ; Now purge old sessions if needed
+    ;
+    PurgeList$ = ""
+    
+    If HistoryPurgeMode = 1
       
-      NewList CrashedSID.i()
-      
-      ; get all sessions that are marked as not closed and not warned
-      ; display most recent if multiple crashes (could happen if multiple instances are running and the pc crashes)
-      sql$ = "SELECT session_id, os_id FROM session "
-      sql$ + "WHERE end_time = 0 AND warned = 0 "
+      ; purge by session count
+      ; exclude running and crashed (not warned) sessions
+      sql$ = "SELECT session_id FROM session "
+      sql$ + "WHERE end_time <> 0 OR warned = 1 "
       sql$ + "ORDER BY start_time DESC"
       
       If DatabaseQuery(#DB_History, sql$)
-        ; check any hits against the running sessions
+        ; skip the number of sessions to keep
+        Count = 0
+        While Count < MaxSessionCount And NextDatabaseRow(#DB_History)
+          Count + 1
+        Wend
+        
+        ; record sessions for deleting
         While NextDatabaseRow(#DB_History)
-          sid   = GetDatabaseLong(#DB_History, 0)
-          OSID$ = GetDatabaseString(#DB_History, 1)
-          
-          If sid <> SessionID And Session_IsRunning(OSID$) = #False
-            AddElement(CrashedSID())
-            CrashedSID() = sid
-          EndIf
+          PurgeList$ + ", " + Str(GetDatabaseLong(#DB_History, 0))
         Wend
         
         FinishDatabaseQuery(#DB_History)
       EndIf
       
-      If ListSize(CrashedSID()) > 0
+    ElseIf HistoryPurgeMode = 2
+      
+      ; purge by start date
+      CurrentDate = Date()
+      StartOfDay = Date(Year(CurrentDate), Month(CurrentDate), Day(CurrentDate), 0, 0, 0)
+      CutOff = AddDate(StartOfDay, #PB_Date_Day, -MaxSessionDays)
+      
+      ; cut off by end_time
+      ; for crashed sessions, use start time, but exclude not yet warned ones
+      sql$ = "SELECT session_id FROM session "
+      sql$ + "WHERE (end_time < " + Str(CutOff) + " AND end_time <> 0) "
+      sql$ + "OR (end_time = 0 AND start_time < " + Str(CutOff) + " AND warned = 1)"
+      
+      If DatabaseQuery(#DB_History, sql$)
+        ; record sessions for deleting
+        While NextDatabaseRow(#DB_History)
+          PurgeList$ + ", " + Str(GetDatabaseLong(#DB_History, 0))
+        Wend
         
-        ; set the warned flag for all these sessions
-        DatabaseUpdate(#DB_History, "BEGIN TRANSACTION")
-        ForEach CrashedSID()
-          DatabaseUpdate(#DB_History, "UPDATE session SET warned = 1 WHERE session_id = " + Str(CrashedSID()))
-        Next CrashedSID()
-        DatabaseUpdate(#DB_History, "COMMIT TRANSACTION")
-        
-        ; ask if the session history should be shown
-        If MessageRequester(#ProductName$, Language("History", "CrashedInfo"), #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
-          FirstElement(CrashedSID())
-          OpenEditHistoryWindow(CrashedSID())
-        EndIf
-        
+        FinishDatabaseQuery(#DB_History)
       EndIf
-      
-      
-    EndIf
-  EndProcedure
-  
-  Procedure History_FlushEvents()
-    CompilerIf #HISTORY_WRITE_ASYNC
-      
-      ; setup a window to display if the wait is too long (hidden)
-      Window.DialogWindow = OpenDialog(?Dialog_HistoryShutdown)
-      SetGadgetState(#GADGET_HistoryShutdown_Progress, #PB_ProgressBar_Unknown)
-      WaitStart.q = ElapsedMilliseconds()
-      Hidden = #True
-      
-      ; wait until the queue is clear
-      ; no need for any locking as it is just a simple check
-      While *HistoryQueueHead
-        WaitWindowEvent(50)
-        
-        If Hidden And (ElapsedMilliseconds() - WaitStart > 250)
-          HideWindow(#WINDOW_EditHistoryShutdown, #False)
-          Hidden = #False
-          
-          CompilerIf #CompileLinuxGtk2
-            gtk_window_set_position_(WindowID(#WINDOW_EditHistoryShutdown), #GTK_WIN_POS_CENTER_ALWAYS)
-          CompilerEndIf
-          
-          CompilerIf #CompileMacCocoa
-            PB_Gadget_CenterWindow(WindowID(#WINDOW_EditHistoryShutdown))
-          CompilerEndIf
-        EndIf
-        
-      Wend
-      
-      Window\Close(0)
-      
-    CompilerEndIf
-  EndProcedure
-  
-  
-  Procedure HistoryShutdownEvents()
-    
-    If HistoryActive
-      
-      ; write a close event for any still open files
-      ; the ide only saves, but does not close each file on shutdown!
-      ForEach FileList()
-        HistoryEvent(@FileList(), #HISTORY_Close)
-      Next FileList()
       
     EndIf
     
-  EndProcedure
-  
-  
-  Procedure EndHistorySession()
-    
-    If HistoryActive
-      
-      ; wait until all these events are written
-      ; the WriteShutdownEvents() procedure can write quite a lot of events, so this could take some time
-      History_FlushEvents()
-      
-      ; write that the session correctly ended
-      DatabaseUpdate(#DB_History, "UPDATE session SET os_id = null, end_time = " + Str(Date()) + " WHERE session_id = " + Str(SessionID))
-      
-      ; end detection of bad sessions
-      Session_End(OSSessionID$)
-      
-      ; Now purge old sessions if needed
-      ;
-      PurgeList$ = ""
-      
-      If HistoryPurgeMode = 1
+    CompilerIf #HISTORY_PURGE_EMPTY_SESSIONS
+      NewList FoundSessionID$()
+      If DatabaseQuery(#DB_History, "SELECT session_id FROM session")
+        While NextDatabaseRow(#DB_History)
+          AddElement(FoundSessionID$())
+          FoundSessionID$() = GetDatabaseString(#DB_History, 0)
+        Wend
+        FinishDatabaseQuery(#DB_History)
         
-        ; purge by session count
-        ; exclude running and crashed (not warned) sessions
-        sql$ = "SELECT session_id FROM session "
-        sql$ + "WHERE end_time <> 0 OR warned = 1 "
-        sql$ + "ORDER BY start_time DESC"
-        
-        If DatabaseQuery(#DB_History, sql$)
-          ; skip the number of sessions to keep
-          Count = 0
-          While Count < MaxSessionCount And NextDatabaseRow(#DB_History)
-            Count + 1
-          Wend
-          
-          ; record sessions for deleting
-          While NextDatabaseRow(#DB_History)
-            PurgeList$ + ", " + Str(GetDatabaseLong(#DB_History, 0))
-          Wend
-          
-          FinishDatabaseQuery(#DB_History)
-        EndIf
-        
-      ElseIf HistoryPurgeMode = 2
-        
-        ; purge by start date
-        CurrentDate = Date()
-        StartOfDay = Date(Year(CurrentDate), Month(CurrentDate), Day(CurrentDate), 0, 0, 0)
-        CutOff = AddDate(StartOfDay, #PB_Date_Day, -MaxSessionDays)
-        
-        ; cut off by end_time
-        ; for crashed sessions, use start time, but exclude not yet warned ones
-        sql$ = "SELECT session_id FROM session "
-        sql$ + "WHERE (end_time < " + Str(CutOff) + " AND end_time <> 0) "
-        sql$ + "OR (end_time = 0 AND start_time < " + Str(CutOff) + " AND warned = 1)"
-        
-        If DatabaseQuery(#DB_History, sql$)
-          ; record sessions for deleting
-          While NextDatabaseRow(#DB_History)
-            PurgeList$ + ", " + Str(GetDatabaseLong(#DB_History, 0))
-          Wend
-          
-          FinishDatabaseQuery(#DB_History)
-        EndIf
-        
-      EndIf
-      
-      CompilerIf #HISTORY_PURGE_EMPTY_SESSIONS
-        NewList FoundSessionID$()
-        If DatabaseQuery(#DB_History, "SELECT session_id FROM session")
-          While NextDatabaseRow(#DB_History)
-            AddElement(FoundSessionID$())
-            FoundSessionID$() = GetDatabaseString(#DB_History, 0)
-          Wend
-          FinishDatabaseQuery(#DB_History)
-          
-          ForEach FoundSessionID$()
-            If DatabaseQuery(#DB_History, "SELECT COUNT(*) FROM event WHERE session_id='" + FoundSessionID$() + "'")
-              If NextDatabaseRow(#DB_History)
-                If GetDatabaseLong(#DB_History, 0) = 0
-                  PurgeList$ + ", " + FoundSessionID$()
-                EndIf
+        ForEach FoundSessionID$()
+          If DatabaseQuery(#DB_History, "SELECT COUNT(*) FROM event WHERE session_id='" + FoundSessionID$() + "'")
+            If NextDatabaseRow(#DB_History)
+              If GetDatabaseLong(#DB_History, 0) = 0
+                PurgeList$ + ", " + FoundSessionID$()
               EndIf
-              FinishDatabaseQuery(#DB_History)
             EndIf
-          Next
-        EndIf
-        FreeList(FoundSessionID$())
-      CompilerEndIf
-      
-      If PurgeList$ <> ""
-        ; strip beginning ", "
-        PurgeList$ = Mid(PurgeList$, 3)
-        ; purge them all at once
-        DatabaseUpdate(#DB_History, "BEGIN TRANSACTION")
-        DatabaseUpdate(#DB_History, "DELETE FROM event WHERE session_id IN (" + PurgeList$ + ")")
-        DatabaseUpdate(#DB_History, "DELETE FROM session WHERE session_id IN (" + PurgeList$ + ")")
-        DatabaseUpdate(#DB_History, "COMMIT TRANSACTION")
+            FinishDatabaseQuery(#DB_History)
+          EndIf
+        Next
       EndIf
-      
-      ; close db
-      CloseDatabase(#DB_History)
-      
-    EndIf
-  EndProcedure
-  
-  ; Make a unique ID string for file identification
-  ;
-  Procedure.s History_MakeUniqueId()
-    Length = 16
-    Dim Buffer.a(Length-1)
+      FreeList(FoundSessionID$())
+    CompilerEndIf
     
-    If OpenCryptRandom()
-      CryptRandomData(@Buffer(0), Length)
-      CloseCryptRandom()
-    Else
-      RandomData(@Buffer(0), Length)
+    If PurgeList$ <> ""
+      ; strip beginning ", "
+      PurgeList$ = Mid(PurgeList$, 3)
+      ; purge them all at once
+      DatabaseUpdate(#DB_History, "BEGIN TRANSACTION")
+      DatabaseUpdate(#DB_History, "DELETE FROM event WHERE session_id IN (" + PurgeList$ + ")")
+      DatabaseUpdate(#DB_History, "DELETE FROM session WHERE session_id IN (" + PurgeList$ + ")")
+      DatabaseUpdate(#DB_History, "COMMIT TRANSACTION")
     EndIf
     
-    Result$ = ""
-    For i = 0 To Length-1
-      Result$ + RSet(Hex(Buffer(i)), 2, "0")
-    Next i
+    ; close db
+    CloseDatabase(#DB_History)
     
-    ProcedureReturn Result$
-  EndProcedure
+  EndIf
+EndProcedure
+
+; Make a unique ID string for file identification
+;
+Procedure.s History_MakeUniqueId()
+  Length = 16
+  Dim Buffer.a(Length-1)
   
-  CompilerIf #HISTORY_WRITE_ASYNC
-    DisableDebugger
+  If OpenCryptRandom()
+    CryptRandomData(@Buffer(0), Length)
+    CloseCryptRandom()
+  Else
+    RandomData(@Buffer(0), Length)
+  EndIf
+  
+  Result$ = ""
+  For i = 0 To Length-1
+    Result$ + RSet(Hex(Buffer(i)), 2, "0")
+  Next i
+  
+  ProcedureReturn Result$
+EndProcedure
+
+CompilerIf #HISTORY_WRITE_ASYNC
+  DisableDebugger
+CompilerEndIf
+
+Procedure History_FreeEvent(*Event.HistoryEvent)
+  If *Event\Content
+    FreeMemory(*Event\Content)
+  EndIf
+  ClearStructure(*Event, HistoryEvent)
+  FreeMemory(*Event)
+EndProcedure
+
+Procedure History_AsyncUpdateName(PreviousName$, Name$)
+  
+  CompilerIf #HISTORY_WRITE_ASYNC = #False
+    Debug "Async: updating event names: " + PreviousName$ + " to " + Name$
   CompilerEndIf
   
-  Procedure History_FreeEvent(*Event.HistoryEvent)
-    If *Event\Content
-      FreeMemory(*Event\Content)
+  ; Use bind variables as we cannot modify strings in this thread
+  Protected Success.i = #False
+  CompilerIf #PB_Compiler_Unicode
+    If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"UPDATE event SET filename = ? WHERE filename = ? AND session_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+      sqlite3_bind_text16(*Statement, 1, @Name$, -1, #SQLITE_STATIC)
+      sqlite3_bind_text16(*Statement, 2, @PreviousName$, -1, #SQLITE_STATIC)
     EndIf
-    ClearStructure(*Event, HistoryEvent)
-    FreeMemory(*Event)
-  EndProcedure
+  CompilerElse
+    If sqlite3_prepare_v2(DatabaseID(#DB_History), @"UPDATE event SET filename = ? WHERE filename = ? AND session_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+      sqlite3_bind_text(*Statement, 1, @Name$, -1, #SQLITE_STATIC)
+      sqlite3_bind_text(*Statement, 2, @PreviousName$, -1, #SQLITE_STATIC)
+    EndIf
+  CompilerEndIf
   
-  Procedure History_AsyncUpdateName(PreviousName$, Name$)
+  If Success
+    sqlite3_bind_int(*Statement, 3, SessionID)
     
-    CompilerIf #HISTORY_WRITE_ASYNC = #False
-      Debug "Async: updating event names: " + PreviousName$ + " to " + Name$
+    While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
+    sqlite3_finalize(*Statement)
+  EndIf
+  
+  
+EndProcedure
+
+Procedure History_AsyncDeleteEvent(EventID)
+  
+  CompilerIf #HISTORY_WRITE_ASYNC = #False
+    Debug "Async: deleting event with id: " + Str(EventID)
+  CompilerEndIf
+  
+  Protected Success.i = #False
+  CompilerIf #PB_Compiler_Unicode
+    If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"DELETE FROM event WHERE event_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+    EndIf
+  CompilerElse
+    If sqlite3_prepare_v2(DatabaseID(#DB_History), @"DELETE FROM event WHERE event_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+    EndIf
+  CompilerEndIf
+  
+  If Success
+    sqlite3_bind_int(*Statement, 1, EventID)
+    
+    While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
+    sqlite3_finalize(*Statement)
+  EndIf
+  
+EndProcedure
+
+Structure HistoryDiffLine
+  Checksum.l
+  Offset.l
+  Length.l
+EndStructure
+
+Structure HistoryDiffLines
+  Line.HistoryDiffLine[0]
+EndStructure
+
+ProcedureC History_Diff_idx(*Lines.HistoryDiffLines, idx.l, *context)
+  ProcedureReturn @*Lines\Line[idx]
+EndProcedure
+
+ProcedureC History_Diff_cmp(*e1.HistoryDiffLine, *e2.HistoryDiffLine, *context)
+  If *e1\Checksum = *e2\Checksum
+    ProcedureReturn 0
+  Else
+    ProcedureReturn 1
+  EndIf
+EndProcedure
+
+Procedure History_DiffEditSize(*edit.diff_edit, Array Lines.HistoryDiffLine(1))
+  Size = 0
+  Last = *edit\off + *edit\len - 1
+  For index = *edit\off To  Last
+    Size + Lines(index)\Length
+  Next index
+  ProcedureReturn Size
+EndProcedure
+
+Procedure History_DiffPreProcess(*Event.HistoryEvent, Array Lines.HistoryDiffLine(1))
+  *Pointer.PTR = *Event\Content
+  *BufferEnd = *Pointer + *Event\Size
+  
+  Lines = 0
+  Space = ArraySize(Lines()) ; don't do +1 to have the extra space for the last line
+  
+  *LineStart = *Pointer
+  While *Pointer < *BufferEnd
+    
+    ; detect next newline
+    If *Pointer\b = 13
+      *Pointer + 1
+      If *Pointer < *BufferEnd And *Pointer\b = 10
+        *Pointer + 1
+      EndIf
+    ElseIf *Pointer\b = 10
+      *Pointer + 1
+    Else
+      ; no newline
+      *Pointer + 1
+      Continue
+    EndIf
+    
+    ; newline found
+    If Space = 0
+      ReDim Lines(Lines * 2)
+      Space = Lines
+    EndIf
+    
+    Lines(Lines)\Checksum = CRC32Fingerprint(*LineStart, *Pointer-*LineStart)
+    Lines(Lines)\Offset = *LineStart - *Event\Content
+    Lines(Lines)\Length = *Pointer - *LineStart
+    Lines + 1
+    Space - 1
+    *LineStart = *Pointer
+  Wend
+  
+  ; add the last line
+  If *Pointer > *LineStart
+    Lines(Lines)\Checksum = CRC32Fingerprint(*LineStart, *Pointer-*LineStart)
+    Lines(Lines)\Offset = *Pointer - *Event\Content
+    Lines(Lines)\Length = *Pointer - *LineStart
+    Lines + 1
+  EndIf
+  
+  ProcedureReturn Lines
+EndProcedure
+
+; Generates an edit script:
+; Beginning: <long> full size of target
+;
+; C<long> : copy from source
+; D<long> : skip from source
+; A<long><content> : add content from diff
+;
+; returns size of diff'ed content
+; returns 0 if diff is larger than real file
+Procedure History_MakeDiff(*Output, *OutSize.INTEGER, *Event.HistoryEvent, *Previous.HistoryEvent)
+  Protected Dim NewLines.HistoryDiffLine(1000)
+  Protected Dim OldLines.HistoryDiffLine(1000)
+  
+  LinesNew = History_DiffPreProcess(*Event, NewLines())
+  LinesOld = History_DiffPreProcess(*Previous, OldLines())
+  
+  *ses = varray_new(SizeOf(diff_edit), #Null)
+  sn.l = 0
+  
+  diff(@OldLines(0), 0, LinesOld, @NewLines(0), 0, LinesNew, @History_Diff_idx(), @History_Diff_cmp(), #Null, 0, *ses, @sn, 0)
+  
+  *OutputEnd = *Output + *OutSize\i
+  *Pointer.PTR = *Output
+  *Pointer\l = *Event\Size ; store original size
+  *Pointer + 4             ; skip original size storage
+  
+  For i = 0 To sn-1
+    *edit.diff_edit = varray_get(*ses, i)
+    If *Pointer + 5 > *OutputEnd
+      varray_del(*ses)
+      ProcedureReturn #False
+    EndIf
+    
+    Select *edit\op
+      Case #DIFF_MATCH
+        *Pointer\b = 'C': *Pointer + 1
+        *Pointer\l = History_DiffEditSize(*edit, OldLines()): *Pointer + 4
+        
+      Case #DIFF_DELETE
+        *Pointer\b = 'D': *Pointer + 1
+        *Pointer\l = History_DiffEditSize(*edit, OldLines()): *Pointer + 4
+        
+      Case #DIFF_INSERT
+        *Pointer\b = 'A': *Pointer + 1
+        EditSize = History_DiffEditSize(*edit, NewLines())
+        *Pointer\l = EditSize: *Pointer + 4
+        
+        If *Pointer + EditSize > *OutputEnd
+          varray_del(*ses)
+          ProcedureReturn #False
+        EndIf
+        
+        CopyMemory(*Event\Content + NewLines(*edit\off)\Offset, *Pointer, EditSize)
+        *Pointer + EditSize
+        
+    EndSelect
+  Next i
+  
+  varray_del(*ses)
+  
+  *OutSize\i = *Pointer - *Output
+  ProcedureReturn #True
+EndProcedure
+
+
+Procedure History_ApplyDiff(*Output, *PreviousBuffer, *Diff.PTR, DiffSize)
+  
+  *DiffEnd = *Diff + DiffSize
+  
+  *Diff + 4 ; skip expanded size
+  
+  While *Diff < *DiffEnd
+    Select *Diff\b
+        
+      Case 'C'
+        *Diff + 1
+        Size = *Diff\l: *Diff + 4
+        CopyMemory(*PreviousBuffer, *Output, Size)
+        *PreviousBuffer + Size
+        *Output + Size
+        
+      Case 'D'
+        *Diff + 1
+        Size = *Diff\l: *Diff + 4
+        ; just skip on the input
+        *PreviousBuffer + Size
+        
+      Case 'A'
+        *Diff + 1
+        Size = *Diff\l: *Diff + 4
+        CopyMemory(*Diff, *Output, Size)
+        *Diff + Size
+        *Output + Size
+        
+      Default
+        ; something is wrong here
+        ProcedureReturn #False
+        
+    EndSelect
+  Wend
+  
+  ProcedureReturn #True
+EndProcedure
+
+Procedure History_WriteEvent(*Event.HistoryEvent)
+  
+  ; calculate checksum if needed
+  If *Event\Checksum = 0 And *Event\Content And *Event\Size
+    *Event\Checksum = CRC32Fingerprint(*Event\Content, *Event\Size)
+  EndIf
+  
+  ; find any previous event for the same source and remove it from the list
+  ; this list is accessed only by this thread
+  *Update.HistoryEvent = 0 ; the one to update on a delete
+  *Previous.HistoryEvent = *HistoryFirstProcessed
+  While *Previous And *Previous\SourceID <> *Event\SourceID
+    *Update = *Previous
+    *Previous = *Previous\ProcessedNext
+  Wend
+  
+  ; previous event found
+  If *Previous
+    
+    ; If the Event is #HISTORY_Edit, decide if there were changes
+    ; Drop the event if there were no changes since last time
+    If *Event\Event = #HISTORY_Edit And *Previous\Size = *Event\Size And *Previous\Checksum = *Event\Checksum
+      History_FreeEvent(*Event)
+      ProcedureReturn
+    EndIf
+    
+    ; unlink the previous event from list
+    If *Update
+      *Update\ProcessedNext = *Previous\ProcessedNext
+    Else
+      *HistoryFirstProcessed = *Previous\ProcessedNext
+    EndIf
+    
+    ; if the event is close, and the only previous event is open or create,
+    ; drop both from the db to avoid lots of empty open/close event combinations
+    If *Event\Event = #HISTORY_Close And (*Previous\Event = #HISTORY_Create Or *Previous\Event = #HISTORY_Open)
+      History_AsyncDeleteEvent(*Previous\EventID)
+      History_FreeEvent(*Previous)
+      History_FreeEvent(*Event)
+      ProcedureReturn
+    EndIf
+    
+    ; if a fresh file is saved, rename all old events to the new filename
+    If *Event\Event = #HISTORY_SaveAs And *Previous\FreshFile
+      History_AsyncUpdateName(*Previous\HistoryName, *Event\HistoryName)
+    EndIf
+    
+  EndIf
+  
+  ; prepare/compress the contents for storage
+  StorageSize = 0
+  *StorageBuffer = #Null
+  
+  If *Event\Content = #Null
+    Type = #DATA_Empty
+    PreviousEventID = 0
+    *Event\DiffCount = 0
+    
+  ElseIf *Previous = #Null Or *Previous\Content = #Null Or *Previous\DiffCount >= #HISTORY_EVENT_MAX_DIFFS
+    ; write full data if no previous data exists, or the max diff count is reached
+    Type = #DATA_Full
+    PreviousEventID = 0
+    StorageSize = *Event\Size
+    *StorageBuffer = *Event\Content
+    
+    ; attempt to compress
+    CompilerIf #ENABLE_HISTORY_COMPRESSION
+      CompressedSize = compressBound(*Event\Size) + 4
+      *CompressedBuffer = AllocateMemory(CompressedSize)
+      If *CompressedBuffer
+        CompressedSize - 4
+        If compress2(*CompressedBuffer + 4, @CompressedSize, *Event\Content , *Event\Size, #HISTORY_COMPRESSION_LEVEL) = #Z_OK
+          Type = #DATA_FullZ
+          PokeL(*CompressedBuffer, *Event\Size) ; store original size in first 4 bytes
+          StorageSize = CompressedSize + 4
+          *StorageBuffer = *CompressedBuffer
+        Else
+          FreeMemory(*CompressedBuffer)
+        EndIf
+      EndIf
+    CompilerEndIf
+    *Event\DiffCount = 0
+    
+  ElseIf *Event\Size = *Previous\Size And *Event\Checksum = *Previous\Checksum
+    Type = #DATA_Same
+    PreviousEventID = *Previous\EventID
+    *Event\DiffCount = *Previous\DiffCount + 1
+    
+  Else
+    ; fallback to full if something fails below
+    Type = #DATA_Full
+    PreviousEventID = 0
+    StorageSize = *Event\Size
+    *StorageBuffer = *Event\Content
+    *Event\DiffCount = *Previous\DiffCount + 1
+    
+    ; try to diff
+    *DiffBuffer = AllocateMemory(StorageSize + 4) ; 4 bytes for the unpacked size
+    If *DiffBuffer
+      DiffSize = StorageSize + 4
+      If History_MakeDiff(*DiffBuffer, @DiffSize, *Event, *Previous)
+        Type = #DATA_Diff
+        *StorageBuffer = *DiffBuffer
+        StorageSize = DiffSize
+        PreviousEventID = *Previous\EventID
+      Else
+        FreeMemory(*DiffBuffer) ; diff is larger than original!
+        *DiffBuffer = 0
+      EndIf
+    EndIf
+    
+    ; attempt to compress
+    CompilerIf #ENABLE_HISTORY_COMPRESSION
+      CompressedSize = compressBound(StorageSize) + 4
+      *CompressedBuffer = AllocateMemory(CompressedSize)
+      If *CompressedBuffer
+        CompressedSize - 4
+        If compress2(*CompressedBuffer + 4, @CompressedSize, *StorageBuffer, StorageSize, #HISTORY_COMPRESSION_LEVEL) = #Z_OK
+          If Type = #DATA_Diff
+            Type = #DATA_DiffZ
+            FreeMemory(*DiffBuffer) ; diff buffer is no longer needed. storagebuffer is overwritten below
+          Else
+            Type = #DATA_FullZ
+          EndIf
+          PokeL(*CompressedBuffer, StorageSize) ; store original size in first 4 bytes
+          StorageSize = CompressedSize + 4
+          *StorageBuffer = *CompressedBuffer
+        Else
+          FreeMemory(*CompressedBuffer)
+        EndIf
+      EndIf
     CompilerEndIf
     
-    ; Use bind variables as we cannot modify strings in this thread
-    CompilerIf #PB_Compiler_Unicode
-      If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"UPDATE event SET filename = ? WHERE filename = ? AND session_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
-        sqlite3_bind_text16(*Statement, 1, @Name$, -1, #SQLITE_STATIC)
-        sqlite3_bind_text16(*Statement, 2, @PreviousName$, -1, #SQLITE_STATIC)
-      CompilerElse
-        If sqlite3_prepare_v2(DatabaseID(#DB_History), @"UPDATE event SET filename = ? WHERE filename = ? AND session_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
-          sqlite3_bind_text(*Statement, 1, @Name$, -1, #SQLITE_STATIC)
-          sqlite3_bind_text(*Statement, 2, @PreviousName$, -1, #SQLITE_STATIC)
-        CompilerEndIf
-        sqlite3_bind_int(*Statement, 3, SessionID)
+  EndIf
+  
+  ; Update the DB
+  ; We cannot use the Database functions for thread safety
+  ; Use the sqlite functions directly
+  ; In PB, sqlite is compiled threadsafe, so this is ok
+  CompilerIf #HISTORY_WRITE_ASYNC = #False
+    Debug "Async: writing history event: " + Str(*Event\Event)
+  CompilerEndIf
+  
+  ; Use bind variables as we cannot modify strings in this thread
+  Protected Success.i = #False
+  CompilerIf #PB_Compiler_Unicode
+    If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"INSERT INTO event(session_id, filename, event, time, type, previous_event, encoding, data) VALUES (?,?,?,?,?,?,?,?)", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+      sqlite3_bind_int (*Statement, 1, SessionID)
+      sqlite3_bind_text16(*Statement, 2, @*Event\HistoryName, -1, #SQLITE_STATIC)
+    EndIf
+  CompilerElse
+    If sqlite3_prepare_v2(DatabaseID(#DB_History), @"INSERT INTO event(session_id, filename, event, time, type, previous_event, encoding, data) VALUES (?,?,?,?,?,?,?,?)", -1, @*Statement, #Null) = #SQLITE_OK
+      Success = #True
+      sqlite3_bind_int (*Statement, 1, SessionID)
+      sqlite3_bind_text(*Statement, 2, @*Event\HistoryName, -1, #SQLITE_STATIC)
+    EndIf
+  CompilerEndIf
+  
+  If Success
+    sqlite3_bind_int (*Statement, 3, *Event\Event)
+    sqlite3_bind_int (*Statement, 4, *Event\Time)
+    sqlite3_bind_int (*Statement, 5, Type)
+    sqlite3_bind_int (*Statement, 6, PreviousEventID)
+    sqlite3_bind_int (*Statement, 7, *Event\Encoding)
+    
+    If *StorageBuffer
+      sqlite3_bind_blob(*Statement, 8, *StorageBuffer, StorageSize, #SQLITE_STATIC)
+    Else
+      sqlite3_bind_null(*Statement, 8)
+    EndIf
+    
+    While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
+    sqlite3_finalize(*Statement)
+    
+    ; retrieve the event id
+    *Event\EventID = sqlite3_last_insert_rowid(DatabaseID(#DB_History))
+  EndIf
+  
+  ; free compressed buffer
+  If *StorageBuffer And *StorageBuffer <> *Event\Content
+    FreeMemory(*StorageBuffer)
+  EndIf
+  
+  ; free the previous event info
+  If *Previous
+    History_FreeEvent(*Previous)
+  EndIf
+  
+  ; if this is a close, free the current event
+  ; otherwise store it for reference on the next one
+  If *Event\Event = #HISTORY_Close
+    History_FreeEvent(*Event)
+    
+  Else
+    *Event\ProcessedNext = *HistoryFirstProcessed
+    *HistoryFirstProcessed = *Event
+    
+  EndIf
+  
+EndProcedure
+
+
+Procedure History_EventThread(*Dummy)
+  
+  Repeat
+    
+    ; wait and get the next event to process
+    WaitSemaphore(*HistorySemaphore)
+    LockMutex(*HistoryMutex)
+    *Event.HistoryEvent = *HistoryQueueHead
+    *HistoryQueueHead = *Event\QueueNext
+    If *HistoryQueueHead = 0
+      *HistoryQueueTail = 0
+    EndIf
+    UnlockMutex(*HistoryMutex)
+    
+    ; write the event
+    History_WriteEvent(*Event)
+    
+  ForEver
+  
+EndProcedure
+
+CompilerIf #HISTORY_WRITE_ASYNC
+  EnableDebugger
+CompilerEndIf
+
+
+Procedure HistoryEvent(*Source.SourceFile, Event)
+  If HistoryActive And *Source <> *ProjectInfo And *Source\IsForm = #False
+    Debug "[HISTORY] Event: " + Str(Event)
+    
+    ; Behavior for SaveAs
+    ; - for fresh files, the writing procedure will rename all previous events to the new name
+    ;   so all events have the identity of the saved name, even the older ones
+    ; - for old files. write a 'close' event for the old file name. then the normal
+    ;   SaveAs for the new filename to separate the two now existing streams of events
+    If Event = #HISTORY_SaveAs And *Source\FreshFile = #False
+      HistoryEvent(*Source, #HISTORY_Close)
+    EndIf
+    
+    Size = ScintillaSendMessage(*Source\EditorGadget, #SCI_GETLENGTH, 0, 0)
+    If Size > HistoryMaxFileSize
+      
+      ; Size checking works like this:
+      ; If the file is too large on open, it is excluded entirely (ExludeFromHistory = true)
+      ; If the file was small but grows to large, write no events but the
+      ; close event, so the event log is consistent
+      ;
+      If Event = #HISTORY_Open
+        *Source\ExcludeFromHistory = #True
+        ProcedureReturn
+      ElseIf *Source\ExcludeFromHistory = #False And Event <> #HISTORY_CLOSE
+        ProcedureReturn
+      EndIf
+    EndIf
+    
+    ; change HistoryName if needed
+    ;
+    If Event = #HISTORY_Create
+      ; make a unique name for this unsaved file. append the creation date so it can later be used for display
+      *Source\HistoryName = "::unsaved::" + History_MakeUniqueID() + Str(Date())
+      *Source\FreshFile = #True
+      
+    ElseIf Event = #HISTORY_Open Or Event = #HISTORY_Save Or Event = #HISTORY_SaveAs
+      *Source\HistoryName = *Source\FileName$
+      *Source\FreshFile = #False
+      
+    EndIf
+    
+    ; get the content
+    If Size = 0
+      *Buffer = #Null
+    Else
+      *Buffer = AllocateMemory(Size+1)
+      ScintillaSendMessage(*Source\EditorGadget,#SCI_GETTEXT, Size+1, *Buffer)
+    EndIf
+    
+    ; enqueue a task to write this event in the thread
+    ; this gives significant speedup when loading many files at once (like on startup)
+    *Event.HistoryEvent = AllocateMemory(SizeOf(HistoryEvent))
+    *Event\SourceID     = *Source\ID
+    *Event\HistoryName  = *Source\HistoryName
+    *Event\Encoding     = *Source\Parser\Encoding
+    *Event\Event        = Event
+    *Event\Time         = Date()
+    *Event\Content      = *Buffer
+    *Event\Size         = Size
+    *Event\Checksum     = 0 ; not yet calculated
+    *Event\FreshFile    = *Source\FreshFile
+    *Event\EventID      = -1 ; set by the thread when writing the event
+    
+    CompilerIf #HISTORY_WRITE_ASYNC
+      LockMutex(*HistoryMutex)
+      If *HistoryQueueTail = 0
+        ; queue is empty
+        *HistoryQueueHead = *Event
+        *HistoryQueueTail = *Event
+      Else
+        *HistoryQueueTail\QueueNext = *Event
+        *HistoryQueueTail = *Event
+      EndIf
+      UnlockMutex(*HistoryMutex)
+      SignalSemaphore(*HistorySemaphore)
+      
+    CompilerElse
+      History_WriteEvent(*Event)
+      
+    CompilerEndIf
+    
+  EndIf
+EndProcedure
+
+Procedure HistoryTimer()
+  If HistoryActive
+    
+    ForEach FileList()
+      If @FileList() <> *ProjectInfo And FileList()\IsForm = 0 And FileList()\ExcludeFromHistory = 0
+        ; the event writing figures out if there are changes
+        ; and will discard this event if there are none
+        HistoryEvent(@FileList(), #HISTORY_Edit)
+      EndIf
+    Next FileList()
+    
+  EndIf
+EndProcedure
+
+; Get a the time from a date value only
+;
+Procedure.s TimeToString(time)
+  ProcedureReturn FormatDate(Language("History","TimeFormat"), time)
+EndProcedure
+
+; Get a time or date from a date value depending if it is today or earlier
+;
+Procedure.s DateTimeToString(time)
+  
+  If time >= StartOfDay
+    ; today: just the time
+    ProcedureReturn TimeToString(time)
+    
+  ElseIf ((StartOfDay - time) / (24*60*60)) < 4
+    ; the past few days, use a weekday for readability
+    WeekDay$ = Language("Misc", "Weekday" + Str(DayOfWeek(time)))
+    ProcedureReturn WeekDay$ + " " + TimeToString(time)
+    
+  Else
+    ; use a day and month
+    ProcedureReturn FormatDate(Language("History","DateTimeFormat"), time)
+    
+  EndIf
+  
+EndProcedure
+
+; special return value for empty sources
+Global EmptyEventSource.EventSource
+
+; Returns an EventSource structure
+Procedure History_LoadEventSource(EventID)
+  
+  ; check cache first
+  ForEach EventSourceCache()
+    If EventSourceCache()\EventID = EventID
+      Debug "[HISTORY CACHE] HIT: " + Str(EventID)
+      
+      ; move to the front of the list (indicates most recently used)
+      MoveElement(EventSourceCache(), #PB_List_First)
+      
+      ProcedureReturn @EventSourceCache()
+    EndIf
+  Next EventSourceCache()
+  
+  ; check the db
+  *Buffer = 0
+  Size = 0
+  
+  If DatabaseQuery(#DB_History, "SELECT type, previous_event, encoding, data FROM event WHERE event_id = " + Str(EventID))
+    If NextDatabaseRow(#DB_History)
+      Type        = GetDatabaseLong(#DB_History, 0)
+      PreviousID  = GetDatabaseLong(#DB_History, 1)
+      Encoding    = GetDatabaseLong(#DB_History, 2)
+      
+      Select Type
+          
+        Case #DATA_Empty
+          FinishDatabaseQuery(#DB_History)
+          ProcedureReturn @EmptyEventSource
+          
+        Case #DATA_Same
+          FinishDatabaseQuery(#DB_History)
+          ProcedureReturn History_LoadEventSource(PreviousID)
+          
+        Case #DATA_Diff
+          DiffSize = DatabaseColumnSize(#DB_History, 3)
+          *Diff = AllocateMemory(DiffSize)
+          GetDatabaseBlob(#DB_History, 3, *Diff, DiffSize)
+          FinishDatabaseQuery(#DB_History)
+          
+          Size = PeekL(*Diff) ; stores final size
+          *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
+          *Previous.EventSource = History_LoadEventSource(PreviousID)
+          History_ApplyDiff(*Buffer, *Previous\Buffer, *Diff, DiffSize)
+          FreeMemory(*Diff)
+          
+        Case #DATA_DiffZ
+          CompressedSize = DatabaseColumnSize(#DB_History, 3)
+          *Compressed = AllocateMemory(CompressedSize)
+          GetDatabaseBlob(#DB_History, 3, *Compressed, CompressedSize)
+          DiffSize = PeekL(*Compressed)
+          *Diff = AllocateMemory(DiffSize)
+          uncompress(*Diff, @DiffSize, *Compressed + 4, CompressedSize - 4)
+          FreeMemory(*Compressed)
+          FinishDatabaseQuery(#DB_History)
+          
+          Size = PeekL(*Diff) ; stores final size
+          *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
+          *Previous.EventSource = History_LoadEventSource(PreviousID)
+          History_ApplyDiff(*Buffer, *Previous\Buffer, *Diff, DiffSize)
+          FreeMemory(*Diff)
+          
+        Case #DATA_Full
+          Size = DatabaseColumnSize(#DB_History, 3)
+          *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
+          GetDatabaseBlob(#DB_History, 3, *Buffer, Size)
+          FinishDatabaseQuery(#DB_History)
+          
+        Case #DATA_FullZ
+          CompressedSize = DatabaseColumnSize(#DB_History, 3)
+          *Compressed = AllocateMemory(CompressedSize)
+          GetDatabaseBlob(#DB_History, 3, *Compressed, CompressedSize)
+          Size = PeekL(*Compressed)
+          *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
+          uncompress(*Buffer, @Size, *Compressed + 4, CompressedSize - 4)
+          FreeMemory(*Compressed)
+          FinishDatabaseQuery(#DB_History)
+          
+        Default
+          MessageRequester(#ProductName$, "Unknown data type in session history database." + #NewLine + "This database seems to be from a newer " + #ProductName$ + " version")
+          ProcedureReturn @EmptyEventSource
+          
+      EndSelect
+    Else
+      FinishDatabaseQuery(#DB_History)
+    EndIf
+  EndIf
+  
+  If *Buffer
+    
+    ; delete an entry from cache if too big
+    If ListSize(EventSourceCache()) >= #HISTORY_EVENT_SOURCE_CACHE
+      ; least recently used
+      LastElement(EventSourceCache())
+      Debug "[HISTORY CACHE] EVICT: " + Str(EventSourceCache()\EventID)
+      FreeMemory(EventSourceCache()\Buffer)
+      DeleteElement(EventSourceCache())
+    EndIf
+    
+    ; insert into cache (as first position)
+    Debug "[HISTORY CACHE] MISS: " + Str(EventID)
+    FirstElement(EventSourceCache())
+    InsertElement(EventSourceCache())
+    EventSourceCache()\EventID = EventID
+    EventSourceCache()\Encoding = Encoding
+    EventSourceCache()\Size = Size
+    EventSourceCache()\Buffer = *Buffer
+    ProcedureReturn @EventSourceCache()
+    
+  Else
+    ProcedureReturn @EmptyEventSource
+  EndIf
+EndProcedure
+
+Procedure History_ShowEventSource(EventID)
+  
+  If CurrentHistorySource = EventID
+    ; no need to reload
+    ProcedureReturn
+  EndIf
+  CurrentHistorySource = EventID
+  
+  ; back up first visible line of previous source
+  FirstLine = ScintillaSendMessage(#GADGET_History_Source, #SCI_GETFIRSTVISIBLELINE, 0, 0)
+  HistoryFirstLines(CurrentHistoryFile$) = FirstLine
+  
+  *File.EventSource = History_LoadEventSource(EventID)
+  If *File\Buffer
+    SetCodeViewer(#GADGET_History_Source, *File\Buffer, *File\Encoding)
+    ; no FreeMemory(), as the loaded buffer lives on in the cache!
+  Else
+    ; source was empty, or an error occurred
+    SetCodeViewer(#GADGET_History_Source, @"", 0)
+  EndIf
+  
+  ; get the file name of this source
+  ; and set the first visible line again
+  If DatabaseQuery(#DB_History, "SELECT filename FROM event WHERE event_id = " + Str(EventID))
+    If NextDatabaseRow(#DB_History)
+      CurrentHistoryFile$ = GetDatabaseString(#DB_History, 0)
+      FirstLine = HistoryFirstLines(CurrentHistoryFile$)
+      ScintillaSendMessage(#GADGET_History_Source, #SCI_LINESCROLL, 0, FirstLine)
+    EndIf
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  
+EndProcedure
+
+Procedure.s History_FileDisplayName(FileName$)
+  
+  If Left(FileName$, 11) = "::unsaved::"
+    Time = Val(Right(FileName$, Len(FileName$)-43))
+    ProcedureReturn Language("History","UnsavedSource") + " (" + DateTimeToString(Time) + ")"
+  Else
+    ProcedureReturn GetFilePart(FileName$)
+  EndIf
+  
+EndProcedure
+
+Procedure.s History_SessionDisplayName(sid, OsID$, Version$, User$, StartTime, EndTime)
+  
+  CurrentVersion$ = History_VersionString(DefaultCompiler\VersionString$)
+  
+  If sid = SessionID
+    Session$ = Language("History", "CurrentSession")
+  Else
+    If EndTime = 0
+      If Session_IsRunning(OsID$)
+        ; session still running
+        Session$ = DateTimeToString(StartTime) + " (" + Language("History", "SessionRunning") + ")"
+      Else
+        ; crashed
+        Session$ = DateTimeToString(StartTime) + " (" + Language("History", "SessionCrashed") + ")"
+      EndIf
+    Else
+      ; finished session
+      Duration = (EndTime - StartTime)  / 60
+      If Duration = 0
+        ; very short session :)
+        Session$ = DateTimeToString(StartTime)
+      ElseIf Duration < 60
+        ; less than one hour
+        Session$ = DateTimeToString(StartTime) + " (" + Str(Duration) + " " + Language("History", "DurationMinutes") + ")"
+      Else
+        ; more than one hour
+        Session$ = DateTimeToString(StartTime) + " (" + Str(Duration / 60) + ":" + RSet(Str(Duration % 60), 2, "0") + " " + Language("History", "DurationHours") + ")"
+      EndIf
+    EndIf
+    
+    ; only add further info if it differs from the current one
+    ;
+    If User$ <> CurrentUser$
+      Session$ + " - " + User$
+    EndIf
+    If Version$ <> CurrentVersion$
+      Session$ + " - " + Version$
+    EndIf
+  EndIf
+  
+  ProcedureReturn Session$
+EndProcedure
+
+Procedure History_FillFileList()
+  
+  ClearGadgetItems(#GADGET_History_FileList)
+  
+  Index = GetGadgetState(#GADGET_History_FileCombo)
+  If Index = -1
+    ProcedureReturn
+  EndIf
+  
+  EventID = GetGadgetItemData(#GADGET_History_FileCombo, Index)
+  File$ = ""
+  If DatabaseQuery(#DB_History, "SELECT filename FROM event WHERE event_id = " + Str(EventID))
+    If NextDatabaseRow(#DB_History)
+      File$ = GetDatabaseString(#DB_History, 0)
+    EndIf
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  
+  If File$ = ""
+    ; no file info found ?
+    ProcedureReturn
+  EndIf
+  
+  If DatabaseQuery(#DB_History, "SELECT event_id, time, event FROM event WHERE filename = '" + SqlEscape(File$) + "' ORDER BY time ASC")
+    
+    index = 0
+    While NextDatabaseRow(#DB_History)
+      EventID      = GetDatabaseLong(#DB_History, 0)
+      Time         = GetDatabaseLong(#DB_History, 1)
+      Action       = GetDatabaseLong(#DB_History, 2)
+      
+      ImageID = OptionalImageID(#IMAGE_History_First + Action)
+      ; always use DateTime here because this list includes all sessions
+      AddGadgetItem(#GADGET_History_FileList, index, DateTimeToString(Time), ImageID)
+      SetGadgetItemData(#GADGET_History_FileList, index, EventID)
+      index + 1
+    Wend
+    
+    FinishDatabaseQuery(#DB_History)
+    
+  EndIf
+  
+  ; scroll all the way down to see the most recent event
+  SetGadgetState(#GADGET_History_FileList, CountGadgetItems(#GADGET_History_FileList)-1)
+  
+EndProcedure
+
+Procedure History_FillFileCombo()
+  
+  ClearGadgetItems(#GADGET_History_FileCombo)
+  
+  sql$ = "SELECT MIN(e.event_id), e.filename FROM event e "
+  sql$ + "GROUP BY e.filename "
+  sql$ + "ORDER BY e.filename ASC"
+  
+  If DatabaseQuery(#DB_History, sql$)
+    
+    index = 0
+    While NextDatabaseRow(#DB_History)
+      EventID   = GetDatabaseLong(#DB_History, 0)
+      File$     = GetDatabaseString(#DB_History, 1)
+      FileName$ = History_FileDisplayName(File$)
+      
+      AddGadgetItem(#GADGET_History_FileCombo, index, FileName$, OptionalImageID(#IMAGE_History_File), 0)
+      SetGadgetItemData(#GADGET_History_FileCombo, index, EventID)
+      index + 1
+    Wend
+    
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  
+  ; display the first file
+  If CountGadgetItems(#GADGET_History_FileCombo) > 0
+    SetGadgetState(#GADGET_History_FileCombo, 0)
+    History_FillFileList()
+  EndIf
+  
+EndProcedure
+
+
+Procedure History_FillSessionTree()
+  
+  ClearGadgetItems(#GADGET_History_SessionTree)
+  
+  Index = GetGadgetState(#GADGET_History_SessionCombo)
+  If Index = -1
+    ProcedureReturn
+  EndIf
+  
+  sid = GetGadgetItemData(#GADGET_History_SessionCombo, Index)
+  
+  ; decide whether to display time and date or only time
+  ; if people use a laptop and don't shut down the IDE, a session can last many days
+  ; use dateTime if the first and last event are on different days
+  UseDates = #False
+  If DatabaseQuery(#DB_History, "SELECT MIN(time), MAX(time) FROM event WHERE session_id = " + Str(sid))
+    If NextDatabaseRow(#DB_History)
+      MinTime = GetDatabaseLong(#DB_History, 0)
+      MaxTime = GetDatabaseLong(#DB_History, 1)
+      If Day(MinTime) <> Day(MaxTime) Or Month(MinTime) <> Month(MaxTime) Or Year(MinTime) <> Year(MaxTime)
+        UseDates = #True
+      EndIf
+    EndIf
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  
+  If DatabaseQuery(#DB_History, "SELECT event_id, filename, time, event FROM event WHERE session_id = " + Str(sid) + " ORDER BY filename ASC, time ASC")
+    
+    LastFile$ = ""
+    index = 0
+    While NextDatabaseRow(#DB_History)
+      EventID      = GetDatabaseLong(#DB_History, 0)
+      File$        = GetDatabaseString(#DB_History, 1)
+      Time         = GetDatabaseLong(#DB_History, 2)
+      Action       = GetDatabaseLong(#DB_History, 3)
+      
+      If File$ <> LastFile$
+        FileName$ = History_FileDisplayName(File$)
         
-        While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
-        sqlite3_finalize(*Statement)
+        AddGadgetItem(#GADGET_History_SessionTree, index, FileName$, OptionalImageID(#IMAGE_History_File), 0)
+        SetGadgetItemData(#GADGET_History_SessionTree, index, -1)
+        index + 1
+        
+        LastFile$ = File$
       EndIf
       
+      ImageID = OptionalImageID(#IMAGE_History_First + Action)
       
-    EndProcedure
+      If UseDates
+        TimeStr$ = DateTimeToString(Time)
+      Else
+        TimeStr$ = TimeToString(Time)
+      EndIf
+      
+      AddGadgetItem(#GADGET_History_SessionTree, index, TimeStr$, ImageID, 1)
+      SetGadgetItemData(#GADGET_History_SessionTree, index, EventID)
+      index + 1
+    Wend
     
-    Procedure History_AsyncDeleteEvent(EventID)
+    FinishDatabaseQuery(#DB_History)
+    
+    For i = 0 To index-1
+      If GetGadgetItemAttribute(#GADGET_History_SessionTree, i,  #PB_Tree_SubLevel) = 0
+        SetGadgetItemState(#GADGET_History_SessionTree, i, #PB_Tree_Expanded)
+      EndIf
+    Next i
+    
+  EndIf
+  
+EndProcedure
+
+Procedure History_FillSessionCombo(DisplaySID)
+  
+  ; display current session if no other one is indicated
+  If DisplaySID = -1
+    DisplaySID = SessionID
+  EndIf
+  SelectedSessionIndex = 0
+  
+  If DatabaseQuery(#DB_History, "SELECT session_id, os_id, version, user, start_time, end_time FROM session ORDER BY start_time DESC")
+    index = 0
+    While NextDatabaseRow(#DB_History)
+      sid       = GetDatabaseLong(#DB_History, 0)
+      osid$     = GetDatabaseString(#DB_History, 1)
+      Version$  = GetDatabaseString(#DB_History, 2)
+      User$     = GetDatabaseString(#DB_History, 3)
+      StartTime = GetDatabaseLong(#DB_History, 4)
+      EndTime   = GetDatabaseLong(#DB_History, 5)
       
-      CompilerIf #HISTORY_WRITE_ASYNC = #False
-        Debug "Async: deleting event with id: " + Str(EventID)
-      CompilerEndIf
+      Session$ = History_SessionDisplayName(sid, osid$, Version$, User$, StartTime, EndTime)
       
-      CompilerIf #PB_Compiler_Unicode
-        If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"DELETE FROM event WHERE event_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
-        CompilerElse
-          If sqlite3_prepare_v2(DatabaseID(#DB_History), @"DELETE FROM event WHERE event_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
-          CompilerEndIf
-          sqlite3_bind_int(*Statement, 1, EventID)
-          
-          While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
-          sqlite3_finalize(*Statement)
-        EndIf
-        
-      EndProcedure
+      If sid = DisplaySID
+        SelectedSessionIndex = index
+      EndIf
       
-      Structure HistoryDiffLine
-        Checksum.l
-        Offset.l
-        Length.l
-      EndStructure
+      AddGadgetItem(#GADGET_History_SessionCombo, index, Session$)
+      SetGadgetItemData(#GADGET_History_SessionCombo, index, sid)
+      index + 1
+    Wend
+    
+    FinishDatabaseQuery(#DB_History)
+  EndIf
+  
+  ; display the current session
+  If CountGadgetItems(#GADGET_History_SessionCombo) > 0
+    SetGadgetState(#GADGET_History_SessionCombo, SelectedSessionIndex)
+    History_FillSessionTree()
+  EndIf
+  
+EndProcedure
+
+
+
+
+
+Procedure OpenEditHistoryWindow(DisplaySID = -1)
+  
+  If HistoryActive = 0
+    ProcedureReturn
+  EndIf
+  
+  ; Calculate start of the current day for the TimeToString() procedure
+  CurrentDate = Date()
+  StartOfDay = Date(Year(CurrentDate), Month(CurrentDate), Day(CurrentDate), 0, 0, 0)
+  
+  ClearMap(HistoryFirstLines())
+  
+  If IsWindow(#WINDOW_EditHistory) = 0
+    
+    EditHistoryDialog = OpenDialog(?Dialog_History, WindowID(#WINDOW_Main), @EditHistoryPosition)
+    If EditHistoryDialog
+      EnsureWindowOnDesktop(#WINDOW_EditHistory)
       
-      Structure HistoryDiffLines
-        Line.HistoryDiffLine[0]
-      EndStructure
+      InitCodeViewer(#GADGET_History_Source, EnableLineNumbers)
+      HideWindow(#WINDOW_EditHistory, 0)
       
-      ProcedureC History_Diff_idx(*Lines.HistoryDiffLines, idx.l, *context)
-        ProcedureReturn @*Lines\Line[idx]
-      EndProcedure
+      SetGadgetState(#GADGET_History_Splitter, EditHistorySplitter)
+    EndIf
+    
+  Else
+    SetWindowForeground(#WINDOW_EditHistory)
+  EndIf
+  
+  ; make sure all events are written to the db
+  History_FlushEvents()
+  
+  ; refresh display
+  History_FillSessionCombo(DisplaySID)
+  History_FillFileCombo()
+  
+  CurrentHistoryFile$ = ""
+  CurrentHistorySource = -1
+  
+EndProcedure
+
+Procedure UpdateEditHistoryWindow()
+  
+  EditHistoryDialog\LanguageUpdate()
+  EditHistoryDialog\GuiUpdate()
+  UpdateCodeViewer(#GADGET_History_Source)
+  
+EndProcedure
+
+Procedure EditHistoryWindowEvent(EventID)
+  
+  Select EventID
       
-      ProcedureC History_Diff_cmp(*e1.HistoryDiffLine, *e2.HistoryDiffLine, *context)
-        If *e1\Checksum = *e2\Checksum
-          ProcedureReturn 0
-        Else
-          ProcedureReturn 1
-        EndIf
-      EndProcedure
-      
-      Procedure History_DiffEditSize(*edit.diff_edit, Array Lines.HistoryDiffLine(1))
-        Size = 0
-        Last = *edit\off + *edit\len - 1
-        For index = *edit\off To  Last
-          Size + Lines(index)\Length
-        Next index
-        ProcedureReturn Size
-      EndProcedure
-      
-      Procedure History_DiffPreProcess(*Event.HistoryEvent, Array Lines.HistoryDiffLine(1))
-        *Pointer.PTR = *Event\Content
-        *BufferEnd = *Pointer + *Event\Size
-        
-        Lines = 0
-        Space = ArraySize(Lines()) ; don't do +1 to have the extra space for the last line
-        
-        *LineStart = *Pointer
-        While *Pointer < *BufferEnd
+    Case #PB_Event_Gadget
+      Select EventGadget()
           
-          ; detect next newline
-          If *Pointer\b = 13
-            *Pointer + 1
-            If *Pointer < *BufferEnd And *Pointer\b = 10
-              *Pointer + 1
-            EndIf
-          ElseIf *Pointer\b = 10
-            *Pointer + 1
-          Else
-            ; no newline
-            *Pointer + 1
-            Continue
-          EndIf
-          
-          ; newline found
-          If Space = 0
-            ReDim Lines(Lines * 2)
-            Space = Lines
-          EndIf
-          
-          Lines(Lines)\Checksum = CRC32Fingerprint(*LineStart, *Pointer-*LineStart)
-          Lines(Lines)\Offset = *LineStart - *Event\Content
-          Lines(Lines)\Length = *Pointer - *LineStart
-          Lines + 1
-          Space - 1
-          *LineStart = *Pointer
-        Wend
-        
-        ; add the last line
-        If *Pointer > *LineStart
-          Lines(Lines)\Checksum = CRC32Fingerprint(*LineStart, *Pointer-*LineStart)
-          Lines(Lines)\Offset = *Pointer - *Event\Content
-          Lines(Lines)\Length = *Pointer - *LineStart
-          Lines + 1
-        EndIf
-        
-        ProcedureReturn Lines
-      EndProcedure
-      
-      ; Generates an edit script:
-      ; Beginning: <long> full size of target
-      ;
-      ; C<long> : copy from source
-      ; D<long> : skip from source
-      ; A<long><content> : add content from diff
-      ;
-      ; returns size of diff'ed content
-      ; returns 0 if diff is larger than real file
-      Procedure History_MakeDiff(*Output, *OutSize.INTEGER, *Event.HistoryEvent, *Previous.HistoryEvent)
-        Protected Dim NewLines.HistoryDiffLine(1000)
-        Protected Dim OldLines.HistoryDiffLine(1000)
-        
-        LinesNew = History_DiffPreProcess(*Event, NewLines())
-        LinesOld = History_DiffPreProcess(*Previous, OldLines())
-        
-        *ses = varray_new(SizeOf(diff_edit), #Null)
-        sn.l = 0
-        
-        diff(@OldLines(0), 0, LinesOld, @NewLines(0), 0, LinesNew, @History_Diff_idx(), @History_Diff_cmp(), #Null, 0, *ses, @sn, 0)
-        
-        *OutputEnd = *Output + *OutSize\i
-        *Pointer.PTR = *Output
-        *Pointer\l = *Event\Size ; store original size
-        *Pointer + 4             ; skip original size storage
-        
-        For i = 0 To sn-1
-          *edit.diff_edit = varray_get(*ses, i)
-          If *Pointer + 5 > *OutputEnd
-            varray_del(*ses)
-            ProcedureReturn #False
-          EndIf
-          
-          Select *edit\op
-            Case #DIFF_MATCH
-              *Pointer\b = 'C': *Pointer + 1
-              *Pointer\l = History_DiffEditSize(*edit, OldLines()): *Pointer + 4
-              
-            Case #DIFF_DELETE
-              *Pointer\b = 'D': *Pointer + 1
-              *Pointer\l = History_DiffEditSize(*edit, OldLines()): *Pointer + 4
-              
-            Case #DIFF_INSERT
-              *Pointer\b = 'A': *Pointer + 1
-              EditSize = History_DiffEditSize(*edit, NewLines())
-              *Pointer\l = EditSize: *Pointer + 4
-              
-              If *Pointer + EditSize > *OutputEnd
-                varray_del(*ses)
-                ProcedureReturn #False
-              EndIf
-              
-              CopyMemory(*Event\Content + NewLines(*edit\off)\Offset, *Pointer, EditSize)
-              *Pointer + EditSize
-              
-          EndSelect
-        Next i
-        
-        varray_del(*ses)
-        
-        *OutSize\i = *Pointer - *Output
-        ProcedureReturn #True
-      EndProcedure
-      
-      
-      Procedure History_ApplyDiff(*Output, *PreviousBuffer, *Diff.PTR, DiffSize)
-        
-        *DiffEnd = *Diff + DiffSize
-        
-        *Diff + 4 ; skip expanded size
-        
-        While *Diff < *DiffEnd
-          Select *Diff\b
-              
-            Case 'C'
-              *Diff + 1
-              Size = *Diff\l: *Diff + 4
-              CopyMemory(*PreviousBuffer, *Output, Size)
-              *PreviousBuffer + Size
-              *Output + Size
-              
-            Case 'D'
-              *Diff + 1
-              Size = *Diff\l: *Diff + 4
-              ; just skip on the input
-              *PreviousBuffer + Size
-              
-            Case 'A'
-              *Diff + 1
-              Size = *Diff\l: *Diff + 4
-              CopyMemory(*Diff, *Output, Size)
-              *Diff + Size
-              *Output + Size
-              
-            Default
-              ; something is wrong here
-              ProcedureReturn #False
-              
-          EndSelect
-        Wend
-        
-        ProcedureReturn #True
-      EndProcedure
-      
-      Procedure History_WriteEvent(*Event.HistoryEvent)
-        
-        ; calculate checksum if needed
-        If *Event\Checksum = 0 And *Event\Content And *Event\Size
-          *Event\Checksum = CRC32Fingerprint(*Event\Content, *Event\Size)
-        EndIf
-        
-        ; find any previous event for the same source and remove it from the list
-        ; this list is accessed only by this thread
-        *Update.HistoryEvent = 0 ; the one to update on a delete
-        *Previous.HistoryEvent = *HistoryFirstProcessed
-        While *Previous And *Previous\SourceID <> *Event\SourceID
-          *Update = *Previous
-          *Previous = *Previous\ProcessedNext
-        Wend
-        
-        ; previous event found
-        If *Previous
-          
-          ; If the Event is #HISTORY_Edit, decide if there were changes
-          ; Drop the event if there were no changes since last time
-          If *Event\Event = #HISTORY_Edit And *Previous\Size = *Event\Size And *Previous\Checksum = *Event\Checksum
-            History_FreeEvent(*Event)
-            ProcedureReturn
-          EndIf
-          
-          ; unlink the previous event from list
-          If *Update
-            *Update\ProcessedNext = *Previous\ProcessedNext
-          Else
-            *HistoryFirstProcessed = *Previous\ProcessedNext
-          EndIf
-          
-          ; if the event is close, and the only previous event is open or create,
-          ; drop both from the db to avoid lots of empty open/close event combinations
-          If *Event\Event = #HISTORY_Close And (*Previous\Event = #HISTORY_Create Or *Previous\Event = #HISTORY_Open)
-            History_AsyncDeleteEvent(*Previous\EventID)
-            History_FreeEvent(*Previous)
-            History_FreeEvent(*Event)
-            ProcedureReturn
-          EndIf
-          
-          ; if a fresh file is saved, rename all old events to the new filename
-          If *Event\Event = #HISTORY_SaveAs And *Previous\FreshFile
-            History_AsyncUpdateName(*Previous\HistoryName, *Event\HistoryName)
-          EndIf
-          
-        EndIf
-        
-        ; prepare/compress the contents for storage
-        StorageSize = 0
-        *StorageBuffer = #Null
-        
-        If *Event\Content = #Null
-          Type = #DATA_Empty
-          PreviousEventID = 0
-          *Event\DiffCount = 0
-          
-        ElseIf *Previous = #Null Or *Previous\Content = #Null Or *Previous\DiffCount >= #HISTORY_EVENT_MAX_DIFFS
-          ; write full data if no previous data exists, or the max diff count is reached
-          Type = #DATA_Full
-          PreviousEventID = 0
-          StorageSize = *Event\Size
-          *StorageBuffer = *Event\Content
-          
-          ; attempt to compress
-          CompilerIf #ENABLE_HISTORY_COMPRESSION
-            CompressedSize = compressBound(*Event\Size) + 4
-            *CompressedBuffer = AllocateMemory(CompressedSize)
-            If *CompressedBuffer
-              CompressedSize - 4
-              If compress2(*CompressedBuffer + 4, @CompressedSize, *Event\Content , *Event\Size, #HISTORY_COMPRESSION_LEVEL) = #Z_OK
-                Type = #DATA_FullZ
-                PokeL(*CompressedBuffer, *Event\Size) ; store original size in first 4 bytes
-                StorageSize = CompressedSize + 4
-                *StorageBuffer = *CompressedBuffer
-              Else
-                FreeMemory(*CompressedBuffer)
-              EndIf
-            EndIf
-          CompilerEndIf
-          *Event\DiffCount = 0
-          
-        ElseIf *Event\Size = *Previous\Size And *Event\Checksum = *Previous\Checksum
-          Type = #DATA_Same
-          PreviousEventID = *Previous\EventID
-          *Event\DiffCount = *Previous\DiffCount + 1
-          
-        Else
-          ; fallback to full if something fails below
-          Type = #DATA_Full
-          PreviousEventID = 0
-          StorageSize = *Event\Size
-          *StorageBuffer = *Event\Content
-          *Event\DiffCount = *Previous\DiffCount + 1
-          
-          ; try to diff
-          *DiffBuffer = AllocateMemory(StorageSize + 4) ; 4 bytes for the unpacked size
-          If *DiffBuffer
-            DiffSize = StorageSize + 4
-            If History_MakeDiff(*DiffBuffer, @DiffSize, *Event, *Previous)
-              Type = #DATA_Diff
-              *StorageBuffer = *DiffBuffer
-              StorageSize = DiffSize
-              PreviousEventID = *Previous\EventID
-            Else
-              FreeMemory(*DiffBuffer) ; diff is larger than original!
-              *DiffBuffer = 0
-            EndIf
-          EndIf
-          
-          ; attempt to compress
-          CompilerIf #ENABLE_HISTORY_COMPRESSION
-            CompressedSize = compressBound(StorageSize) + 4
-            *CompressedBuffer = AllocateMemory(CompressedSize)
-            If *CompressedBuffer
-              CompressedSize - 4
-              If compress2(*CompressedBuffer + 4, @CompressedSize, *StorageBuffer, StorageSize, #HISTORY_COMPRESSION_LEVEL) = #Z_OK
-                If Type = #DATA_Diff
-                  Type = #DATA_DiffZ
-                  FreeMemory(*DiffBuffer) ; diff buffer is no longer needed. storagebuffer is overwritten below
-                Else
-                  Type = #DATA_FullZ
-                EndIf
-                PokeL(*CompressedBuffer, StorageSize) ; store original size in first 4 bytes
-                StorageSize = CompressedSize + 4
-                *StorageBuffer = *CompressedBuffer
-              Else
-                FreeMemory(*CompressedBuffer)
-              EndIf
-            EndIf
-          CompilerEndIf
-          
-        EndIf
-        
-        ; Update the DB
-        ; We cannot use the Database functions for thread safety
-        ; Use the sqlite functions directly
-        ; In PB, sqlite is compiled threadsafe, so this is ok
-        CompilerIf #HISTORY_WRITE_ASYNC = #False
-          Debug "Async: writing history event: " + Str(*Event\Event)
-        CompilerEndIf
-        
-        ; Use bind variables as we cannot modify strings in this thread
-        CompilerIf #PB_Compiler_Unicode
-          If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"INSERT INTO event(session_id, filename, event, time, type, previous_event, encoding, data) VALUES (?,?,?,?,?,?,?,?)", -1, @*Statement, #Null) = #SQLITE_OK
-            sqlite3_bind_int (*Statement, 1, SessionID)
-            sqlite3_bind_text16(*Statement, 2, @*Event\HistoryName, -1, #SQLITE_STATIC)
+        Case #GADGET_History_Splitter
+          CompilerIf #CompileWindows
+            ; just update the column width. the rest is automatic
+            SendMessage_(GadgetID(#GADGET_History_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
           CompilerElse
-            If sqlite3_prepare_v2(DatabaseID(#DB_History), @"INSERT INTO event(session_id, filename, event, time, type, previous_event, encoding, data) VALUES (?,?,?,?,?,?,?,?)", -1, @*Statement, #Null) = #SQLITE_OK
-              sqlite3_bind_int (*Statement, 1, SessionID)
-              sqlite3_bind_text(*Statement, 2, @*Event\HistoryName, -1, #SQLITE_STATIC)
-            CompilerEndIf
-            sqlite3_bind_int (*Statement, 3, *Event\Event)
-            sqlite3_bind_int (*Statement, 4, *Event\Time)
-            sqlite3_bind_int (*Statement, 5, Type)
-            sqlite3_bind_int (*Statement, 6, PreviousEventID)
-            sqlite3_bind_int (*Statement, 7, *Event\Encoding)
-            
-            If *StorageBuffer
-              sqlite3_bind_blob(*Statement, 8, *StorageBuffer, StorageSize, #SQLITE_STATIC)
-            Else
-              sqlite3_bind_null(*Statement, 8)
-            EndIf
-            
-            While sqlite3_step(*Statement) = #SQLITE_ROW: Wend
-            sqlite3_finalize(*Statement)
-            
-            ; retrieve the event id
-            *Event\EventID = sqlite3_last_insert_rowid(DatabaseID(#DB_History))
-          EndIf
+            ; need to resize the gui accordingly
+            EditHistoryDialog\SizeUpdate()
+          CompilerEndIf
           
-          ; free compressed buffer
-          If *StorageBuffer And *StorageBuffer <> *Event\Content
-            FreeMemory(*StorageBuffer)
-          EndIf
+        Case #GADGET_History_SessionCombo
+          History_FillSessionTree()
           
-          ; free the previous event info
-          If *Previous
-            History_FreeEvent(*Previous)
-          EndIf
-          
-          ; if this is a close, free the current event
-          ; otherwise store it for reference on the next one
-          If *Event\Event = #HISTORY_Close
-            History_FreeEvent(*Event)
-            
-          Else
-            *Event\ProcessedNext = *HistoryFirstProcessed
-            *HistoryFirstProcessed = *Event
-            
-          EndIf
-          
-        EndProcedure
-        
-        
-        Procedure History_EventThread(*Dummy)
-          
-          Repeat
-            
-            ; wait and get the next event to process
-            WaitSemaphore(*HistorySemaphore)
-            LockMutex(*HistoryMutex)
-            *Event.HistoryEvent = *HistoryQueueHead
-            *HistoryQueueHead = *Event\QueueNext
-            If *HistoryQueueHead = 0
-              *HistoryQueueTail = 0
-            EndIf
-            UnlockMutex(*HistoryMutex)
-            
-            ; write the event
-            History_WriteEvent(*Event)
-            
-          ForEver
-          
-        EndProcedure
-        
-        CompilerIf #HISTORY_WRITE_ASYNC
-          EnableDebugger
-        CompilerEndIf
-        
-        
-        Procedure HistoryEvent(*Source.SourceFile, Event)
-          If HistoryActive And *Source <> *ProjectInfo And *Source\IsForm = #False
-            Debug "[HISTORY] Event: " + Str(Event)
-            
-            ; Behavior for SaveAs
-            ; - for fresh files, the writing procedure will rename all previous events to the new name
-            ;   so all events have the identity of the saved name, even the older ones
-            ; - for old files. write a 'close' event for the old file name. then the normal
-            ;   SaveAs for the new filename to separate the two now existing streams of events
-            If Event = #HISTORY_SaveAs And *Source\FreshFile = #False
-              HistoryEvent(*Source, #HISTORY_Close)
-            EndIf
-            
-            Size = ScintillaSendMessage(*Source\EditorGadget, #SCI_GETLENGTH, 0, 0)
-            If Size > HistoryMaxFileSize
-              
-              ; Size checking works like this:
-              ; If the file is too large on open, it is excluded entirely (ExludeFromHistory = true)
-              ; If the file was small but grows to large, write no events but the
-              ; close event, so the event log is consistent
-              ;
-              If Event = #HISTORY_Open
-                *Source\ExcludeFromHistory = #True
-                ProcedureReturn
-              ElseIf *Source\ExcludeFromHistory = #False And Event <> #HISTORY_CLOSE
-                ProcedureReturn
-              EndIf
-            EndIf
-            
-            ; change HistoryName if needed
-            ;
-            If Event = #HISTORY_Create
-              ; make a unique name for this unsaved file. append the creation date so it can later be used for display
-              *Source\HistoryName = "::unsaved::" + History_MakeUniqueID() + Str(Date())
-              *Source\FreshFile = #True
-              
-            ElseIf Event = #HISTORY_Open Or Event = #HISTORY_Save Or Event = #HISTORY_SaveAs
-              *Source\HistoryName = *Source\FileName$
-              *Source\FreshFile = #False
-              
-            EndIf
-            
-            ; get the content
-            If Size = 0
-              *Buffer = #Null
-            Else
-              *Buffer = AllocateMemory(Size+1)
-              ScintillaSendMessage(*Source\EditorGadget,#SCI_GETTEXT, Size+1, *Buffer)
-            EndIf
-            
-            ; enqueue a task to write this event in the thread
-            ; this gives significant speedup when loading many files at once (like on startup)
-            *Event.HistoryEvent = AllocateMemory(SizeOf(HistoryEvent))
-            *Event\SourceID     = *Source\ID
-            *Event\HistoryName  = *Source\HistoryName
-            *Event\Encoding     = *Source\Parser\Encoding
-            *Event\Event        = Event
-            *Event\Time         = Date()
-            *Event\Content      = *Buffer
-            *Event\Size         = Size
-            *Event\Checksum     = 0 ; not yet calculated
-            *Event\FreshFile    = *Source\FreshFile
-            *Event\EventID      = -1 ; set by the thread when writing the event
-            
-            CompilerIf #HISTORY_WRITE_ASYNC
-              LockMutex(*HistoryMutex)
-              If *HistoryQueueTail = 0
-                ; queue is empty
-                *HistoryQueueHead = *Event
-                *HistoryQueueTail = *Event
-              Else
-                *HistoryQueueTail\QueueNext = *Event
-                *HistoryQueueTail = *Event
-              EndIf
-              UnlockMutex(*HistoryMutex)
-              SignalSemaphore(*HistorySemaphore)
-              
-            CompilerElse
-              History_WriteEvent(*Event)
-              
-            CompilerEndIf
-            
-          EndIf
-        EndProcedure
-        
-        Procedure HistoryTimer()
-          If HistoryActive
-            
-            ForEach FileList()
-              If @FileList() <> *ProjectInfo And FileList()\IsForm = 0 And FileList()\ExcludeFromHistory = 0
-                ; the event writing figures out if there are changes
-                ; and will discard this event if there are none
-                HistoryEvent(@FileList(), #HISTORY_Edit)
-              EndIf
-            Next FileList()
-            
-          EndIf
-        EndProcedure
-        
-        ; Get a the time from a date value only
-        ;
-        Procedure.s TimeToString(time)
-          ProcedureReturn FormatDate(Language("History","TimeFormat"), time)
-        EndProcedure
-        
-        ; Get a time or date from a date value depending if it is today or earlier
-        ;
-        Procedure.s DateTimeToString(time)
-          
-          If time >= StartOfDay
-            ; today: just the time
-            ProcedureReturn TimeToString(time)
-            
-          ElseIf ((StartOfDay - time) / (24*60*60)) < 4
-            ; the past few days, use a weekday for readability
-            WeekDay$ = Language("Misc", "Weekday" + Str(DayOfWeek(time)))
-            ProcedureReturn WeekDay$ + " " + TimeToString(time)
-            
-          Else
-            ; use a day and month
-            ProcedureReturn FormatDate(Language("History","DateTimeFormat"), time)
-            
-          EndIf
-          
-        EndProcedure
-        
-        ; special return value for empty sources
-        Global EmptyEventSource.EventSource
-        
-        ; Returns an EventSource structure
-        Procedure History_LoadEventSource(EventID)
-          
-          ; check cache first
-          ForEach EventSourceCache()
-            If EventSourceCache()\EventID = EventID
-              Debug "[HISTORY CACHE] HIT: " + Str(EventID)
-              
-              ; move to the front of the list (indicates most recently used)
-              MoveElement(EventSourceCache(), #PB_List_First)
-              
-              ProcedureReturn @EventSourceCache()
-            EndIf
-          Next EventSourceCache()
-          
-          ; check the db
-          *Buffer = 0
-          Size = 0
-          
-          If DatabaseQuery(#DB_History, "SELECT type, previous_event, encoding, data FROM event WHERE event_id = " + Str(EventID))
-            If NextDatabaseRow(#DB_History)
-              Type        = GetDatabaseLong(#DB_History, 0)
-              PreviousID  = GetDatabaseLong(#DB_History, 1)
-              Encoding    = GetDatabaseLong(#DB_History, 2)
-              
-              Select Type
-                  
-                Case #DATA_Empty
-                  FinishDatabaseQuery(#DB_History)
-                  ProcedureReturn @EmptyEventSource
-                  
-                Case #DATA_Same
-                  FinishDatabaseQuery(#DB_History)
-                  ProcedureReturn History_LoadEventSource(PreviousID)
-                  
-                Case #DATA_Diff
-                  DiffSize = DatabaseColumnSize(#DB_History, 3)
-                  *Diff = AllocateMemory(DiffSize)
-                  GetDatabaseBlob(#DB_History, 3, *Diff, DiffSize)
-                  FinishDatabaseQuery(#DB_History)
-                  
-                  Size = PeekL(*Diff) ; stores final size
-                  *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
-                  *Previous.EventSource = History_LoadEventSource(PreviousID)
-                  History_ApplyDiff(*Buffer, *Previous\Buffer, *Diff, DiffSize)
-                  FreeMemory(*Diff)
-                  
-                Case #DATA_DiffZ
-                  CompressedSize = DatabaseColumnSize(#DB_History, 3)
-                  *Compressed = AllocateMemory(CompressedSize)
-                  GetDatabaseBlob(#DB_History, 3, *Compressed, CompressedSize)
-                  DiffSize = PeekL(*Compressed)
-                  *Diff = AllocateMemory(DiffSize)
-                  uncompress(*Diff, @DiffSize, *Compressed + 4, CompressedSize - 4)
-                  FreeMemory(*Compressed)
-                  FinishDatabaseQuery(#DB_History)
-                  
-                  Size = PeekL(*Diff) ; stores final size
-                  *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
-                  *Previous.EventSource = History_LoadEventSource(PreviousID)
-                  History_ApplyDiff(*Buffer, *Previous\Buffer, *Diff, DiffSize)
-                  FreeMemory(*Diff)
-                  
-                Case #DATA_Full
-                  Size = DatabaseColumnSize(#DB_History, 3)
-                  *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
-                  GetDatabaseBlob(#DB_History, 3, *Buffer, Size)
-                  FinishDatabaseQuery(#DB_History)
-                  
-                Case #DATA_FullZ
-                  CompressedSize = DatabaseColumnSize(#DB_History, 3)
-                  *Compressed = AllocateMemory(CompressedSize)
-                  GetDatabaseBlob(#DB_History, 3, *Compressed, CompressedSize)
-                  Size = PeekL(*Compressed)
-                  *Buffer = AllocateMemory(Size + 1) ; need to add a NULL (for scintilla SETTEXT)
-                  uncompress(*Buffer, @Size, *Compressed + 4, CompressedSize - 4)
-                  FreeMemory(*Compressed)
-                  FinishDatabaseQuery(#DB_History)
-                  
-                Default
-                  MessageRequester(#ProductName$, "Unknown data type in session history database." + #NewLine + "This database seems to be from a newer " + #ProductName$ + " version")
-                  ProcedureReturn @EmptyEventSource
-                  
-              EndSelect
-            Else
-              FinishDatabaseQuery(#DB_History)
+        Case #GADGET_History_SessionTree
+          Index = GetGadgetState(#GADGET_History_SessionTree)
+          If Index <> -1
+            EventID = GetGadgetItemData(#GADGET_History_SessionTree, Index)
+            If EventID <> -1
+              History_ShowEventSource(EventID)
             EndIf
           EndIf
           
-          If *Buffer
-            
-            ; delete an entry from cache if too big
-            If ListSize(EventSourceCache()) >= #HISTORY_EVENT_SOURCE_CACHE
-              ; least recently used
-              LastElement(EventSourceCache())
-              Debug "[HISTORY CACHE] EVICT: " + Str(EventSourceCache()\EventID)
-              FreeMemory(EventSourceCache()\Buffer)
-              DeleteElement(EventSourceCache())
-            EndIf
-            
-            ; insert into cache (as first position)
-            Debug "[HISTORY CACHE] MISS: " + Str(EventID)
-            FirstElement(EventSourceCache())
-            InsertElement(EventSourceCache())
-            EventSourceCache()\EventID = EventID
-            EventSourceCache()\Encoding = Encoding
-            EventSourceCache()\Size = Size
-            EventSourceCache()\Buffer = *Buffer
-            ProcedureReturn @EventSourceCache()
-            
-          Else
-            ProcedureReturn @EmptyEventSource
-          EndIf
-        EndProcedure
-        
-        Procedure History_ShowEventSource(EventID)
+        Case #GADGET_History_FileCombo
+          History_FillFileList()
           
-          If CurrentHistorySource = EventID
-            ; no need to reload
-            ProcedureReturn
-          EndIf
-          CurrentHistorySource = EventID
-          
-          ; back up first visible line of previous source
-          FirstLine = ScintillaSendMessage(#GADGET_History_Source, #SCI_GETFIRSTVISIBLELINE, 0, 0)
-          HistoryFirstLines(CurrentHistoryFile$) = FirstLine
-          
-          *File.EventSource = History_LoadEventSource(EventID)
-          If *File\Buffer
-            SetCodeViewer(#GADGET_History_Source, *File\Buffer, *File\Encoding)
-            ; no FreeMemory(), as the loaded buffer lives on in the cache!
-          Else
-            ; source was empty, or an error occurred
-            SetCodeViewer(#GADGET_History_Source, @"", 0)
-          EndIf
-          
-          ; get the file name of this source
-          ; and set the first visible line again
-          If DatabaseQuery(#DB_History, "SELECT filename FROM event WHERE event_id = " + Str(EventID))
-            If NextDatabaseRow(#DB_History)
-              CurrentHistoryFile$ = GetDatabaseString(#DB_History, 0)
-              FirstLine = HistoryFirstLines(CurrentHistoryFile$)
-              ScintillaSendMessage(#GADGET_History_Source, #SCI_LINESCROLL, 0, FirstLine)
-            EndIf
-            FinishDatabaseQuery(#DB_History)
-          EndIf
-          
-        EndProcedure
-        
-        Procedure.s History_FileDisplayName(FileName$)
-          
-          If Left(FileName$, 11) = "::unsaved::"
-            Time = Val(Right(FileName$, Len(FileName$)-43))
-            ProcedureReturn Language("History","UnsavedSource") + " (" + DateTimeToString(Time) + ")"
-          Else
-            ProcedureReturn GetFilePart(FileName$)
-          EndIf
-          
-        EndProcedure
-        
-        Procedure.s History_SessionDisplayName(sid, OsID$, Version$, User$, StartTime, EndTime)
-          
-          CurrentVersion$ = History_VersionString(DefaultCompiler\VersionString$)
-          
-          If sid = SessionID
-            Session$ = Language("History", "CurrentSession")
-          Else
-            If EndTime = 0
-              If Session_IsRunning(OsID$)
-                ; session still running
-                Session$ = DateTimeToString(StartTime) + " (" + Language("History", "SessionRunning") + ")"
-              Else
-                ; crashed
-                Session$ = DateTimeToString(StartTime) + " (" + Language("History", "SessionCrashed") + ")"
-              EndIf
-            Else
-              ; finished session
-              Duration = (EndTime - StartTime)  / 60
-              If Duration = 0
-                ; very short session :)
-                Session$ = DateTimeToString(StartTime)
-              ElseIf Duration < 60
-                ; less than one hour
-                Session$ = DateTimeToString(StartTime) + " (" + Str(Duration) + " " + Language("History", "DurationMinutes") + ")"
-              Else
-                ; more than one hour
-                Session$ = DateTimeToString(StartTime) + " (" + Str(Duration / 60) + ":" + RSet(Str(Duration % 60), 2, "0") + " " + Language("History", "DurationHours") + ")"
-              EndIf
-            EndIf
-            
-            ; only add further info if it differs from the current one
-            ;
-            If User$ <> CurrentUser$
-              Session$ + " - " + User$
-            EndIf
-            If Version$ <> CurrentVersion$
-              Session$ + " - " + Version$
+        Case #GADGET_History_FileList
+          Index = GetGadgetState(#GADGET_History_FileList)
+          If Index <> -1
+            EventID = GetGadgetItemData(#GADGET_History_FileList, Index)
+            If EventID <> -1
+              History_ShowEventSource(EventID)
             EndIf
           EndIf
           
-          ProcedureReturn Session$
-        EndProcedure
-        
-        Procedure History_FillFileList()
           
-          ClearGadgetItems(#GADGET_History_FileList)
-          
-          Index = GetGadgetState(#GADGET_History_FileCombo)
-          If Index = -1
-            ProcedureReturn
-          EndIf
-          
-          EventID = GetGadgetItemData(#GADGET_History_FileCombo, Index)
-          File$ = ""
-          If DatabaseQuery(#DB_History, "SELECT filename FROM event WHERE event_id = " + Str(EventID))
-            If NextDatabaseRow(#DB_History)
-              File$ = GetDatabaseString(#DB_History, 0)
-            EndIf
-            FinishDatabaseQuery(#DB_History)
-          EndIf
-          
-          If File$ = ""
-            ; no file info found ?
-            ProcedureReturn
-          EndIf
-          
-          If DatabaseQuery(#DB_History, "SELECT event_id, time, event FROM event WHERE filename = '" + SqlEscape(File$) + "' ORDER BY time ASC")
-            
-            index = 0
-            While NextDatabaseRow(#DB_History)
-              EventID      = GetDatabaseLong(#DB_History, 0)
-              Time         = GetDatabaseLong(#DB_History, 1)
-              Action       = GetDatabaseLong(#DB_History, 2)
-              
-              ImageID = OptionalImageID(#IMAGE_History_First + Action)
-              ; always use DateTime here because this list includes all sessions
-              AddGadgetItem(#GADGET_History_FileList, index, DateTimeToString(Time), ImageID)
-              SetGadgetItemData(#GADGET_History_FileList, index, EventID)
-              index + 1
-            Wend
-            
-            FinishDatabaseQuery(#DB_History)
-            
-          EndIf
-          
-          ; scroll all the way down to see the most recent event
-          SetGadgetState(#GADGET_History_FileList, CountGadgetItems(#GADGET_History_FileList)-1)
-          
-        EndProcedure
-        
-        Procedure History_FillFileCombo()
-          
-          ClearGadgetItems(#GADGET_History_FileCombo)
-          
-          sql$ = "SELECT MIN(e.event_id), e.filename FROM event e "
-          sql$ + "GROUP BY e.filename "
-          sql$ + "ORDER BY e.filename ASC"
-          
-          If DatabaseQuery(#DB_History, sql$)
-            
-            index = 0
-            While NextDatabaseRow(#DB_History)
-              EventID   = GetDatabaseLong(#DB_History, 0)
-              File$     = GetDatabaseString(#DB_History, 1)
-              FileName$ = History_FileDisplayName(File$)
-              
-              AddGadgetItem(#GADGET_History_FileCombo, index, FileName$, OptionalImageID(#IMAGE_History_File), 0)
-              SetGadgetItemData(#GADGET_History_FileCombo, index, EventID)
-              index + 1
-            Wend
-            
-            FinishDatabaseQuery(#DB_History)
-          EndIf
-          
-          ; display the first file
-          If CountGadgetItems(#GADGET_History_FileCombo) > 0
-            SetGadgetState(#GADGET_History_FileCombo, 0)
-            History_FillFileList()
-          EndIf
-          
-        EndProcedure
-        
-        
-        Procedure History_FillSessionTree()
-          
-          ClearGadgetItems(#GADGET_History_SessionTree)
-          
-          Index = GetGadgetState(#GADGET_History_SessionCombo)
-          If Index = -1
-            ProcedureReturn
-          EndIf
-          
-          sid = GetGadgetItemData(#GADGET_History_SessionCombo, Index)
-          
-          ; decide whether to display time and date or only time
-          ; if people use a laptop and don't shut down the IDE, a session can last many days
-          ; use dateTime if the first and last event are on different days
-          UseDates = #False
-          If DatabaseQuery(#DB_History, "SELECT MIN(time), MAX(time) FROM event WHERE session_id = " + Str(sid))
-            If NextDatabaseRow(#DB_History)
-              MinTime = GetDatabaseLong(#DB_History, 0)
-              MaxTime = GetDatabaseLong(#DB_History, 1)
-              If Day(MinTime) <> Day(MaxTime) Or Month(MinTime) <> Month(MaxTime) Or Year(MinTime) <> Year(MaxTime)
-                UseDates = #True
-              EndIf
-            EndIf
-            FinishDatabaseQuery(#DB_History)
-          EndIf
-          
-          If DatabaseQuery(#DB_History, "SELECT event_id, filename, time, event FROM event WHERE session_id = " + Str(sid) + " ORDER BY filename ASC, time ASC")
-            
-            LastFile$ = ""
-            index = 0
-            While NextDatabaseRow(#DB_History)
-              EventID      = GetDatabaseLong(#DB_History, 0)
-              File$        = GetDatabaseString(#DB_History, 1)
-              Time         = GetDatabaseLong(#DB_History, 2)
-              Action       = GetDatabaseLong(#DB_History, 3)
-              
-              If File$ <> LastFile$
-                FileName$ = History_FileDisplayName(File$)
-                
-                AddGadgetItem(#GADGET_History_SessionTree, index, FileName$, OptionalImageID(#IMAGE_History_File), 0)
-                SetGadgetItemData(#GADGET_History_SessionTree, index, -1)
-                index + 1
-                
-                LastFile$ = File$
-              EndIf
-              
-              ImageID = OptionalImageID(#IMAGE_History_First + Action)
-              
-              If UseDates
-                TimeStr$ = DateTimeToString(Time)
-              Else
-                TimeStr$ = TimeToString(Time)
-              EndIf
-              
-              AddGadgetItem(#GADGET_History_SessionTree, index, TimeStr$, ImageID, 1)
-              SetGadgetItemData(#GADGET_History_SessionTree, index, EventID)
-              index + 1
-            Wend
-            
-            FinishDatabaseQuery(#DB_History)
-            
-            For i = 0 To index-1
-              If GetGadgetItemAttribute(#GADGET_History_SessionTree, i,  #PB_Tree_SubLevel) = 0
-                SetGadgetItemState(#GADGET_History_SessionTree, i, #PB_Tree_Expanded)
-              EndIf
-            Next i
-            
-          EndIf
-          
-        EndProcedure
-        
-        Procedure History_FillSessionCombo(DisplaySID)
-          
-          ; display current session if no other one is indicated
-          If DisplaySID = -1
-            DisplaySID = SessionID
-          EndIf
-          SelectedSessionIndex = 0
-          
-          If DatabaseQuery(#DB_History, "SELECT session_id, os_id, version, user, start_time, end_time FROM session ORDER BY start_time DESC")
-            index = 0
-            While NextDatabaseRow(#DB_History)
-              sid       = GetDatabaseLong(#DB_History, 0)
-              osid$     = GetDatabaseString(#DB_History, 1)
-              Version$  = GetDatabaseString(#DB_History, 2)
-              User$     = GetDatabaseString(#DB_History, 3)
-              StartTime = GetDatabaseLong(#DB_History, 4)
-              EndTime   = GetDatabaseLong(#DB_History, 5)
-              
-              Session$ = History_SessionDisplayName(sid, osid$, Version$, User$, StartTime, EndTime)
-              
-              If sid = DisplaySID
-                SelectedSessionIndex = index
-              EndIf
-              
-              AddGadgetItem(#GADGET_History_SessionCombo, index, Session$)
-              SetGadgetItemData(#GADGET_History_SessionCombo, index, sid)
-              index + 1
-            Wend
-            
-            FinishDatabaseQuery(#DB_History)
-          EndIf
-          
-          ; display the current session
-          If CountGadgetItems(#GADGET_History_SessionCombo) > 0
-            SetGadgetState(#GADGET_History_SessionCombo, SelectedSessionIndex)
-            History_FillSessionTree()
-          EndIf
-          
-        EndProcedure
-        
-        
-        
-        
-        
-        Procedure OpenEditHistoryWindow(DisplaySID = -1)
-          
-          If HistoryActive = 0
-            ProcedureReturn
-          EndIf
-          
-          ; Calculate start of the current day for the TimeToString() procedure
-          CurrentDate = Date()
-          StartOfDay = Date(Year(CurrentDate), Month(CurrentDate), Day(CurrentDate), 0, 0, 0)
-          
-          ClearMap(HistoryFirstLines())
-          
-          If IsWindow(#WINDOW_EditHistory) = 0
-            
-            EditHistoryDialog = OpenDialog(?Dialog_History, WindowID(#WINDOW_Main), @EditHistoryPosition)
-            If EditHistoryDialog
-              EnsureWindowOnDesktop(#WINDOW_EditHistory)
-              
-              InitCodeViewer(#GADGET_History_Source, EnableLineNumbers)
-              HideWindow(#WINDOW_EditHistory, 0)
-              
-              SetGadgetState(#GADGET_History_Splitter, EditHistorySplitter)
-            EndIf
-            
-          Else
-            SetWindowForeground(#WINDOW_EditHistory)
-          EndIf
-          
-          ; make sure all events are written to the db
-          History_FlushEvents()
-          
-          ; refresh display
-          History_FillSessionCombo(DisplaySID)
-          History_FillFileCombo()
-          
-          CurrentHistoryFile$ = ""
-          CurrentHistorySource = -1
-          
-        EndProcedure
-        
-        Procedure UpdateEditHistoryWindow()
-          
-          EditHistoryDialog\LanguageUpdate()
-          EditHistoryDialog\GuiUpdate()
-          UpdateCodeViewer(#GADGET_History_Source)
-          
-        EndProcedure
-        
-        Procedure EditHistoryWindowEvent(EventID)
-          
-          Select EventID
-              
-            Case #PB_Event_Gadget
-              Select EventGadget()
-                  
-                Case #GADGET_History_Splitter
-                  CompilerIf #CompileWindows
-                    ; just update the column width. the rest is automatic
-                    SendMessage_(GadgetID(#GADGET_History_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-                  CompilerElse
-                    ; need to resize the gui accordingly
-                    EditHistoryDialog\SizeUpdate()
-                  CompilerEndIf
-                  
-                Case #GADGET_History_SessionCombo
-                  History_FillSessionTree()
-                  
-                Case #GADGET_History_SessionTree
-                  Index = GetGadgetState(#GADGET_History_SessionTree)
-                  If Index <> -1
-                    EventID = GetGadgetItemData(#GADGET_History_SessionTree, Index)
-                    If EventID <> -1
-                      History_ShowEventSource(EventID)
-                    EndIf
-                  EndIf
-                  
-                Case #GADGET_History_FileCombo
-                  History_FillFileList()
-                  
-                Case #GADGET_History_FileList
-                  Index = GetGadgetState(#GADGET_History_FileList)
-                  If Index <> -1
-                    EventID = GetGadgetItemData(#GADGET_History_FileList, Index)
-                    If EventID <> -1
-                      History_ShowEventSource(EventID)
-                    EndIf
-                  EndIf
-                  
-                  
-              EndSelect
-              
-            Case #PB_Event_CloseWindow
-              If MemorizeWindow
-                EditHistorySplitter = GetGadgetState(#GADGET_History_Splitter)
-                EditHistoryDialog\Close(@EditHistoryPosition)
-              Else
-                EditHistoryDialog\Close()
-              EndIf
-              
-              EditHistoryDialog = 0 ; Important on OS X to put back the pointer to null after closing, as it can be called in the resize callback (https://www.purebasic.fr/english/viewtopic.php?f=24&t=59703&start=60)
-              
-              ; clear the display cache
-              ForEach EventSourceCache()
-                FreeMemory(EventSourceCache()\Buffer)
-              Next EventSourceCache()
-              ClearList(EventSourceCache())
-              
-          EndSelect
-          
-        EndProcedure
-        
-        
-        
+      EndSelect
+      
+    Case #PB_Event_CloseWindow
+      If MemorizeWindow
+        EditHistorySplitter = GetGadgetState(#GADGET_History_Splitter)
+        EditHistoryDialog\Close(@EditHistoryPosition)
+      Else
+        EditHistoryDialog\Close()
+      EndIf
+      
+      EditHistoryDialog = 0 ; Important on OS X to put back the pointer to null after closing, as it can be called in the resize callback (https://www.purebasic.fr/english/viewtopic.php?f=24&t=59703&start=60)
+      
+      ; clear the display cache
+      ForEach EventSourceCache()
+        FreeMemory(EventSourceCache()\Buffer)
+      Next EventSourceCache()
+      ClearList(EventSourceCache())
+      
+  EndSelect
+  
+EndProcedure
+
+
+

--- a/PureBasicIDE/EditHistory.pb
+++ b/PureBasicIDE/EditHistory.pb
@@ -573,7 +573,7 @@ Procedure History_AsyncUpdateName(PreviousName$, Name$)
   CompilerEndIf
   
   ; Use bind variables as we cannot modify strings in this thread
-  Protected Success.i = #False
+  Protected Success = #False
   CompilerIf #PB_Compiler_Unicode
     If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"UPDATE event SET filename = ? WHERE filename = ? AND session_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
       Success = #True
@@ -604,7 +604,7 @@ Procedure History_AsyncDeleteEvent(EventID)
     Debug "Async: deleting event with id: " + Str(EventID)
   CompilerEndIf
   
-  Protected Success.i = #False
+  Protected Success = #False
   CompilerIf #PB_Compiler_Unicode
     If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"DELETE FROM event WHERE event_id = ?", -1, @*Statement, #Null) = #SQLITE_OK
       Success = #True
@@ -952,7 +952,7 @@ Procedure History_WriteEvent(*Event.HistoryEvent)
   CompilerEndIf
   
   ; Use bind variables as we cannot modify strings in this thread
-  Protected Success.i = #False
+  Protected Success = #False
   CompilerIf #PB_Compiler_Unicode
     If sqlite3_prepare16_v2(DatabaseID(#DB_History), @"INSERT INTO event(session_id, filename, event, time, type, previous_event, encoding, data) VALUES (?,?,?,?,?,?,?,?)", -1, @*Statement, #Null) = #SQLITE_OK
       Success = #True

--- a/PureBasicIDE/FileSystem.pb
+++ b/PureBasicIDE/FileSystem.pb
@@ -184,7 +184,7 @@ Procedure.s CreateRelativePath(BasePath$, FileName$)
   ;
   For x = Len(BasePath$) To 1 Step -1
     If Mid(BasePath$, x, 1) = #Separator
-      Protected CaseMode.i
+      Protected CaseMode
       CompilerIf #PB_Compiler_OS = #PB_OS_Linux
         CaseMode = #PB_String_CaseSensitive
       CompilerElse

--- a/PureBasicIDE/ProcedureBrowser.pb
+++ b/PureBasicIDE/ProcedureBrowser.pb
@@ -441,7 +441,7 @@ Procedure ProcedureBrowser_EventHandler(*Entry.ToolsPanelEntry, EventGadgetID)
     ; On OSX, for some reason we get events when you type in the Scintilla, so only react when the browser is focused
     ; as else the Caret jumps around to the selected procedure all the time
     ;
-    Protected EventValid.i = #False
+    Protected EventValid = #False
     CompilerIf #CompileMac
       If EventGadgetID = #GADGET_ProcedureBrowser And GetActiveGadget() = #GADGET_ProcedureBrowser
         EventValid = #True

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -227,990 +227,973 @@ Procedure IsPureBasicFile(FileName$)
   
   CompilerIf #SpiderBasic
     If Ext$ = "SB" Or Ext$ = "SBI" Or Ext$ = "SBF" Or Ext$ = "SBP"
-    CompilerElse
-      If Ext$ = "PB" Or Ext$ = "PBI" Or Ext$ = "PBF" Or Ext$ = "PBP"
-      CompilerEndIf
       ProcedureReturn #True
     EndIf
-    
-    ProcedureReturn #False
-  EndProcedure
+  CompilerElse
+    If Ext$ = "PB" Or Ext$ = "PBI" Or Ext$ = "PBF" Or Ext$ = "PBP"
+      ProcedureReturn #True
+    EndIf
+  CompilerEndIf
   
+  ProcedureReturn #False
+EndProcedure
+
+
+; copy the config data part of a project file
+;
+Procedure CopyProjectConfig(*Source.ProjectFileConfig, *Dest.ProjectFileConfig)
+  *Dest\FileName$   = *Source\FileName$
   
-  ; copy the config data part of a project file
-  ;
-  Procedure CopyProjectConfig(*Source.ProjectFileConfig, *Dest.ProjectFileConfig)
-    *Dest\FileName$   = *Source\FileName$
-    
-    *Dest\AutoLoad    = *Source\AutoLoad
-    *Dest\AutoScan    = *Source\AutoScan
-    *Dest\ShowPanel   = *Source\ShowPanel
-    *Dest\ShowWarning = *Source\ShowWarning
-  EndProcedure
+  *Dest\AutoLoad    = *Source\AutoLoad
+  *Dest\AutoScan    = *Source\AutoScan
+  *Dest\ShowPanel   = *Source\ShowPanel
+  *Dest\ShowWarning = *Source\ShowWarning
+EndProcedure
+
+; Clear any allocated data in a project filelist file before removing it
+;
+Procedure ClearProjectFile(*File.ProjectFile)
   
-  ; Clear any allocated data in a project filelist file before removing it
-  ;
-  Procedure ClearProjectFile(*File.ProjectFile)
-    
-    FreeSourceItemArray(@*File\Parser) ; has a 0-check and sets the value to 0
-    
-  EndProcedure
+  FreeSourceItemArray(@*File\Parser) ; has a 0-check and sets the value to 0
   
+EndProcedure
+
+
+; Unlink file from project. Set KeepData=#true if the project will not be closed
+; (so #false on project close or IDE close)
+;
+Procedure UnlinkSourceFromProject(*Source.SourceFile, RescanFile)
   
-  ; Unlink file from project. Set KeepData=#true if the project will not be closed
-  ; (so #false on project close or IDE close)
-  ;
-  Procedure UnlinkSourceFromProject(*Source.SourceFile, RescanFile)
+  If *Source\ProjectFile
+    *File.ProjectFile = *Source\ProjectFile
+    *File\Source        = 0
+    *Source\ProjectFile = 0
+    RefreshSourceTitle(*Source)
     
-    If *Source\ProjectFile
-      *File.ProjectFile = *Source\ProjectFile
-      *File\Source        = 0
-      *Source\ProjectFile = 0
-      RefreshSourceTitle(*Source)
+    If *Source = *ActiveSource
+      UpdateMenuStates()
+      UpdateMainWindowTitle()
+      ErrorLog_SyncState()
+    EndIf
+    
+    ; Re-scan the file from disk if the project data is still needed
+    ;
+    If RescanFile And *File\AutoScan
+      ScanFile(*File\FileName$, @*File\Parser)
+    EndIf
+  EndIf
+  
+EndProcedure
+
+
+; Link a sourcefile to the project
+; Just call this on all sourcefiles opened. Files outside of the project are handled correctly
+;
+Procedure LinkSourceToProject(*Source.SourceFile, *File.ProjectFile = 0)
+  
+  If *Source\FileName$ ; cannot link a non-saved file
+    
+    ; find project file (if not specified)
+    If *File = 0
+      ForEach ProjectFiles()
+        If IsEqualFile(*Source\FileName$, ProjectFiles()\FileName$)
+          *File = @ProjectFiles()
+          Break
+        EndIf
+      Next ProjectFiles()
+    EndIf
+    
+    If *Source\ProjectFile And *Source\ProjectFile <> *File
+      UnlinkSourceFromProject(*Source, #True)
+    EndIf
+    
+    ; check again, as the file may not be in the project at all
+    If *File
+      *Source\ProjectFile = *File
+      *File\Source = *Source
       
+      FreeSourceItemArray(@*File\Parser) ; free any data we have from a previous scan
+      
+      RefreshSourceTitle(*Source)
       If *Source = *ActiveSource
         UpdateMenuStates()
         UpdateMainWindowTitle()
-        ErrorLog_SyncState()
-      EndIf
-      
-      ; Re-scan the file from disk if the project data is still needed
-      ;
-      If RescanFile And *File\AutoScan
-        ScanFile(*File\FileName$, @*File\Parser)
+        ErrorLog_SyncState()     ; the state may change as now the ProjectShowLog counts
       EndIf
     EndIf
-    
-  EndProcedure
+  EndIf
   
+EndProcedure
+
+; Update the data kept on the project file, including the link to a sourcefile
+Procedure UpdateProjectFile(*File.ProjectFile)
   
-  ; Link a sourcefile to the project
-  ; Just call this on all sourcefiles opened. Files outside of the project are handled correctly
-  ;
-  Procedure LinkSourceToProject(*Source.SourceFile, *File.ProjectFile = 0)
-    
-    If *Source\FileName$ ; cannot link a non-saved file
-      
-      ; find project file (if not specified)
-      If *File = 0
-        ForEach ProjectFiles()
-          If IsEqualFile(*Source\FileName$, ProjectFiles()\FileName$)
-            *File = @ProjectFiles()
-            Break
-          EndIf
-        Next ProjectFiles()
-      EndIf
-      
-      If *Source\ProjectFile And *Source\ProjectFile <> *File
-        UnlinkSourceFromProject(*Source, #True)
-      EndIf
-      
-      ; check again, as the file may not be in the project at all
-      If *File
-        *Source\ProjectFile = *File
-        *File\Source = *Source
-        
-        FreeSourceItemArray(@*File\Parser) ; free any data we have from a previous scan
-        
-        RefreshSourceTitle(*Source)
-        If *Source = *ActiveSource
-          UpdateMenuStates()
-          UpdateMainWindowTitle()
-          ErrorLog_SyncState()     ; the state may change as now the ProjectShowLog counts
-        EndIf
-      EndIf
+  ; clear any data scanned from disk
+  FreeSourceItemArray(@*File\Parser) ; has a 0-check and sets the value to 0
+  
+  ; find the source that represents this file (if any)
+  *Source.SourceFile = 0
+  ForEach FileList()
+    If @FileList() <> *ProjectInfo And FileList()\FileName$ <> "" And IsEqualFile(*File\FileName$, FileList()\FileName$)
+      *Source = @FileList()
+      Break
+    EndIf
+  Next FileList()
+  ChangeCurrentElement(FileList(), *ActiveSource)
+  
+  If *Source
+    If *Source\ProjectFile And *Source\ProjectFile <> *File
+      UnlinkSourceFromProject(*Source, #True)
     EndIf
     
-  EndProcedure
+    If *Source\ProjectFile = 0 ; if nonzero, it equals our *File, so ok
+      LinkSourceToProject(*Source, *File)
+    EndIf
+    
+  Else
+    *File\Source = 0
+    
+    ; scan the autocomplete info from disk if required
+    If *File\AutoScan
+      ScanFile(*File\Filename$, @*File\Parser)
+    EndIf
+  EndIf
   
-  ; Update the data kept on the project file, including the link to a sourcefile
-  Procedure UpdateProjectFile(*File.ProjectFile)
+EndProcedure
+
+; Sets the default target from the target list, creating it if there is none
+;
+Procedure SetProjectDefaultTarget()
+  
+  If ListSize(ProjectTargets()) = 0
+    ; No targets are present, create a new default one
+    ;
+    AddElement(ProjectTargets())
+    SetCompileTargetDefaults(@ProjectTargets()) ; preference default values
     
-    ; clear any data scanned from disk
-    FreeSourceItemArray(@*File\Parser) ; has a 0-check and sets the value to 0
+    ProjectTargets()\ID = GetUniqueID()
     
-    ; find the source that represents this file (if any)
-    *Source.SourceFile = 0
-    ForEach FileList()
-      If @FileList() <> *ProjectInfo And FileList()\FileName$ <> "" And IsEqualFile(*File\FileName$, FileList()\FileName$)
-        *Source = @FileList()
+    ; Set project specific stuff within the target
+    ;
+    ProjectTargets()\IsProject = #True
+    ProjectTargets()\Name$     = Language("Compiler", "DefaultTargetName")
+    ProjectTargets()\IsEnabled = #True
+    ProjectTargets()\IsDefault = #True
+    *DefaultTarget = @ProjectTargets()
+    
+  Else
+    
+    FirstElement(ProjectTargets())
+    *DefaultTarget = @ProjectTargets() ; fallback, if no target has the default flag
+    
+    ForEach ProjectTargets()
+      If ProjectTargets()\IsDefault
+        *DefaultTarget = @ProjectTargets()
         Break
       EndIf
-    Next FileList()
-    ChangeCurrentElement(FileList(), *ActiveSource)
+    Next ProjectTargets()
     
-    If *Source
-      If *Source\ProjectFile And *Source\ProjectFile <> *File
-        UnlinkSourceFromProject(*Source, #True)
-      EndIf
-      
-      If *Source\ProjectFile = 0 ; if nonzero, it equals our *File, so ok
-        LinkSourceToProject(*Source, *File)
-      EndIf
-      
-    Else
-      *File\Source = 0
-      
-      ; scan the autocomplete info from disk if required
-      If *File\AutoScan
-        ScanFile(*File\Filename$, @*File\Parser)
-      EndIf
-    EndIf
-    
-  EndProcedure
-  
-  ; Sets the default target from the target list, creating it if there is none
-  ;
-  Procedure SetProjectDefaultTarget()
-    
-    If ListSize(ProjectTargets()) = 0
-      ; No targets are present, create a new default one
-      ;
-      AddElement(ProjectTargets())
-      SetCompileTargetDefaults(@ProjectTargets()) ; preference default values
-      
-      ProjectTargets()\ID = GetUniqueID()
-      
-      ; Set project specific stuff within the target
-      ;
-      ProjectTargets()\IsProject = #True
-      ProjectTargets()\Name$     = Language("Compiler", "DefaultTargetName")
-      ProjectTargets()\IsEnabled = #True
-      ProjectTargets()\IsDefault = #True
-      *DefaultTarget = @ProjectTargets()
-      
-    Else
-      
-      FirstElement(ProjectTargets())
-      *DefaultTarget = @ProjectTargets() ; fallback, if no target has the default flag
-      
-      ForEach ProjectTargets()
-        If ProjectTargets()\IsDefault
-          *DefaultTarget = @ProjectTargets()
-          Break
-        EndIf
-      Next ProjectTargets()
-      
-      ; make sure the flag value is consistent
-      ForEach ProjectTargets()
-        If *DefaultTarget = @ProjectTargets()
-          ProjectTargets()\IsDefault = #True
-        Else
-          ProjectTargets()\IsDefault = #False
-        EndIf
-      Next ProjectTargets()
-    EndIf
-    
-  EndProcedure
-  
-  Procedure ResizeProjectInfo(Width, Height)
-    
-    GetRequiredSize(#GADGET_ProjectInfo_OpenOptions, @Button1Width.l, @Button1Height.l)
-    GetRequiredSize(#GADGET_ProjectInfo_OpenCompilerOptions, @Button2Width.l, @Button2Height.l)
-    ButtonWidth  = Max(Button1Width, Max(Button2Width, 100))
-    
-    ; calculate height for info part
-    TextHeight = GetRequiredHeight(#GADGET_ProjectInfo_Info)
-    TextHeight = Max(TextHeight, Button1Height+Button2Height+5)
-    InfoHeight = 15 + ProjectInfoFrameHeight + TextHeight
-    If InfoHeight > (Height-60) / 2
-      ; info size too great, cap it
-      InfoHeight = (Height-60) / 2
-    EndIf
-    
-    CompilerIf #CompileMacCocoa
-      BorderOffset = 8
-    CompilerElse
-      BorderOffset = 0
-    CompilerEndIf
-    
-    ; size for other parts
-    PartHeight = (Height-60-InfoHeight) / 2
-    
-    ResizeGadget(#GADGET_ProjectInfo_FrameProject, 20-BorderOffset, 20-BorderOffset, Width-40, InfoHeight)
-    ResizeGadget(#GADGET_ProjectInfo_Info, 30-BorderOffset, 25+ProjectInfoFrameHeight-BorderOffset, Width-65-ButtonWidth, InfoHeight-15-ProjectInfoFrameHeight)
-    ResizeGadget(#GADGET_ProjectInfo_OpenOptions, Width-30-ButtonWidth-BorderOffset, 25+ProjectInfoFrameHeight-BorderOffset, ButtonWidth, Button1Height)
-    ResizeGadget(#GADGET_ProjectInfo_OpenCompilerOptions, Width-30-ButtonWidth-BorderOffset, 30+ProjectInfoFrameHeight+Button1Height-BorderOffset, ButtonWidth, Button1Height)
-    
-    ResizeGadget(#GADGET_ProjectInfo_FrameFiles, 20-BorderOffset, InfoHeight+30-BorderOffset, Width-40, PartHeight)
-    ResizeGadget(#GADGET_ProjectInfo_Files, 30-BorderOffset, InfoHeight+35+ProjectInfoFrameHeight-BorderOffset, Width-60, PartHeight-15-ProjectInfoFrameHeight)
-    
-    ResizeGadget(#GADGET_ProjectInfo_FrameTargets, 20-BorderOffset, InfoHeight+PartHeight+40-BorderOffset, Width-40, PartHeight)
-    ResizeGadget(#GADGET_ProjectInfo_Targets, 30-BorderOffset, InfoHeight+PartHeight+45+ProjectInfoFrameHeight-BorderOffset, Width-60, PartHeight-15-ProjectInfoFrameHeight)
-    
-    CompilerIf #CompileWindows
-      ; Will size the middle columns small, and the last as big as possible
-      For i = 1 To 6
-        If i <> 5 ; leave the "size" column alone
-          SendMessage_(GadgetID(#GADGET_ProjectInfo_Files), #LVM_SETCOLUMNWIDTH, i, #LVSCW_AUTOSIZE_USEHEADER)
-        EndIf
-      Next i
-      
-      For i = 1 To 8
-        If i <> 7 ; leave the "format" column alone
-          SendMessage_(GadgetID(#GADGET_ProjectInfo_Targets), #LVM_SETCOLUMNWIDTH, i, #LVSCW_AUTOSIZE_USEHEADER)
-        EndIf
-      Next i
-    CompilerEndIf
-    
-  EndProcedure
-  
-  Procedure.s ProjectInfo_Boolean(Input)
-    If Input
-      ProcedureReturn Language("Misc","Yes")
-    Else
-      ProcedureReturn ""
-    EndIf
-  EndProcedure
-  
-  ; Apply project data changes
-  Procedure UpdateProjectInfo()
-    If *ProjectInfo
-      
-      ; Project Info
-      ;
-      Text$ = Language("Project","ProjectName")+": " + ProjectName$ + #NewLine
-      Text$ + Language("Project","ProjectFile")+": " + ProjectFile$
-      
-      If ProjectLastOpenDate
-        Text$ + #NewLine + #NewLine
-        Text$ + Language("Project","LastOpen")+": " + ReplaceString(ReplaceString(ReplaceString(Language("Project","LastOpenText"), "%date%", FormatDate(Language("Project","FileDateFormat"), ProjectLastOpenDate)), "%user%", ProjectLastOpenUser$), "%host%", ProjectLastOpenHost$) + #NewLine
-        Text$ + Language("Project","LastOpenEditor")+": " + ProjectLastOpenEditor$
-      EndIf
-      
-      If Trim(ProjectComments$) <> ""
-        Text$ + #NewLine + #NewLine
-        Text$ + Language("Project","Comments")+": "+#NewLine
-        Text$ + ProjectComments$
-      EndIf
-      
-      SetGadgetText(#GADGET_ProjectInfo_Info, Text$)
-      
-      ; File List
-      ;
-      ClearGadgetItems(#GADGET_ProjectInfo_Files)
-      ForEach ProjectFiles()
-        Text$ = CreateRelativePath(GetPathPart(ProjectFile$), ProjectFiles()\Filename$) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectFiles()\AutoLoad) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectFiles()\ShowWarning) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectFiles()\AutoScan) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectFiles()\ShowPanel) + Chr(10)
-        
-        Size = FileSize(ProjectFiles()\Filename$)
-        If Size < 0 ; file missing
-          Text$ + Chr(10) + Chr(10)
-        Else
-          Text$ + StrByteSize(Size) + Chr(10)
-          Text$ + FormatDate(Language("Project","FileDateFormat"), GetFileDate(ProjectFiles()\Filename$, #PB_Date_Modified))
-        EndIf
-        
-        If ProjectFiles()\AutoScan
-          ImageID = OptionalImageID(#IMAGE_ProjectPanel_FileScanned)
-        Else
-          ImageID = OptionalImageID(#IMAGE_ProjectPanel_File)
-        EndIf
-        AddGadgetItem(#GADGET_ProjectInfo_Files, -1, Text$, ImageID)
-        
-        ; Associate the ProjectFile structure (for the Popup menu)
-        SetGadgetItemData(#GADGET_ProjectInfo_Files, CountGadgetItems(#GADGET_ProjectInfo_Files)-1, @ProjectFiles())
-      Next ProjectFiles()
-      
-      ; Target list
-      ;
-      ClearGadgetItems(#GADGET_ProjectInfo_Targets)
-      ForEach ProjectTargets()
-        Text$ = ProjectTargets()\Name$ + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectTargets()\Debugger) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableThread) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableASM) + Chr(10)
-        Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableOnError) + Chr(10)
-        
-        If ProjectTargets()\UseCompileCount
-          Text$ + Str(ProjectTargets()\CompileCount) + Chr(10)
-        Else
-          Text$ + Chr(10)
-        EndIf
-        
-        If ProjectTargets()\UseBuildCount
-          Text$ + Str(ProjectTargets()\BuildCount) + Chr(10)
-        Else
-          Text$ + Chr(10)
-        EndIf
-        
-        ; These are also not localized in the Compile Options/Preferences
-        ;
-        Select ProjectTargets()\ExecutableFormat
-            CompilerIf #CompileWindows
-            Case 0: Text$ + "Windows" + Chr(10)
-            Case 1: Text$ + "Console" + Chr(10)
-            Case 2: Text$ + "Dll" + Chr(10)
-            CompilerEndIf
-            
-            CompilerIf #CompileLinux
-            Case 0: Text$ + "Linux" + Chr(10)
-            Case 1: Text$ + "Console" + Chr(10)
-            Case 2: Text$ + ".so" + Chr(10)
-            CompilerEndIf
-            
-            CompilerIf #CompileMac
-            Case 0: Text$ + "MacOS" + Chr(10)
-            Case 1: Text$ + "Console" + Chr(10)
-            Case 2: Text$ + ".dylib" + Chr(10)
-            CompilerEndIf
-        EndSelect
-        
-        Text$ + ProjectTargets()\MainFile$
-        AddGadgetItem(#GADGET_ProjectInfo_Targets, -1, Text$, ProjectTargetImage(@ProjectTargets()))
-      Next ProjectTargets()
-      
-      ResizeProjectInfo(GadgetWidth(#GADGET_ProjectInfo), GadgetHeight(#GADGET_ProjectInfo))
-    EndIf
-    
-  EndProcedure
-  
-  ; Apply preferences changes
-  Procedure UpdateProjectInfoPreferences()
-    If *ProjectInfo
-      SetTabBarGadgetItemText(#GADGET_FilesPanel, 0, "> " + Language("Project","TabTitle"))
-      
-      SetGadgetText(#GADGET_ProjectInfo_FrameProject, Language("Project","ProjectInfo"))
-      SetGadgetText(#GADGET_ProjectInfo_FrameFiles, Language("Project","FileTab"))
-      SetGadgetText(#GADGET_ProjectInfo_FrameTargets, Language("Project","ProjectTargets"))
-      
-      SetGadgetText(#GADGET_ProjectInfo_OpenOptions, Language("Project","ProjectOptions"))
-      SetGadgetText(#GADGET_ProjectInfo_OpenCompilerOptions, Language("Project","CompilerOptions"))
-      
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","Filename"), 0)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileLoadShort"), 1)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileWarnShort"), 2)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileScanShort"), 3)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FilePanelShort"), 4)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileSize"), 5)
-      SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileModified"), 6)
-      
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","TargetShort"), 0)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","DebugShort"), 1)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","ThreadShort"), 2)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","AsmShort"), 3)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","OnErrorShort"), 4)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","CompileCountShort"), 5)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","BuildCountShort"), 6)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","FormatShort"), 7)
-      SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","InputFile"), 8)
-      
-      ; to autosize the columns on Windows
-      ResizeProjectInfo(GadgetWidth(#GADGET_ProjectInfo), GadgetHeight(#GADGET_ProjectInfo))
-      
-      ; Theme icons and content get changed in a normal update
-      UpdateProjectInfo()
-    EndIf
-  EndProcedure
-  
-  
-  
-  Procedure AddProjectInfo()
-    If *ProjectInfo = 0
-      
-      ; The Project info is always at the beginning
-      FirstElement(FileList())
-      *ProjectInfo = InsertElement(FileList())
-      
-      If *ProjectInfo
-        
-        OpenGadgetList(#GADGET_SourceContainer)
-        
-        ; Create the ProjectInfo gadgets
-        ;
-        ContainerGadget(#GADGET_ProjectInfo, 0, 0, 0, 0, #PB_Container_Double)
-        FrameGadget(#GADGET_ProjectInfo_FrameProject, 0, 0, 0, 0, Language("Project","ProjectInfo"))
-        CompilerIf #CompileWindows
-          ProjectInfoFlags = #SS_LEFTNOWORDWRAP
-        CompilerEndIf
-        TextGadget(#GADGET_ProjectInfo_Info, 0, 0, 0, 0, "", ProjectInfoFlags)
-        ButtonGadget(#GADGET_ProjectInfo_OpenOptions, 0, 0, 0, 0, Language("Project","ProjectOptions"))
-        ButtonGadget(#GADGET_ProjectInfo_OpenCompilerOptions, 0, 0, 0, 0, Language("Project","CompilerOptions"))
-        
-        FrameGadget(#GADGET_ProjectInfo_FrameFiles, 0, 0, 0, 0, Language("Project","FileTab"))
-        ListIconGadget(#GADGET_ProjectInfo_Files, 0, 0, 0, 0, Language("Project","Filename"), 300, #PB_ListIcon_GridLines|#PB_ListIcon_FullRowSelect|#PB_ListIcon_MultiSelect)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 1, Language("Project","FileLoadShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 2, Language("Project","FileWarnShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 3, Language("Project","FileScanShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 4, Language("Project","FilePanelShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 5, Language("Project","FileSize"), 80)
-        AddGadgetColumn(#GADGET_ProjectInfo_Files, 6, Language("Project","FileModified"), 60)
-        
-        CompilerIf #CompileWindows
-          ; Make the settings columns centered for a better look
-          For i = 1 To 4
-            column.LVCOLUMN\mask = #LVCF_FMT
-            column\fmt = #LVCFMT_CENTER
-            SendMessage_(GadgetID(#GADGET_ProjectInfo_Files), #LVM_SETCOLUMN, i, @column)
-          Next i
-        CompilerEndIf
-        
-        FrameGadget(#GADGET_ProjectInfo_FrameTargets, 0, 0, 0, 0, Language("Project","ProjectTargets"))
-        ListIconGadget(#GADGET_ProjectInfo_Targets, 0, 0, 0, 0, Language("Project","TargetShort"), 200, #PB_ListIcon_GridLines|#PB_ListIcon_FullRowSelect)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 1, Language("Project","DebugShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 2, Language("Project","ThreadShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 3, Language("Project","AsmShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 4, Language("Project","OnErrorShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 5, Language("Project","CompileCountShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 6, Language("Project","BuildCountShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 7, Language("Project","FormatShort"), 60)
-        AddGadgetColumn(#GADGET_ProjectInfo_Targets, 8, Language("Project","InputFile"), 200)
-        
-        CompilerIf #CompileWindows
-          ; Make the settings columns centered for a better look
-          For i = 1 To 7
-            column.LVCOLUMN\mask = #LVCF_FMT
-            column\fmt = #LVCFMT_CENTER
-            SendMessage_(GadgetID(#GADGET_ProjectInfo_Targets), #LVM_SETCOLUMN, i, @column)
-          Next i
-        CompilerEndIf
-        
-        CloseGadgetList()
-        HideGadget(#GADGET_ProjectInfo, 1)
-        
-        ProjectInfoFrameHeight = Max(GadgetHeight(#GADGET_ProjectInfo_FrameProject, #PB_Gadget_RequiredSize) + 3, 10)
-        
-        ; *ActiveSource is modified in CreateEditorGadget()
-        *RealActiveSource = *ActiveSource
-        
-        ; This creates a full Scintilla with the big callback, but it is never shown,
-        ; and so it doesn't matter. This way, the code that expects a Scintilla to be
-        ; present will work without crashing
-        ;
-        CreateEditorGadget()
-        HideEditorGadget(*ProjectInfo\EditorGadget, 1) ; this is never visible
-        
-        ; Back to the active source.
-        *ActiveSource = *RealActiveSource
-        
-        CloseGadgetList()
-        
-        ; Note:
-        ;   The TabBarGadget cannot handle an Add with a number beyond the count of items
-        ;   Probably a bug that should be fixed there. But this workaround will do the trick
-        If CountTabBarGadgetItems(#GADGET_FilesPanel) = 0
-          ; first item, use #PB_Default
-          AddTabBarGadgetItem(#GADGET_FilesPanel, #PB_Default, Language("Project", "TabTitle"))
-        Else
-          ; items exist: using 0 works
-          AddTabBarGadgetItem(#GADGET_FilesPanel, 0, Language("Project", "TabTitle"))
-        EndIf
-        
-        CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
-          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-        CompilerElse
-          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-          SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
-        CompilerEndIf
-        
-        SetTabBarGadgetItemImage(#GADGET_FilesPanel, 0, OptionalImageID(#IMAGE_FilePanel_Project))
-        
-        UpdateProjectInfo()
-        ResizeMainWindow()
-      EndIf
-    EndIf
-  EndProcedure
-  
-  Procedure RemoveProjectInfo()
-    If *ProjectInfo
-      Gadget = *ProjectInfo\EditorGadget
-      
-      ChangeCurrentElement(FileList(), *ProjectInfo)
-      Index = ListIndex(FileList())
-      DeleteElement(FileList())
-      
-      If *ActiveSource = *ProjectInfo ; currently visible
-        FirstElement(FileList())
-        *ActiveSource = 0
+    ; make sure the flag value is consistent
+    ForEach ProjectTargets()
+      If *DefaultTarget = @ProjectTargets()
+        ProjectTargets()\IsDefault = #True
       Else
-        ChangeCurrentElement(FileList(), *ActiveSource)
+        ProjectTargets()\IsDefault = #False
       EndIf
-      
-      RemoveTabBarGadgetItem(#GADGET_FilesPanel, Index)
-      
-      ; Its important to 0 this before the next ChangeActiveSourcecode()
-      *ProjectInfo = 0
-      
-      ChangeActiveSourcecode()
-      FreeEditorGadget(Gadget)
-      
-      If *ActiveSource
-        SetActiveGadget(*ActiveSource\EditorGadget)
-      EndIf
-      
-      FreeGadget(#GADGET_ProjectInfo)
-    EndIf
-  EndProcedure
+    Next ProjectTargets()
+  EndIf
   
-  ; Check the project version on the XML
-  ; returns true/false to load/not load
-  ;
-  Procedure CheckProjectVersion(Filename$)
-    
-    VersionString$ = GetXMLAttribute(MainXMLNode(#XML_LoadProject), "version")
-    Creator$       = GetXMLAttribute(MainXMLNode(#XML_LoadProject), "creator")
-    
-    version = Int(ValD(VersionString$) * 100.0)
-    If GetXMLAttribute(MainXMLNode(#XML_LoadProject), "minversion") = ""
-      minversion = 0
-    Else
-      minversion = Int(ValD(GetXMLAttribute(MainXMLNode(#XML_LoadProject), "minversion")) * 100.0)
-    EndIf
-    
-    If version < #Project_Version
-      Text$ = Language("Project","VersionLow") + #NewLine
-      Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
-      Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
-      Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
-      Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$ + #NewLine
-      If CommandlineBuild = 0
-        Text$ + #NewLine + Language("Project", "LoadAnyway")
-        If MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_No
-          ProcedureReturn #False
-        EndIf
-      Else
-        PrintN(Text$)
-        ProcedureReturn #False
-      EndIf
-      
-      
-    ElseIf version > #Project_Version And minversion <= #Project_Version
-      Text$ = Language("Project","VersionHigh") + #NewLine
-      Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
-      Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
-      Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
-      Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$ + #NewLine
-      If CommandlineBuild = 0
-        Text$ + #NewLine + Language("Project", "LoadAnyway")
-        If MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_No
-          ProcedureReturn #False
-        EndIf
-      Else
-        PrintN(Text$)
-        ProcedureReturn #False
-      EndIf
-      
-    ElseIf version > #Project_Version
-      Text$ = Language("Project","VersionTooHigh") + #NewLine
-      Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
-      Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
-      Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
-      Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$
-      
-      If CommandlineBuild = 0
-        MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Error)
-      Else
-        PrintN(Text$)
-      EndIf
-      ProcedureReturn #False
-      
-    EndIf
-    
-    ProcedureReturn #True
-  EndProcedure
+EndProcedure
+
+Procedure ResizeProjectInfo(Width, Height)
   
+  GetRequiredSize(#GADGET_ProjectInfo_OpenOptions, @Button1Width.l, @Button1Height.l)
+  GetRequiredSize(#GADGET_ProjectInfo_OpenCompilerOptions, @Button2Width.l, @Button2Height.l)
+  ButtonWidth  = Max(Button1Width, Max(Button2Width, 100))
   
-  ; displays an error if it fails, returns true/false
-  ;
-  Procedure LoadProject(Filename$)
-    Error$  = ""
-    Success = #False
+  ; calculate height for info part
+  TextHeight = GetRequiredHeight(#GADGET_ProjectInfo_Info)
+  TextHeight = Max(TextHeight, Button1Height+Button2Height+5)
+  InfoHeight = 15 + ProjectInfoFrameHeight + TextHeight
+  If InfoHeight > (Height-60) / 2
+    ; info size too great, cap it
+    InfoHeight = (Height-60) / 2
+  EndIf
+  
+  CompilerIf #CompileMacCocoa
+    BorderOffset = 8
+  CompilerElse
+    BorderOffset = 0
+  CompilerEndIf
+  
+  ; size for other parts
+  PartHeight = (Height-60-InfoHeight) / 2
+  
+  ResizeGadget(#GADGET_ProjectInfo_FrameProject, 20-BorderOffset, 20-BorderOffset, Width-40, InfoHeight)
+  ResizeGadget(#GADGET_ProjectInfo_Info, 30-BorderOffset, 25+ProjectInfoFrameHeight-BorderOffset, Width-65-ButtonWidth, InfoHeight-15-ProjectInfoFrameHeight)
+  ResizeGadget(#GADGET_ProjectInfo_OpenOptions, Width-30-ButtonWidth-BorderOffset, 25+ProjectInfoFrameHeight-BorderOffset, ButtonWidth, Button1Height)
+  ResizeGadget(#GADGET_ProjectInfo_OpenCompilerOptions, Width-30-ButtonWidth-BorderOffset, 30+ProjectInfoFrameHeight+Button1Height-BorderOffset, ButtonWidth, Button1Height)
+  
+  ResizeGadget(#GADGET_ProjectInfo_FrameFiles, 20-BorderOffset, InfoHeight+30-BorderOffset, Width-40, PartHeight)
+  ResizeGadget(#GADGET_ProjectInfo_Files, 30-BorderOffset, InfoHeight+35+ProjectInfoFrameHeight-BorderOffset, Width-60, PartHeight-15-ProjectInfoFrameHeight)
+  
+  ResizeGadget(#GADGET_ProjectInfo_FrameTargets, 20-BorderOffset, InfoHeight+PartHeight+40-BorderOffset, Width-40, PartHeight)
+  ResizeGadget(#GADGET_ProjectInfo_Targets, 30-BorderOffset, InfoHeight+PartHeight+45+ProjectInfoFrameHeight-BorderOffset, Width-60, PartHeight-15-ProjectInfoFrameHeight)
+  
+  CompilerIf #CompileWindows
+    ; Will size the middle columns small, and the last as big as possible
+    For i = 1 To 6
+      If i <> 5 ; leave the "size" column alone
+        SendMessage_(GadgetID(#GADGET_ProjectInfo_Files), #LVM_SETCOLUMNWIDTH, i, #LVSCW_AUTOSIZE_USEHEADER)
+      EndIf
+    Next i
     
-    If IsProject And IsEqualFile(Filename$, ProjectFile$)
-      ProcedureReturn #True ; there is no sense in reloading the project (it even causes trouble, as we load before we close/save)
-    EndIf
+    For i = 1 To 8
+      If i <> 7 ; leave the "format" column alone
+        SendMessage_(GadgetID(#GADGET_ProjectInfo_Targets), #LVM_SETCOLUMNWIDTH, i, #LVSCW_AUTOSIZE_USEHEADER)
+      EndIf
+    Next i
+  CompilerEndIf
+  
+EndProcedure
+
+Procedure.s ProjectInfo_Boolean(Input)
+  If Input
+    ProcedureReturn Language("Misc","Yes")
+  Else
+    ProcedureReturn ""
+  EndIf
+EndProcedure
+
+; Apply project data changes
+Procedure UpdateProjectInfo()
+  If *ProjectInfo
     
-    WarnFiles$ = "" ; files that were modified while closed
-    
-    ; Load the XML and validate the main node and namespace
+    ; Project Info
     ;
-    IsLoaded = 0
-    If LoadXML(#XML_LoadProject, FileName$)
-      If XMLStatus(#XML_LoadProject) = #PB_XML_Success And MainXMLNode(#XML_LoadProject)
-        If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = #ProjectFileNamespace$ + "/project"
-          IsLoaded = 1
-        EndIf
-      EndIf
+    Text$ = Language("Project","ProjectName")+": " + ProjectName$ + #NewLine
+    Text$ + Language("Project","ProjectFile")+": " + ProjectFile$
+    
+    If ProjectLastOpenDate
+      Text$ + #NewLine + #NewLine
+      Text$ + Language("Project","LastOpen")+": " + ReplaceString(ReplaceString(ReplaceString(Language("Project","LastOpenText"), "%date%", FormatDate(Language("Project","FileDateFormat"), ProjectLastOpenDate)), "%user%", ProjectLastOpenUser$), "%host%", ProjectLastOpenHost$) + #NewLine
+      Text$ + Language("Project","LastOpenEditor")+": " + ProjectLastOpenEditor$
     EndIf
     
-    If IsLoaded
+    If Trim(ProjectComments$) <> ""
+      Text$ + #NewLine + #NewLine
+      Text$ + Language("Project","Comments")+": "+#NewLine
+      Text$ + ProjectComments$
+    EndIf
+    
+    SetGadgetText(#GADGET_ProjectInfo_Info, Text$)
+    
+    ; File List
+    ;
+    ClearGadgetItems(#GADGET_ProjectInfo_Files)
+    ForEach ProjectFiles()
+      Text$ = CreateRelativePath(GetPathPart(ProjectFile$), ProjectFiles()\Filename$) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectFiles()\AutoLoad) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectFiles()\ShowWarning) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectFiles()\AutoScan) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectFiles()\ShowPanel) + Chr(10)
       
-      If CheckProjectVersion(FileName$) And CloseProject() ; Close the previous project (If any). If the user cancel the previous project closing, we have to stop.
-        Success = #True
-        *Main   = MainXMLNode(#XML_LoadProject)
+      Size = FileSize(ProjectFiles()\Filename$)
+      If Size < 0 ; file missing
+        Text$ + Chr(10) + Chr(10)
+      Else
+        Text$ + StrByteSize(Size) + Chr(10)
+        Text$ + FormatDate(Language("Project","FileDateFormat"), GetFileDate(ProjectFiles()\Filename$, #PB_Date_Modified))
+      EndIf
+      
+      If ProjectFiles()\AutoScan
+        ImageID = OptionalImageID(#IMAGE_ProjectPanel_FileScanned)
+      Else
+        ImageID = OptionalImageID(#IMAGE_ProjectPanel_File)
+      EndIf
+      AddGadgetItem(#GADGET_ProjectInfo_Files, -1, Text$, ImageID)
+      
+      ; Associate the ProjectFile structure (for the Popup menu)
+      SetGadgetItemData(#GADGET_ProjectInfo_Files, CountGadgetItems(#GADGET_ProjectInfo_Files)-1, @ProjectFiles())
+    Next ProjectFiles()
+    
+    ; Target list
+    ;
+    ClearGadgetItems(#GADGET_ProjectInfo_Targets)
+    ForEach ProjectTargets()
+      Text$ = ProjectTargets()\Name$ + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectTargets()\Debugger) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableThread) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableASM) + Chr(10)
+      Text$ + ProjectInfo_Boolean(ProjectTargets()\EnableOnError) + Chr(10)
+      
+      If ProjectTargets()\UseCompileCount
+        Text$ + Str(ProjectTargets()\CompileCount) + Chr(10)
+      Else
+        Text$ + Chr(10)
+      EndIf
+      
+      If ProjectTargets()\UseBuildCount
+        Text$ + Str(ProjectTargets()\BuildCount) + Chr(10)
+      Else
+        Text$ + Chr(10)
+      EndIf
+      
+      ; These are also not localized in the Compile Options/Preferences
+      ;
+      Select ProjectTargets()\ExecutableFormat
+          CompilerIf #CompileWindows
+          Case 0: Text$ + "Windows" + Chr(10)
+          Case 1: Text$ + "Console" + Chr(10)
+          Case 2: Text$ + "Dll" + Chr(10)
+          CompilerEndIf
+          
+          CompilerIf #CompileLinux
+          Case 0: Text$ + "Linux" + Chr(10)
+          Case 1: Text$ + "Console" + Chr(10)
+          Case 2: Text$ + ".so" + Chr(10)
+          CompilerEndIf
+          
+          CompilerIf #CompileMac
+          Case 0: Text$ + "MacOS" + Chr(10)
+          Case 1: Text$ + "Console" + Chr(10)
+          Case 2: Text$ + ".dylib" + Chr(10)
+          CompilerEndIf
+      EndSelect
+      
+      Text$ + ProjectTargets()\MainFile$
+      AddGadgetItem(#GADGET_ProjectInfo_Targets, -1, Text$, ProjectTargetImage(@ProjectTargets()))
+    Next ProjectTargets()
+    
+    ResizeProjectInfo(GadgetWidth(#GADGET_ProjectInfo), GadgetHeight(#GADGET_ProjectInfo))
+  EndIf
+  
+EndProcedure
+
+; Apply preferences changes
+Procedure UpdateProjectInfoPreferences()
+  If *ProjectInfo
+    SetTabBarGadgetItemText(#GADGET_FilesPanel, 0, "> " + Language("Project","TabTitle"))
+    
+    SetGadgetText(#GADGET_ProjectInfo_FrameProject, Language("Project","ProjectInfo"))
+    SetGadgetText(#GADGET_ProjectInfo_FrameFiles, Language("Project","FileTab"))
+    SetGadgetText(#GADGET_ProjectInfo_FrameTargets, Language("Project","ProjectTargets"))
+    
+    SetGadgetText(#GADGET_ProjectInfo_OpenOptions, Language("Project","ProjectOptions"))
+    SetGadgetText(#GADGET_ProjectInfo_OpenCompilerOptions, Language("Project","CompilerOptions"))
+    
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","Filename"), 0)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileLoadShort"), 1)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileWarnShort"), 2)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileScanShort"), 3)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FilePanelShort"), 4)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileSize"), 5)
+    SetGadgetItemText(#GADGET_ProjectInfo_Files, -1, Language("Project","FileModified"), 6)
+    
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","TargetShort"), 0)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","DebugShort"), 1)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","ThreadShort"), 2)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","AsmShort"), 3)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","OnErrorShort"), 4)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","CompileCountShort"), 5)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","BuildCountShort"), 6)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","FormatShort"), 7)
+    SetGadgetItemText(#GADGET_ProjectInfo_Targets, -1, Language("Project","InputFile"), 8)
+    
+    ; to autosize the columns on Windows
+    ResizeProjectInfo(GadgetWidth(#GADGET_ProjectInfo), GadgetHeight(#GADGET_ProjectInfo))
+    
+    ; Theme icons and content get changed in a normal update
+    UpdateProjectInfo()
+  EndIf
+EndProcedure
+
+
+
+Procedure AddProjectInfo()
+  If *ProjectInfo = 0
+    
+    ; The Project info is always at the beginning
+    FirstElement(FileList())
+    *ProjectInfo = InsertElement(FileList())
+    
+    If *ProjectInfo
+      
+      OpenGadgetList(#GADGET_SourceContainer)
+      
+      ; Create the ProjectInfo gadgets
+      ;
+      ContainerGadget(#GADGET_ProjectInfo, 0, 0, 0, 0, #PB_Container_Double)
+      FrameGadget(#GADGET_ProjectInfo_FrameProject, 0, 0, 0, 0, Language("Project","ProjectInfo"))
+      CompilerIf #CompileWindows
+        ProjectInfoFlags = #SS_LEFTNOWORDWRAP
+      CompilerEndIf
+      TextGadget(#GADGET_ProjectInfo_Info, 0, 0, 0, 0, "", ProjectInfoFlags)
+      ButtonGadget(#GADGET_ProjectInfo_OpenOptions, 0, 0, 0, 0, Language("Project","ProjectOptions"))
+      ButtonGadget(#GADGET_ProjectInfo_OpenCompilerOptions, 0, 0, 0, 0, Language("Project","CompilerOptions"))
+      
+      FrameGadget(#GADGET_ProjectInfo_FrameFiles, 0, 0, 0, 0, Language("Project","FileTab"))
+      ListIconGadget(#GADGET_ProjectInfo_Files, 0, 0, 0, 0, Language("Project","Filename"), 300, #PB_ListIcon_GridLines|#PB_ListIcon_FullRowSelect|#PB_ListIcon_MultiSelect)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 1, Language("Project","FileLoadShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 2, Language("Project","FileWarnShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 3, Language("Project","FileScanShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 4, Language("Project","FilePanelShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 5, Language("Project","FileSize"), 80)
+      AddGadgetColumn(#GADGET_ProjectInfo_Files, 6, Language("Project","FileModified"), 60)
+      
+      CompilerIf #CompileWindows
+        ; Make the settings columns centered for a better look
+        For i = 1 To 4
+          column.LVCOLUMN\mask = #LVCF_FMT
+          column\fmt = #LVCFMT_CENTER
+          SendMessage_(GadgetID(#GADGET_ProjectInfo_Files), #LVM_SETCOLUMN, i, @column)
+        Next i
+      CompilerEndIf
+      
+      FrameGadget(#GADGET_ProjectInfo_FrameTargets, 0, 0, 0, 0, Language("Project","ProjectTargets"))
+      ListIconGadget(#GADGET_ProjectInfo_Targets, 0, 0, 0, 0, Language("Project","TargetShort"), 200, #PB_ListIcon_GridLines|#PB_ListIcon_FullRowSelect)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 1, Language("Project","DebugShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 2, Language("Project","ThreadShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 3, Language("Project","AsmShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 4, Language("Project","OnErrorShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 5, Language("Project","CompileCountShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 6, Language("Project","BuildCountShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 7, Language("Project","FormatShort"), 60)
+      AddGadgetColumn(#GADGET_ProjectInfo_Targets, 8, Language("Project","InputFile"), 200)
+      
+      CompilerIf #CompileWindows
+        ; Make the settings columns centered for a better look
+        For i = 1 To 7
+          column.LVCOLUMN\mask = #LVCF_FMT
+          column\fmt = #LVCFMT_CENTER
+          SendMessage_(GadgetID(#GADGET_ProjectInfo_Targets), #LVM_SETCOLUMN, i, @column)
+        Next i
+      CompilerEndIf
+      
+      CloseGadgetList()
+      HideGadget(#GADGET_ProjectInfo, 1)
+      
+      ProjectInfoFrameHeight = Max(GadgetHeight(#GADGET_ProjectInfo_FrameProject, #PB_Gadget_RequiredSize) + 3, 10)
+      
+      ; *ActiveSource is modified in CreateEditorGadget()
+      *RealActiveSource = *ActiveSource
+      
+      ; This creates a full Scintilla with the big callback, but it is never shown,
+      ; and so it doesn't matter. This way, the code that expects a Scintilla to be
+      ; present will work without crashing
+      ;
+      CreateEditorGadget()
+      HideEditorGadget(*ProjectInfo\EditorGadget, 1) ; this is never visible
+      
+      ; Back to the active source.
+      *ActiveSource = *RealActiveSource
+      
+      CloseGadgetList()
+      
+      ; Note:
+      ;   The TabBarGadget cannot handle an Add with a number beyond the count of items
+      ;   Probably a bug that should be fixed there. But this workaround will do the trick
+      If CountTabBarGadgetItems(#GADGET_FilesPanel) = 0
+        ; first item, use #PB_Default
+        AddTabBarGadgetItem(#GADGET_FilesPanel, #PB_Default, Language("Project", "TabTitle"))
+      Else
+        ; items exist: using 0 works
+        AddTabBarGadgetItem(#GADGET_FilesPanel, 0, Language("Project", "TabTitle"))
+      EndIf
+      
+      CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
+        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
+        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
+      CompilerElse
+        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
+      CompilerEndIf
+      
+      SetTabBarGadgetItemImage(#GADGET_FilesPanel, 0, OptionalImageID(#IMAGE_FilePanel_Project))
+      
+      UpdateProjectInfo()
+      ResizeMainWindow()
+    EndIf
+  EndIf
+EndProcedure
+
+Procedure RemoveProjectInfo()
+  If *ProjectInfo
+    Gadget = *ProjectInfo\EditorGadget
+    
+    ChangeCurrentElement(FileList(), *ProjectInfo)
+    Index = ListIndex(FileList())
+    DeleteElement(FileList())
+    
+    If *ActiveSource = *ProjectInfo ; currently visible
+      FirstElement(FileList())
+      *ActiveSource = 0
+    Else
+      ChangeCurrentElement(FileList(), *ActiveSource)
+    EndIf
+    
+    RemoveTabBarGadgetItem(#GADGET_FilesPanel, Index)
+    
+    ; Its important to 0 this before the next ChangeActiveSourcecode()
+    *ProjectInfo = 0
+    
+    ChangeActiveSourcecode()
+    FreeEditorGadget(Gadget)
+    
+    If *ActiveSource
+      SetActiveGadget(*ActiveSource\EditorGadget)
+    EndIf
+    
+    FreeGadget(#GADGET_ProjectInfo)
+  EndIf
+EndProcedure
+
+; Check the project version on the XML
+; returns true/false to load/not load
+;
+Procedure CheckProjectVersion(Filename$)
+  
+  VersionString$ = GetXMLAttribute(MainXMLNode(#XML_LoadProject), "version")
+  Creator$       = GetXMLAttribute(MainXMLNode(#XML_LoadProject), "creator")
+  
+  version = Int(ValD(VersionString$) * 100.0)
+  If GetXMLAttribute(MainXMLNode(#XML_LoadProject), "minversion") = ""
+    minversion = 0
+  Else
+    minversion = Int(ValD(GetXMLAttribute(MainXMLNode(#XML_LoadProject), "minversion")) * 100.0)
+  EndIf
+  
+  If version < #Project_Version
+    Text$ = Language("Project","VersionLow") + #NewLine
+    Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
+    Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
+    Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
+    Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$ + #NewLine
+    If CommandlineBuild = 0
+      Text$ + #NewLine + Language("Project", "LoadAnyway")
+      If MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_No
+        ProcedureReturn #False
+      EndIf
+    Else
+      PrintN(Text$)
+      ProcedureReturn #False
+    EndIf
+    
+    
+  ElseIf version > #Project_Version And minversion <= #Project_Version
+    Text$ = Language("Project","VersionHigh") + #NewLine
+    Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
+    Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
+    Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
+    Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$ + #NewLine
+    If CommandlineBuild = 0
+      Text$ + #NewLine + Language("Project", "LoadAnyway")
+      If MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Question|#PB_MessageRequester_YesNo) = #PB_MessageRequester_No
+        ProcedureReturn #False
+      EndIf
+    Else
+      PrintN(Text$)
+      ProcedureReturn #False
+    EndIf
+    
+  ElseIf version > #Project_Version
+    Text$ = Language("Project","VersionTooHigh") + #NewLine
+    Text$ + #NewLine + Language("Project","ProjectFile") + ": " + Filename$ + #NewLine
+    Text$ + Language("Project","ProjectVersion") + ": " + VersionString$ + #NewLine
+    Text$ + Language("Project","CurrentVersion") + ": " + #Project_VersionString + #NewLine
+    Text$ + Language("Project","LastWrittenBy")  + ": " + Creator$
+    
+    If CommandlineBuild = 0
+      MessageRequester(Language("Project","TitleShort"), Text$, #FLAG_Error)
+    Else
+      PrintN(Text$)
+    EndIf
+    ProcedureReturn #False
+    
+  EndIf
+  
+  ProcedureReturn #True
+EndProcedure
+
+
+; displays an error if it fails, returns true/false
+;
+Procedure LoadProject(Filename$)
+  Error$  = ""
+  Success = #False
+  
+  If IsProject And IsEqualFile(Filename$, ProjectFile$)
+    ProcedureReturn #True ; there is no sense in reloading the project (it even causes trouble, as we load before we close/save)
+  EndIf
+  
+  WarnFiles$ = "" ; files that were modified while closed
+  
+  ; Load the XML and validate the main node and namespace
+  ;
+  IsLoaded = 0
+  If LoadXML(#XML_LoadProject, FileName$)
+    If XMLStatus(#XML_LoadProject) = #PB_XML_Success And MainXMLNode(#XML_LoadProject)
+      If ResolveXMLNodeName(MainXMLNode(#XML_LoadProject), "/") = #ProjectFileNamespace$ + "/project"
+        IsLoaded = 1
+      EndIf
+    EndIf
+  EndIf
+  
+  If IsLoaded
+    
+    If CheckProjectVersion(FileName$) And CloseProject() ; Close the previous project (If any). If the user cancel the previous project closing, we have to stop.
+      Success = #True
+      *Main   = MainXMLNode(#XML_LoadProject)
+      
+      ; add new project to "Recent projects"
+      ;
+      If CommandlineBuild = 0
+        RecentFiles_AddFile(FileName$, #True)
+      EndIf
+      
+      ; Set the project default options, in case some key is not present
+      IsProject         = 1
+      IsProjectCreation = 0
+      
+      ProjectLastOpenDate    = 0
+      ProjectLastOpenHost$   = ""
+      ProjectLastOpenUser$   = ""
+      ProjectLastOpenEditor$ = Xml_SingleLine(GetXMLAttribute(*Main, "creator"))
+      
+      ProjectFile$      = FileName$
+      ProjectName$      = Language("Project","DefaultName")
+      ProjectComments$  = ""
+      ProjectCloseFiles = 1
+      ProjectOpenMode   = 0
+      ProjectShowLog    = 1
+      AutoCloseBuildWindow = 0
+      ResetList(ProjectFiles())
+      
+      BasePath$         = GetPathPart(FileName$)
+      
+      ; User-changable configuration
+      ;
+      *Config = GetSection(*Main, "config")
+      If *Config
+        *Options = XMLNodeFromPath(*Config, "options")
+        If *Options
+          ProjectName$      = Xml_SingleLine(GetXMLAttribute(*Options, "name"))
+          ProjectCloseFiles = Xml_Boolean(GetXMLAttribute(*Options, "closefiles"), ProjectCloseFiles)
+          ProjectOpenMode   = Xml_Integer(GetXMLAttribute(*Options, "openmode"))
+        EndIf
+        ProjectComments$  = Xml_MultiLine(ReadNode(*Config, "comment"))
         
-        ; add new project to "Recent projects"
-        ;
-        If CommandlineBuild = 0
-          RecentFiles_AddFile(FileName$, #True)
+        *BuildWindow = XMLNodeFromPath(*Config, "buildwindow")
+        If *BuildWindow
+          AutoCloseBuildWindow = Xml_Boolean(GetXMLAttribute(*BuildWindow, "autoclose"), AutoCloseBuildWindow)
+        EndIf
+      EndIf
+      
+      
+      ; Automatically managed data
+      ;
+      *ConfigData = GetSection(*Main, "data")
+      If *ConfigData
+        *ViewPath = XMLNodeFromPath(*ConfigData, "explorer")
+        If *ViewPath
+          ProjectExplorerPath$   = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*ViewPath, "view")))
+          ProjectExplorerPattern = Xml_Integer(GetXMLAttribute(*ViewPath, "pattern"))
         EndIf
         
-        ; Set the project default options, in case some key is not present
-        IsProject         = 1
-        IsProjectCreation = 0
-        
-        ProjectLastOpenDate    = 0
-        ProjectLastOpenHost$   = ""
-        ProjectLastOpenUser$   = ""
-        ProjectLastOpenEditor$ = Xml_SingleLine(GetXMLAttribute(*Main, "creator"))
-        
-        ProjectFile$      = FileName$
-        ProjectName$      = Language("Project","DefaultName")
-        ProjectComments$  = ""
-        ProjectCloseFiles = 1
-        ProjectOpenMode   = 0
-        ProjectShowLog    = 1
-        AutoCloseBuildWindow = 0
-        ResetList(ProjectFiles())
-        
-        BasePath$         = GetPathPart(FileName$)
-        
-        ; User-changable configuration
-        ;
-        *Config = GetSection(*Main, "config")
-        If *Config
-          *Options = XMLNodeFromPath(*Config, "options")
-          If *Options
-            ProjectName$      = Xml_SingleLine(GetXMLAttribute(*Options, "name"))
-            ProjectCloseFiles = Xml_Boolean(GetXMLAttribute(*Options, "closefiles"), ProjectCloseFiles)
-            ProjectOpenMode   = Xml_Integer(GetXMLAttribute(*Options, "openmode"))
-          EndIf
-          ProjectComments$  = Xml_MultiLine(ReadNode(*Config, "comment"))
-          
-          *BuildWindow = XMLNodeFromPath(*Config, "buildwindow")
-          If *BuildWindow
-            AutoCloseBuildWindow = Xml_Boolean(GetXMLAttribute(*BuildWindow, "autoclose"), AutoCloseBuildWindow)
-          EndIf
+        *ShowLog = XMLNodeFromPath(*ConfigData, "log")
+        If *ShowLog
+          ProjectShowLog = Xml_Boolean(GetXMLAttribute(*ShowLog, "show"), ProjectShowLog)
         EndIf
         
+        *LastOpen = XMLNodeFromPath(*ConfigData, "lastopen")
+        If *LastOpen
+          Date$ = XML_SingleLine(GetXMLAttribute(*LastOpen, "date"))
+          If Date$ <> ""
+            ProjectLastOpenDate = ParseDate("%yyyy-%mm-%dd %hh:%ii", Date$)
+          EndIf
+          
+          ProjectLastOpenHost$ = Xml_SingleLine(GetXMLAttribute(*LastOpen, "host"))
+          ProjectLastOpenUser$ = Xml_SingleLine(GetXMLAttribute(*LastOpen, "user"))
+        EndIf
+      EndIf
+      
+      ; This is important to set to 0 as when we load one of the project files below
+      ; we have no target info yet, and this could be set from an old Project to an invalid address!
+      ;
+      *DefaultTarget = 0
+      
+      ; Project file list
+      ; (load this even in commandline build mode, so the project is correctly saved back!)
+      ;
+      *Files = GetSection(*Main, "files")
+      If *Files
+        *File = ChildXMLNode(*Files)
         
-        ; Automatically managed data
-        ;
-        *ConfigData = GetSection(*Main, "data")
-        If *ConfigData
-          *ViewPath = XMLNodeFromPath(*ConfigData, "explorer")
-          If *ViewPath
-            ProjectExplorerPath$   = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*ViewPath, "view")))
-            ProjectExplorerPattern = Xml_Integer(GetXMLAttribute(*ViewPath, "pattern"))
-          EndIf
-          
-          *ShowLog = XMLNodeFromPath(*ConfigData, "log")
-          If *ShowLog
-            ProjectShowLog = Xml_Boolean(GetXMLAttribute(*ShowLog, "show"), ProjectShowLog)
-          EndIf
-          
-          *LastOpen = XMLNodeFromPath(*ConfigData, "lastopen")
-          If *LastOpen
-            Date$ = XML_SingleLine(GetXMLAttribute(*LastOpen, "date"))
-            If Date$ <> ""
-              ProjectLastOpenDate = ParseDate("%yyyy-%mm-%dd %hh:%ii", Date$)
-            EndIf
+        While *File
+          If XMLNodeType(*File) = #PB_XML_Normal And GetXMLNodeName(*File) = "file"
+            AddElement(ProjectFiles())
+            ProjectFiles()\Filename$ = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*File, "name")))
             
-            ProjectLastOpenHost$ = Xml_SingleLine(GetXMLAttribute(*LastOpen, "host"))
-            ProjectLastOpenUser$ = Xml_SingleLine(GetXMLAttribute(*LastOpen, "user"))
-          EndIf
-        EndIf
-        
-        ; This is important to set to 0 as when we load one of the project files below
-        ; we have no target info yet, and this could be set from an old Project to an invalid address!
-        ;
-        *DefaultTarget = 0
-        
-        ; Project file list
-        ; (load this even in commandline build mode, so the project is correctly saved back!)
-        ;
-        *Files = GetSection(*Main, "files")
-        If *Files
-          *File = ChildXMLNode(*Files)
-          
-          While *File
-            If XMLNodeType(*File) = #PB_XML_Normal And GetXMLNodeName(*File) = "file"
-              AddElement(ProjectFiles())
-              ProjectFiles()\Filename$ = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*File, "name")))
-              
-              *Config = XMLNodeFromPath(*File, "config")
-              If *Config
-                ProjectFiles()\AutoLoad    = Xml_Boolean(GetXMLAttribute(*Config, "load"))
-                ProjectFiles()\AutoScan    = Xml_Boolean(GetXMLAttribute(*Config, "scan"))
-                ProjectFiles()\ShowPanel   = Xml_Boolean(GetXMLAttribute(*Config, "panel"))
-                ProjectFiles()\ShowWarning = Xml_Boolean(GetXMLAttribute(*Config, "warn"))
-                ProjectFiles()\LastOpen    = Xml_Boolean(GetXMLAttribute(*Config, "lastopen"))
-                ProjectFiles()\PanelState$ = Xml_SingleLine(GetXMLAttribute(*Config, "panelstate")) ; the default for this is "all open", so need no backward compatibility here
-              Else
-                ProjectFiles()\AutoLoad    = 0
-                ProjectFiles()\AutoScan    = IsCodeFile(ProjectFiles()\Filename$)
-                ProjectFiles()\ShowPanel   = 1
-                ProjectFiles()\ShowWarning = 1
-                ProjectFiles()\LastOpen    = 0
-                ProjectFiles()\PanelState$ = ""
-              EndIf
-              
-              *Fingerprint = XMLNodeFromPath(*File, "fingerprint")
-              If *Fingerprint
-                ProjectFiles()\Md5$ = LCase(Xml_SingleLine(GetXMLAttribute(*Fingerprint, "md5")))
-              EndIf
-            EndIf
-            
-            *File = NextXMLNode(*File)
-          Wend
-          
-        EndIf
-        
-        ; Project targets
-        ;
-        ClearList(ProjectTargets())
-        
-        *Targets = GetSection(*Main, "targets")
-        If *Targets
-          *Target = ChildXMLNode(*Targets)
-          
-          While *Target
-            If XMLNodeType(*Target) = #PB_XML_Normal And GetXMLNodeName(*Target) = "target"
-              AddElement(ProjectTargets())
-              ProjectTargets()\ID = GetUniqueID()
-              ProjectTargets()\IsProject = #True
-              ProjectTargets()\IsEnabled = Xml_Boolean(GetXMLAttribute(*Target, "enabled"))
-              ProjectTargets()\IsDefault = Xml_Boolean(GetXMLAttribute(*Target, "default"))
-              ProjectTargets()\Name$     = Xml_SingleLine(GetXMLAttribute(*Target, "name"))
-              
-              ; loop through the entries
-              ;
-              *Entry = ChildXMLNode(*Target)
-              While *Entry
-                If XMLNodeType(*Entry) = #PB_XML_Normal
-                  Select GetXMLNodeName(*Entry)
-                    Case "inputfile" :  ProjectTargets()\MainFile$         = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "outputfile":  ProjectTargets()\OutputFile$       = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "commandline": ProjectTargets()\Commandline$      = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "executable":  ProjectTargets()\ExecutableName$   = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*Entry, "value")))
-                    Case "directory":   ProjectTargets()\CurrentDirectory$ = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "subsystem":   ProjectTargets()\Subsystem$        = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "linker":      ProjectTargets()\LinkerOptions$    = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
-                    Case "watchlist":   ProjectTargets()\Watchlist$        = Xml_SingleLine(GetXMLNodeText(*Entry)) ; not stored as attribute as they may get big
-                    Case "tools":       ProjectTargets()\EnabledTools$     = Xml_SingleLine(GetXMLNodeText(*Entry))
-                      
-                    Case "compiler"
-                      ProjectTargets()\CustomCompiler = #True
-                      ProjectTargets()\CompilerVersion$ = Xml_SingleLine(GetXMLAttribute(*Entry, "version"))
-                      
-                    Case "options"
-                      ProjectTargets()\EnableASM     = Xml_Boolean(GetXMLAttribute(*Entry, "asm"))
-                      ProjectTargets()\EnableThread  = Xml_Boolean(GetXMLAttribute(*Entry, "thread"))
-                      ProjectTargets()\EnableXP      = Xml_Boolean(GetXMLAttribute(*Entry, "xpskin"))
-                      ProjectTargets()\EnableAdmin   = Xml_Boolean(GetXMLAttribute(*Entry, "admin"))
-                      ProjectTargets()\EnableUser    = Xml_Boolean(GetXMLAttribute(*Entry, "user"))
-                      ProjectTargets()\DPIAware      = Xml_Boolean(GetXMLAttribute(*Entry, "dpiaware"))
-                      ProjectTargets()\EnableOnError = Xml_Boolean(GetXMLAttribute(*Entry, "onerror"))
-                      ProjectTargets()\Debugger      = Xml_Boolean(GetXMLAttribute(*Entry, "debug"))
-                      ProjectTargets()\EnableUnicode = Xml_Boolean(GetXMLAttribute(*Entry, "unicode"))
-                      
-                      CompilerIf #SpiderBasic
-                        ProjectTargets()\OptimizeJS    = Xml_Boolean(GetXMLAttribute(*Entry, "optimizejs"))
-                        ProjectTargets()\WebServerAddress$ = Xml_SingleLine(GetXMLAttribute(*Entry, "webserveraddress"))
-                        ProjectTargets()\WindowTheme$  = Xml_SingleLine(GetXMLAttribute(*Entry, "windowtheme"))
-                        ProjectTargets()\GadgetTheme$  = Xml_SingleLine(GetXMLAttribute(*Entry, "gadgettheme"))
-                      CompilerEndIf
-                      
-                      CompilerIf #SpiderBasic
-                      Case "export"
-                        ProjectTargets()\WebAppName$            = Xml_SingleLine(GetXMLAttribute(*Entry, "webappname"))
-                        ProjectTargets()\WebAppIcon$            = Xml_SingleLine(GetXMLAttribute(*Entry, "webappicon"))
-                        ProjectTargets()\HtmlFilename$          = Xml_SingleLine(GetXMLAttribute(*Entry, "htmlfilename"))
-                        ProjectTargets()\JavaScriptFilename$    = Xml_SingleLine(GetXMLAttribute(*Entry, "javascriptfilename"))
-                        ProjectTargets()\JavaScriptPath$        = Xml_SingleLine(GetXMLAttribute(*Entry, "javascriptpath"))
-                        ProjectTargets()\CopyJavaScriptLibrary  = Xml_Boolean   (GetXMLAttribute(*Entry, "copyjavascriptlibrary"))
-                        ProjectTargets()\ExportCommandLine$     = Xml_SingleLine(GetXMLAttribute(*Entry, "exportcommandline"))
-                        ProjectTargets()\ExportArguments$       = Xml_SingleLine(GetXMLAttribute(*Entry, "exportarguments"))
-                        ProjectTargets()\EnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "enableresourcedirectory"))
-                        ProjectTargets()\ResourceDirectory$     = Xml_SingleLine(GetXMLAttribute(*Entry, "resourcedirectory"))
-                        ProjectTargets()\WebAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "webappenabledebugger"))
-                        
-                        ProjectTargets()\iOSAppName$         = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappname"))
-                        ProjectTargets()\iOSAppIcon$         = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappicon"))
-                        ProjectTargets()\iOSAppVersion$      = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappversion"))
-                        ProjectTargets()\iOSAppPackageID$    = Xml_SingleLine(GetXMLAttribute(*Entry, "iosapppackageid"))
-                        ProjectTargets()\iOSAppStartupImage$ = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappstartupimage"))
-                        ProjectTargets()\iOSAppOrientation   = Val(Xml_SingleLine(GetXMLAttribute(*Entry, "iosapporientation")))
-                        ProjectTargets()\iOSAppFullScreen    = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappfullscreen"))
-                        ProjectTargets()\iOSAppGeolocation   = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappgeolocation"))
-                        ProjectTargets()\iOSAppOutput$       = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappoutput"))
-                        ProjectTargets()\iOSAppAutoUpload    = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappautoupload"))
-                        ProjectTargets()\iOSAppEnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappenableresourcedirectory"))
-                        ProjectTargets()\iOSAppResourceDirectory$      = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappresourcedirectory"))
-                        ProjectTargets()\iOSAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappenabledebugger"))
-                        
-                        ProjectTargets()\AndroidAppName$         = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappname"))
-                        ProjectTargets()\AndroidAppIcon$         = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappicon"))
-                        ProjectTargets()\AndroidAppVersion$      = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappversion"))
-                        ProjectTargets()\AndroidAppPackageID$    = Xml_SingleLine(GetXMLAttribute(*Entry, "androidapppackageid"))
-                        ProjectTargets()\AndroidAppIAPKey$       = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappiapkey"))
-                        ProjectTargets()\AndroidAppStartupImage$ = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappstartupimage"))
-                        ProjectTargets()\AndroidAppOrientation   = Val(Xml_SingleLine(GetXMLAttribute(*Entry, "androidapporientation")))
-                        ProjectTargets()\AndroidAppFullScreen    = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappfullscreen"))
-                        ProjectTargets()\AndroidAppGeolocation   = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappgeolocation"))
-                        ProjectTargets()\AndroidAppOutput$       = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappoutput"))
-                        ProjectTargets()\AndroidAppAutoUpload    = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappautoupload"))
-                        ProjectTargets()\AndroidAppEnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappenableresourcedirectory"))
-                        ProjectTargets()\AndroidAppResourceDirectory$      = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappresourcedirectory"))
-                        ProjectTargets()\AndroidAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappenabledebugger"))
-                      CompilerEndIf
-                      
-                    Case "purifier"
-                      ProjectTargets()\EnablePurifier = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      ProjectTargets()\PurifierGranularity$ = Xml_SingleLine(GetXMLAttribute(*Entry, "granularity"))
-                      
-                    Case "temporaryexe"
-                      If LCase(Xml_SingleLine(GetXMLAttribute(*Entry, "value"))) = "source"
-                        ProjectTargets()\TemporaryExePlace = 1
-                      EndIf
-                      
-                    Case "icon"
-                      ProjectTargets()\IconName$ = Xml_SingleLine(GetXMLNodeText(*Entry))
-                      ProjectTargets()\UseIcon   = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      
-                    Case "format"
-                      Select GetXMLAttribute(*Entry, "exe")
-                        Case "console": ProjectTargets()\ExecutableFormat = 1
-                        Case "dll"    : ProjectTargets()\ExecutableFormat = 2
-                        Default       : ProjectTargets()\ExecutableFormat = 0
-                      EndSelect
-                      ProjectTargets()\CPU = Xml_Integer(GetXMLAttribute(*Entry, "cpu"))
-                      
-                    Case "debugger"
-                      ProjectTargets()\CustomDebugger = Xml_Boolean(GetXMLAttribute(*Entry, "custom"))
-                      Select GetXMLAttribute(*Entry, "type")
-                        Case "standalone": ProjectTargets()\DebuggerType = 2
-                        Case "console"   : ProjectTargets()\DebuggerType = 3
-                        Default          : ProjectTargets()\DebuggerType = 1
-                      EndSelect
-                      
-                    Case "warnings"
-                      ProjectTargets()\CustomWarning = Xml_Boolean(GetXMLAttribute(*Entry, "custom"))
-                      Select GetXMLAttribute(*Entry, "type")
-                        Case "ignore": ProjectTargets()\WarningMode = 0
-                        Case "error" : ProjectTargets()\WarningMode = 2
-                        Default      : ProjectTargets()\WarningMode = 1
-                      EndSelect
-                      
-                    Case "compilecount"
-                      ProjectTargets()\UseCompileCount = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      ProjectTargets()\CompileCount    = Xml_Integer(GetXMLAttribute(*Entry, "value"))
-                      
-                    Case "buildcount"
-                      ProjectTargets()\UseBuildCount = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      ProjectTargets()\BuildCount    = Xml_Integer(GetXMLAttribute(*Entry, "value"))
-                      
-                    Case "execonstant"
-                      ProjectTargets()\UseCreateExe = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      
-                    Case "versioninfo"
-                      ProjectTargets()\VersionInfo = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
-                      For i = 0 To 23
-                        *Field = XMLNodeFromPath(*Entry, "field"+Str(i))
-                        If *Field
-                          ProjectTargets()\VersionField$[i] = Xml_SingleLine(GetXMLAttribute(*Field, "value")) ; the stuff is stored, even if disabled
-                        EndIf
-                      Next i
-                      
-                    Case "resources"
-                      *Resource = ChildXMLNode(*Entry)
-                      While *Resource And ProjectTargets()\NbResourceFiles < #MAX_ResourceFiles
-                        If XMLNodeType(*Resource) = #PB_XML_Normal And GetXMLNodeName(*Resource) = "resource"
-                          ProjectTargets()\ResourceFiles$[ProjectTargets()\NbResourceFiles] = Xml_SingleLine(GetXMLAttribute(*Resource, "value"))
-                          ProjectTargets()\NbResourceFiles + 1
-                        EndIf
-                        *Resource = NextXMLNode(*Resource)
-                      Wend
-                      
-                    Case "constants"
-                      *Constant = ChildXMLNode(*Entry)
-                      While *Constant And ProjectTargets()\NbConstants < #MAX_Constants
-                        If XMLNodeType(*Constant) = #PB_XML_Normal And GetXMLNodeName(*Constant) = "constant"
-                          ProjectTargets()\Constant$[ProjectTargets()\NbConstants] = Xml_SingleLine(GetXMLAttribute(*Constant, "value"))
-                          ProjectTargets()\ConstantEnabled[ProjectTargets()\NbConstants] = Xml_Boolean(GetXMLAttribute(*Constant, "enable"))
-                          ProjectTargets()\NbConstants + 1
-                        EndIf
-                        *Constant = NextXMLNode(*Constant)
-                      Wend
-                      
-                  EndSelect
-                EndIf
-                
-                *Entry = NextXMLNode(*Entry)
-              Wend
-              
-              ; Set the *Target\FileName$ field correctly (for compilation)
-              ProjectTargets()\FileName$ = ResolveRelativePath(BasePath$, ProjectTargets()\MainFile$)
-              
-            EndIf
-            
-            *Target = NextXMLNode(*Target)
-          Wend
-        EndIf
-        
-        ; Ensure that there is a default target (create on if there are no targets)
-        SetProjectDefaultTarget()
-        
-        If ProjectOpenMode = 3 And CommandlineBuild = 0
-          ; open the mainfile of the default target only
-          If *DefaultTarget And *DefaultTarget\MainFile$
-            LoadSourceFile(*DefaultTarget\FileName$) ; use the resolved path
-          EndIf
-        EndIf
-        
-        ; Auto-sort the project files for better handling
-        SortStructuredList(ProjectFiles(), #PB_Sort_Ascending | #PB_Sort_NoCase, OffsetOf(ProjectFile\FileName$), #PB_String)
-        
-        If CommandlineBuild = 0
-          
-          ; add our special project info tab
-          AddProjectInfo()
-          
-          ; Link any previously open files to the project (do it before loading the project files as it's faster)
-          ForEach FileList()
-            If @FileList() <> *ProjectInfo
-              LinkSourceToProject(@FileList())
-            EndIf
-          Next FileList()
-          
-          ; really load all the project file (do it after adding the special project tab for better look)
-          ForEach ProjectFiles()
-            If FileSize(ProjectFiles()\FileName$) < 0
-              If MessageRequester(#ProductName$, LanguagePattern("Project","FileMissing", "%filename%", ProjectFiles()\Filename$), #PB_MessageRequester_YesNo|#FLAG_Question) = #PB_MessageRequester_Yes
-                NewFileName$ = OpenFileRequester(Language("FileStuff","OpenFileTitle"), ProjectFiles()\FileName$, Language("Compiler","AllFilesPattern"), 0)
-                
-                ; If the user aborts, keep the old filename. The file will not be scanable etc,
-                ; but it will be saved back to the project file with all options so maybe it is
-                ; present on a later run again
-                ;
-                If NewFileName$
-                  ProjectFiles()\FileName$ = NewFileName$
-                  
-                  PushListPosition(ProjectFiles())
-                  LoadSourceFile(ProjectFiles()\FileName$)
-                  
-                  ; Flush events. So when many sources are opened at once, the User can see a bit the
-                  ; progress, instead of just an unresponsive window for quite a while.
-                  ; There is almost no flicker anymore, so it actually looks quite good.
-                  ;
-                  ; Note: don't put this in the LoadSourceFile() routine as it can be call from the debugger and flushing the event will get another debug event !
-                  FlushEvents()
-                  PopListPosition(ProjectFiles())
-                EndIf
-              EndIf
-              
+            *Config = XMLNodeFromPath(*File, "config")
+            If *Config
+              ProjectFiles()\AutoLoad    = Xml_Boolean(GetXMLAttribute(*Config, "load"))
+              ProjectFiles()\AutoScan    = Xml_Boolean(GetXMLAttribute(*Config, "scan"))
+              ProjectFiles()\ShowPanel   = Xml_Boolean(GetXMLAttribute(*Config, "panel"))
+              ProjectFiles()\ShowWarning = Xml_Boolean(GetXMLAttribute(*Config, "warn"))
+              ProjectFiles()\LastOpen    = Xml_Boolean(GetXMLAttribute(*Config, "lastopen"))
+              ProjectFiles()\PanelState$ = Xml_SingleLine(GetXMLAttribute(*Config, "panelstate")) ; the default for this is "all open", so need no backward compatibility here
             Else
-              If ProjectFiles()\ShowWarning And ProjectFiles()\Md5$ <> LCase(FileFingerprint(ProjectFiles()\FileName$, #PB_Cipher_MD5))
-                WarnFiles$ + #NewLine + ProjectFiles()\FileName$
+              ProjectFiles()\AutoLoad    = 0
+              ProjectFiles()\AutoScan    = IsCodeFile(ProjectFiles()\Filename$)
+              ProjectFiles()\ShowPanel   = 1
+              ProjectFiles()\ShowWarning = 1
+              ProjectFiles()\LastOpen    = 0
+              ProjectFiles()\PanelState$ = ""
+            EndIf
+            
+            *Fingerprint = XMLNodeFromPath(*File, "fingerprint")
+            If *Fingerprint
+              ProjectFiles()\Md5$ = LCase(Xml_SingleLine(GetXMLAttribute(*Fingerprint, "md5")))
+            EndIf
+          EndIf
+          
+          *File = NextXMLNode(*File)
+        Wend
+        
+      EndIf
+      
+      ; Project targets
+      ;
+      ClearList(ProjectTargets())
+      
+      *Targets = GetSection(*Main, "targets")
+      If *Targets
+        *Target = ChildXMLNode(*Targets)
+        
+        While *Target
+          If XMLNodeType(*Target) = #PB_XML_Normal And GetXMLNodeName(*Target) = "target"
+            AddElement(ProjectTargets())
+            ProjectTargets()\ID = GetUniqueID()
+            ProjectTargets()\IsProject = #True
+            ProjectTargets()\IsEnabled = Xml_Boolean(GetXMLAttribute(*Target, "enabled"))
+            ProjectTargets()\IsDefault = Xml_Boolean(GetXMLAttribute(*Target, "default"))
+            ProjectTargets()\Name$     = Xml_SingleLine(GetXMLAttribute(*Target, "name"))
+            
+            ; loop through the entries
+            ;
+            *Entry = ChildXMLNode(*Target)
+            While *Entry
+              If XMLNodeType(*Entry) = #PB_XML_Normal
+                Select GetXMLNodeName(*Entry)
+                  Case "inputfile" :  ProjectTargets()\MainFile$         = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "outputfile":  ProjectTargets()\OutputFile$       = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "commandline": ProjectTargets()\Commandline$      = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "executable":  ProjectTargets()\ExecutableName$   = ResolveRelativePath(BasePath$, Xml_SingleLine(GetXMLAttribute(*Entry, "value")))
+                  Case "directory":   ProjectTargets()\CurrentDirectory$ = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "subsystem":   ProjectTargets()\Subsystem$        = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "linker":      ProjectTargets()\LinkerOptions$    = Xml_SingleLine(GetXMLAttribute(*Entry, "value"))
+                  Case "watchlist":   ProjectTargets()\Watchlist$        = Xml_SingleLine(GetXMLNodeText(*Entry)) ; not stored as attribute as they may get big
+                  Case "tools":       ProjectTargets()\EnabledTools$     = Xml_SingleLine(GetXMLNodeText(*Entry))
+                    
+                  Case "compiler"
+                    ProjectTargets()\CustomCompiler = #True
+                    ProjectTargets()\CompilerVersion$ = Xml_SingleLine(GetXMLAttribute(*Entry, "version"))
+                    
+                  Case "options"
+                    ProjectTargets()\EnableASM     = Xml_Boolean(GetXMLAttribute(*Entry, "asm"))
+                    ProjectTargets()\EnableThread  = Xml_Boolean(GetXMLAttribute(*Entry, "thread"))
+                    ProjectTargets()\EnableXP      = Xml_Boolean(GetXMLAttribute(*Entry, "xpskin"))
+                    ProjectTargets()\EnableAdmin   = Xml_Boolean(GetXMLAttribute(*Entry, "admin"))
+                    ProjectTargets()\EnableUser    = Xml_Boolean(GetXMLAttribute(*Entry, "user"))
+                    ProjectTargets()\DPIAware      = Xml_Boolean(GetXMLAttribute(*Entry, "dpiaware"))
+                    ProjectTargets()\EnableOnError = Xml_Boolean(GetXMLAttribute(*Entry, "onerror"))
+                    ProjectTargets()\Debugger      = Xml_Boolean(GetXMLAttribute(*Entry, "debug"))
+                    ProjectTargets()\EnableUnicode = Xml_Boolean(GetXMLAttribute(*Entry, "unicode"))
+                    
+                    CompilerIf #SpiderBasic
+                      ProjectTargets()\OptimizeJS    = Xml_Boolean(GetXMLAttribute(*Entry, "optimizejs"))
+                      ProjectTargets()\WebServerAddress$ = Xml_SingleLine(GetXMLAttribute(*Entry, "webserveraddress"))
+                      ProjectTargets()\WindowTheme$  = Xml_SingleLine(GetXMLAttribute(*Entry, "windowtheme"))
+                      ProjectTargets()\GadgetTheme$  = Xml_SingleLine(GetXMLAttribute(*Entry, "gadgettheme"))
+                    CompilerEndIf
+                    
+                    CompilerIf #SpiderBasic
+                    Case "export"
+                      ProjectTargets()\WebAppName$            = Xml_SingleLine(GetXMLAttribute(*Entry, "webappname"))
+                      ProjectTargets()\WebAppIcon$            = Xml_SingleLine(GetXMLAttribute(*Entry, "webappicon"))
+                      ProjectTargets()\HtmlFilename$          = Xml_SingleLine(GetXMLAttribute(*Entry, "htmlfilename"))
+                      ProjectTargets()\JavaScriptFilename$    = Xml_SingleLine(GetXMLAttribute(*Entry, "javascriptfilename"))
+                      ProjectTargets()\JavaScriptPath$        = Xml_SingleLine(GetXMLAttribute(*Entry, "javascriptpath"))
+                      ProjectTargets()\CopyJavaScriptLibrary  = Xml_Boolean   (GetXMLAttribute(*Entry, "copyjavascriptlibrary"))
+                      ProjectTargets()\ExportCommandLine$     = Xml_SingleLine(GetXMLAttribute(*Entry, "exportcommandline"))
+                      ProjectTargets()\ExportArguments$       = Xml_SingleLine(GetXMLAttribute(*Entry, "exportarguments"))
+                      ProjectTargets()\EnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "enableresourcedirectory"))
+                      ProjectTargets()\ResourceDirectory$     = Xml_SingleLine(GetXMLAttribute(*Entry, "resourcedirectory"))
+                      ProjectTargets()\WebAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "webappenabledebugger"))
+                      
+                      ProjectTargets()\iOSAppName$         = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappname"))
+                      ProjectTargets()\iOSAppIcon$         = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappicon"))
+                      ProjectTargets()\iOSAppVersion$      = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappversion"))
+                      ProjectTargets()\iOSAppPackageID$    = Xml_SingleLine(GetXMLAttribute(*Entry, "iosapppackageid"))
+                      ProjectTargets()\iOSAppStartupImage$ = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappstartupimage"))
+                      ProjectTargets()\iOSAppOrientation   = Val(Xml_SingleLine(GetXMLAttribute(*Entry, "iosapporientation")))
+                      ProjectTargets()\iOSAppFullScreen    = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappfullscreen"))
+                      ProjectTargets()\iOSAppGeolocation   = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappgeolocation"))
+                      ProjectTargets()\iOSAppOutput$       = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappoutput"))
+                      ProjectTargets()\iOSAppAutoUpload    = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappautoupload"))
+                      ProjectTargets()\iOSAppEnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappenableresourcedirectory"))
+                      ProjectTargets()\iOSAppResourceDirectory$      = Xml_SingleLine(GetXMLAttribute(*Entry, "iosappresourcedirectory"))
+                      ProjectTargets()\iOSAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "iosappenabledebugger"))
+                      
+                      ProjectTargets()\AndroidAppName$         = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappname"))
+                      ProjectTargets()\AndroidAppIcon$         = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappicon"))
+                      ProjectTargets()\AndroidAppVersion$      = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappversion"))
+                      ProjectTargets()\AndroidAppPackageID$    = Xml_SingleLine(GetXMLAttribute(*Entry, "androidapppackageid"))
+                      ProjectTargets()\AndroidAppIAPKey$       = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappiapkey"))
+                      ProjectTargets()\AndroidAppStartupImage$ = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappstartupimage"))
+                      ProjectTargets()\AndroidAppOrientation   = Val(Xml_SingleLine(GetXMLAttribute(*Entry, "androidapporientation")))
+                      ProjectTargets()\AndroidAppFullScreen    = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappfullscreen"))
+                      ProjectTargets()\AndroidAppGeolocation   = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappgeolocation"))
+                      ProjectTargets()\AndroidAppOutput$       = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappoutput"))
+                      ProjectTargets()\AndroidAppAutoUpload    = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappautoupload"))
+                      ProjectTargets()\AndroidAppEnableResourceDirectory = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappenableresourcedirectory"))
+                      ProjectTargets()\AndroidAppResourceDirectory$      = Xml_SingleLine(GetXMLAttribute(*Entry, "androidappresourcedirectory"))
+                      ProjectTargets()\AndroidAppEnableDebugger   = Xml_Boolean   (GetXMLAttribute(*Entry, "androidappenabledebugger"))
+                    CompilerEndIf
+                    
+                  Case "purifier"
+                    ProjectTargets()\EnablePurifier = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    ProjectTargets()\PurifierGranularity$ = Xml_SingleLine(GetXMLAttribute(*Entry, "granularity"))
+                    
+                  Case "temporaryexe"
+                    If LCase(Xml_SingleLine(GetXMLAttribute(*Entry, "value"))) = "source"
+                      ProjectTargets()\TemporaryExePlace = 1
+                    EndIf
+                    
+                  Case "icon"
+                    ProjectTargets()\IconName$ = Xml_SingleLine(GetXMLNodeText(*Entry))
+                    ProjectTargets()\UseIcon   = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    
+                  Case "format"
+                    Select GetXMLAttribute(*Entry, "exe")
+                      Case "console": ProjectTargets()\ExecutableFormat = 1
+                      Case "dll"    : ProjectTargets()\ExecutableFormat = 2
+                      Default       : ProjectTargets()\ExecutableFormat = 0
+                    EndSelect
+                    ProjectTargets()\CPU = Xml_Integer(GetXMLAttribute(*Entry, "cpu"))
+                    
+                  Case "debugger"
+                    ProjectTargets()\CustomDebugger = Xml_Boolean(GetXMLAttribute(*Entry, "custom"))
+                    Select GetXMLAttribute(*Entry, "type")
+                      Case "standalone": ProjectTargets()\DebuggerType = 2
+                      Case "console"   : ProjectTargets()\DebuggerType = 3
+                      Default          : ProjectTargets()\DebuggerType = 1
+                    EndSelect
+                    
+                  Case "warnings"
+                    ProjectTargets()\CustomWarning = Xml_Boolean(GetXMLAttribute(*Entry, "custom"))
+                    Select GetXMLAttribute(*Entry, "type")
+                      Case "ignore": ProjectTargets()\WarningMode = 0
+                      Case "error" : ProjectTargets()\WarningMode = 2
+                      Default      : ProjectTargets()\WarningMode = 1
+                    EndSelect
+                    
+                  Case "compilecount"
+                    ProjectTargets()\UseCompileCount = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    ProjectTargets()\CompileCount    = Xml_Integer(GetXMLAttribute(*Entry, "value"))
+                    
+                  Case "buildcount"
+                    ProjectTargets()\UseBuildCount = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    ProjectTargets()\BuildCount    = Xml_Integer(GetXMLAttribute(*Entry, "value"))
+                    
+                  Case "execonstant"
+                    ProjectTargets()\UseCreateExe = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    
+                  Case "versioninfo"
+                    ProjectTargets()\VersionInfo = Xml_Boolean(GetXMLAttribute(*Entry, "enable"))
+                    For i = 0 To 23
+                      *Field = XMLNodeFromPath(*Entry, "field"+Str(i))
+                      If *Field
+                        ProjectTargets()\VersionField$[i] = Xml_SingleLine(GetXMLAttribute(*Field, "value")) ; the stuff is stored, even if disabled
+                      EndIf
+                    Next i
+                    
+                  Case "resources"
+                    *Resource = ChildXMLNode(*Entry)
+                    While *Resource And ProjectTargets()\NbResourceFiles < #MAX_ResourceFiles
+                      If XMLNodeType(*Resource) = #PB_XML_Normal And GetXMLNodeName(*Resource) = "resource"
+                        ProjectTargets()\ResourceFiles$[ProjectTargets()\NbResourceFiles] = Xml_SingleLine(GetXMLAttribute(*Resource, "value"))
+                        ProjectTargets()\NbResourceFiles + 1
+                      EndIf
+                      *Resource = NextXMLNode(*Resource)
+                    Wend
+                    
+                  Case "constants"
+                    *Constant = ChildXMLNode(*Entry)
+                    While *Constant And ProjectTargets()\NbConstants < #MAX_Constants
+                      If XMLNodeType(*Constant) = #PB_XML_Normal And GetXMLNodeName(*Constant) = "constant"
+                        ProjectTargets()\Constant$[ProjectTargets()\NbConstants] = Xml_SingleLine(GetXMLAttribute(*Constant, "value"))
+                        ProjectTargets()\ConstantEnabled[ProjectTargets()\NbConstants] = Xml_Boolean(GetXMLAttribute(*Constant, "enable"))
+                        ProjectTargets()\NbConstants + 1
+                      EndIf
+                      *Constant = NextXMLNode(*Constant)
+                    Wend
+                    
+                EndSelect
               EndIf
               
-              If ProjectOpenMode = 1 Or (ProjectOpenMode = 0 And ProjectFiles()\LastOpen) Or (ProjectOpenMode = 2 And ProjectFiles()\AutoLoad)
+              *Entry = NextXMLNode(*Entry)
+            Wend
+            
+            ; Set the *Target\FileName$ field correctly (for compilation)
+            ProjectTargets()\FileName$ = ResolveRelativePath(BasePath$, ProjectTargets()\MainFile$)
+            
+          EndIf
+          
+          *Target = NextXMLNode(*Target)
+        Wend
+      EndIf
+      
+      ; Ensure that there is a default target (create on if there are no targets)
+      SetProjectDefaultTarget()
+      
+      If ProjectOpenMode = 3 And CommandlineBuild = 0
+        ; open the mainfile of the default target only
+        If *DefaultTarget And *DefaultTarget\MainFile$
+          LoadSourceFile(*DefaultTarget\FileName$) ; use the resolved path
+        EndIf
+      EndIf
+      
+      ; Auto-sort the project files for better handling
+      SortStructuredList(ProjectFiles(), #PB_Sort_Ascending | #PB_Sort_NoCase, OffsetOf(ProjectFile\FileName$), #PB_String)
+      
+      If CommandlineBuild = 0
+        
+        ; add our special project info tab
+        AddProjectInfo()
+        
+        ; Link any previously open files to the project (do it before loading the project files as it's faster)
+        ForEach FileList()
+          If @FileList() <> *ProjectInfo
+            LinkSourceToProject(@FileList())
+          EndIf
+        Next FileList()
+        
+        ; really load all the project file (do it after adding the special project tab for better look)
+        ForEach ProjectFiles()
+          If FileSize(ProjectFiles()\FileName$) < 0
+            If MessageRequester(#ProductName$, LanguagePattern("Project","FileMissing", "%filename%", ProjectFiles()\Filename$), #PB_MessageRequester_YesNo|#FLAG_Question) = #PB_MessageRequester_Yes
+              NewFileName$ = OpenFileRequester(Language("FileStuff","OpenFileTitle"), ProjectFiles()\FileName$, Language("Compiler","AllFilesPattern"), 0)
+              
+              ; If the user aborts, keep the old filename. The file will not be scanable etc,
+              ; but it will be saved back to the project file with all options so maybe it is
+              ; present on a later run again
+              ;
+              If NewFileName$
+                ProjectFiles()\FileName$ = NewFileName$
+                
                 PushListPosition(ProjectFiles())
-                LoadSourceFile(ProjectFiles()\FileName$) ; can change the ProjectFiles() index
+                LoadSourceFile(ProjectFiles()\FileName$)
                 
                 ; Flush events. So when many sources are opened at once, the User can see a bit the
                 ; progress, instead of just an unresponsive window for quite a while.
@@ -1222,1092 +1205,1059 @@ Procedure IsPureBasicFile(FileName$)
               EndIf
             EndIf
             
-            ; Update the data kept on this file (source link or scanned data)
-            UpdateProjectFile(@ProjectFiles())
-          Next
-          
-          ; Display our file warning (if any)
-          If WarnFiles$ <> ""
-            MessageRequester(#ProductName$, Language("Project", "FilesChanged")+":"+#NewLine+WarnFiles$, #FLAG_Warning)
+          Else
+            If ProjectFiles()\ShowWarning And ProjectFiles()\Md5$ <> LCase(FileFingerprint(ProjectFiles()\FileName$, #PB_Cipher_MD5))
+              WarnFiles$ + #NewLine + ProjectFiles()\FileName$
+            EndIf
+            
+            If ProjectOpenMode = 1 Or (ProjectOpenMode = 0 And ProjectFiles()\LastOpen) Or (ProjectOpenMode = 2 And ProjectFiles()\AutoLoad)
+              PushListPosition(ProjectFiles())
+              LoadSourceFile(ProjectFiles()\FileName$) ; can change the ProjectFiles() index
+              
+              ; Flush events. So when many sources are opened at once, the User can see a bit the
+              ; progress, instead of just an unresponsive window for quite a while.
+              ; There is almost no flicker anymore, so it actually looks quite good.
+              ;
+              ; Note: don't put this in the LoadSourceFile() routine as it can be call from the debugger and flushing the event will get another debug event !
+              FlushEvents()
+              PopListPosition(ProjectFiles())
+            EndIf
           EndIf
+          
+          ; Update the data kept on this file (source link or scanned data)
+          UpdateProjectFile(@ProjectFiles())
+        Next
+        
+        ; Display our file warning (if any)
+        If WarnFiles$ <> ""
+          MessageRequester(#ProductName$, Language("Project", "FilesChanged")+":"+#NewLine+WarnFiles$, #FLAG_Warning)
+        EndIf
+        
+        ; Update the menu to reflect the new target list
+        StartFlickerFix(#WINDOW_Main)
+        CreateIDEMenu()
+        StopFlickerFix(#WINDOW_Main, 1)
+        
+        ; clear project log
+        ClearList(ProjectLog())
+        
+        ; Check if there is any file open from the project
+        ;
+        *ProjectSource.SourceFile = 0
+        ForEach FileList()
+          If FileList()\ProjectFile
+            If @FileList() = *ActiveSource
+              *ProjectSource = *ActiveSource ; use this and do not look further
+              Break
+            Else
+              *ProjectSource = @FileList() ; continue search to find the last one in the list
+            EndIf
+          EndIf
+        Next FileList()
+        ChangeCurrentElement(FileList(), *ActiveSource)
+        
+        ; if no files from the project are open now, select the Info source
+        ;
+        If *ProjectSource = 0
+          FirstElement(FileList()) ; switch the Project Info
+        Else
+          ChangeCurrentElement(FileList(), *ProjectSource) ; switch to this source
+        EndIf
+        ChangeActiveSourceCode()
+        
+      EndIf
+      
+    Else
+      ;
+      ; The loading fails here, but we do not display a requester, as the
+      ; check already did that (to ask the user)
+      ;
+      FreeXML(#XML_LoadProject)
+      ProcedureReturn #False
+    EndIf
+    
+  EndIf
+  
+  If Success = #False
+    If CommandlineBuild = 0
+      MessageRequester(Language("Project","TitleShort"), Language("Project","LoadError")+#NewLine+FileName$, #FLAG_Error)
+    Else
+      PrintN(Language("Project","LoadError"))
+      PrintN(FileName$)
+    EndIf
+  ElseIf CommandlineBuild = 0
+    UpdateProjectPanel()
+    UpdateMenuStates() ; updated project related menu stuff
+    UpdateMainWindowTitle() ; put the project name in the title
+  EndIf
+  
+  ; Can exist even on failure
+  If IsXML(#XML_LoadProject)
+    FreeXML(#XML_LoadProject)
+  EndIf
+  
+  ProcedureReturn Success
+EndProcedure
+
+
+; displays an error if it fails, returns true/false
+;
+Procedure SaveProject(ShowErrors)
+  
+  ; The main layout of the project files is as follows:
+  ;
+  ; root: "project"
+  ;  - xmlns     (required): "http://www.purebasic.com/namespace" (important as this is checked!)
+  ;  - version   (required): project file version (starts with 1.0)
+  ;  - minversion(optional): minimum compatible file version (some sections may be unreadable)
+  ;  - creator   (required): full PB version string of the file creator
+  ;
+  ; inside root: "section"
+  ;  - name      (required): section name
+  ;  - minversion(optional): minimum file version compatible with the section
+  ;
+  ; The loading code supports the optional minversion parts from the first version on
+  ; to ensure future compatibility where possible.
+  ;
+  ; The content of each such section depends on the section name.
+  ; See the save code for more info on that
+  
+  BasePath$ = GetPathPart(ProjectFile$)
+  Success   = #False
+  
+  If CreateXML(#XML_SaveProject, #PB_UTF8)
+    
+    ; Generate main node
+    ;
+    *Main = CreateXMLNode(RootXMLNode(#XML_SaveProject), "project")
+    SetXMLAttribute(*Main, "xmlns",   #ProjectFileNamespace$)
+    SetXMLAttribute(*Main, "version", #Project_VersionString)
+    SetXMLAttribute(*Main, "creator", DefaultCompiler\VersionString$)
+    
+    ; User-changable configuration
+    ;
+    *Config = NewSection(*Main, "config")
+    *Options = AppendNode(*Config, "options")
+    SetXMLAttribute(*Options, "closefiles", Str(ProjectCloseFiles))
+    SetXMLAttribute(*Options, "openmode",   Str(ProjectOpenMode))
+    SetXMLAttribute(*Options, "name",       ProjectName$)
+    
+    If ProjectComments$
+      AppendNode(*Config, "comment", ProjectComments$)
+    EndIf
+    
+    If AutoCloseBuildWindow
+      *BuildWindow = AppendNode(*Config, "buildwindow")
+      SetXMLAttribute(*BuildWindow, "autoclose", "1")
+    EndIf
+    
+    ; Automatically managed data
+    ;
+    *ConfigData = NewSection(*Main, "data")
+    *ViewPath = AppendNode(*ConfigData, "explorer")
+    SetXMLAttribute(*ViewPath, "view",    CreateRelativePath(BasePath$, ProjectExplorerPath$))
+    SetXMLAttribute(*ViewPath, "pattern", Str(ProjectExplorerPattern))
+    
+    *Showlog = AppendNode(*ConfigData, "log")
+    SetXMLAttribute(*ShowLog, "show", Str(ProjectShowLog))
+    
+    ; For the ProjectInfo
+    ;
+    *LastOpen = AppendNode(*ConfigData, "lastopen")
+    SetXMLAttribute(*LastOpen, "date", FormatDate("%yyyy-%mm-%dd %hh:%ii", Date()))
+    SetXMLAttribute(*LastOpen, "user", UserName())
+    SetXMLAttribute(*LastOpen, "host", ComputerName())
+    
+    ; Project file list
+    ;
+    *Files = NewSection(*Main, "files")
+    
+    ; Make sure Project panel expanded states are up to date
+    StoreProjectPanelStates()
+    
+    ForEach ProjectFiles()
+      *File = AppendNode(*Files, "file")
+      SetXMLAttribute(*File, "name", CreateRelativePath(BasePath$, ProjectFiles()\FileName$))
+      
+      *FileConfig = AppendNode(*File, "config")
+      SetXMLAttribute(*FileConfig, "load",     Str(ProjectFiles()\AutoLoad))
+      SetXMLAttribute(*FileConfig, "scan",     Str(ProjectFiles()\AutoScan))
+      SetXMLAttribute(*FileConfig, "panel",    Str(ProjectFiles()\ShowPanel))
+      SetXMLAttribute(*FileConfig, "warn",     Str(ProjectFiles()\ShowWarning))
+      SetXMLAttribute(*FileConfig, "lastopen", Str(ProjectFiles()\LastOpen))
+      
+      If ProjectFiles()\ShowPanel
+        SetXMLAttribute(*FileConfig, "panelstate", ProjectFiles()\PanelState$)
+      EndIf
+      
+      ; files are saved in CloseProject() before this, so its ok
+      If ProjectFiles()\ShowWarning
+        *Fingerprint = AppendNode(*File, "fingerprint")
+        SetXMLAttribute(*Fingerprint, "md5", FileFingerprint(ProjectFiles()\FileName$, #PB_Cipher_MD5))
+      EndIf
+    Next ProjectFiles()
+    
+    ; Project target list
+    ; We only write keys that have non-default values to not blow up the file
+    ;
+    *Targets = NewSection(*Main, "targets")
+    
+    ForEach ProjectTargets()
+      *Target = AppendNode(*Targets, "target")
+      SetXMLAttribute(*Target, "name", ProjectTargets()\Name$)
+      SetXMLAttribute(*Target, "enabled", Str(ProjectTargets()\IsEnabled))
+      SetXMLAttribute(*Target, "default", Str(ProjectTargets()\IsDefault))
+      
+      ; these are always set
+      *Node = AppendNode(*Target, "inputfile")
+      SetXMLAttribute(*Node, "value", ProjectTargets()\MainFile$)
+      
+      *Node = AppendNode(*Target, "outputfile")
+      SetXMLAttribute(*Node, "value", ProjectTargets()\OutputFile$)
+      
+      If ProjectTargets()\CustomCompiler
+        *Node = AppendNode(*Target, "compiler")
+        SetXMLAttribute(*Node, "version", ProjectTargets()\CompilerVersion$)
+      EndIf
+      
+      If ProjectTargets()\CommandLine$
+        *Node = AppendNode(*Target, "commandline")
+        SetXMLAttribute(*Node, "value", ProjectTargets()\CommandLine$)
+      EndIf
+      If ProjectTargets()\ExecutableName$
+        ; this is a full path, so make it relative
+        *Node = AppendNode(*Target, "executable")
+        SetXMLAttribute(*Node, "value", CreateRelativePath(BasePath$, ProjectTargets()\ExecutableName$))
+      EndIf
+      If ProjectTargets()\CurrentDirectory$
+        *Node = AppendNode(*Target, "directory")
+        SetXMLAttribute(*Node, "value", ProjectTargets()\CurrentDirectory$) ; It's already a relative path
+      EndIf
+      
+      *Options = AppendNode(*Target, "options")
+      If ProjectTargets()\EnableASM
+        SetXMLAttribute(*Options, "asm",     "1")
+      EndIf
+      If ProjectTargets()\EnableUnicode
+        ; write back the found value for compatibility with pre-5.50 versions
+        SetXMLAttribute(*Options, "unicode", "1")
+      EndIf
+      If ProjectTargets()\EnableThread
+        SetXMLAttribute(*Options, "thread",  "1")
+      EndIf
+      If ProjectTargets()\EnableXP
+        SetXMLAttribute(*Options, "xpskin",  "1")
+      EndIf
+      If ProjectTargets()\EnableAdmin
+        SetXMLAttribute(*Options, "admin",   "1")
+      EndIf
+      If ProjectTargets()\EnableUser
+        SetXMLAttribute(*Options, "user",    "1")
+      EndIf
+      If ProjectTargets()\DPIAware
+        SetXMLAttribute(*Options, "dpiaware",  "1")
+      EndIf
+      If ProjectTargets()\EnableOnError
+        SetXMLAttribute(*Options, "onerror", "1")
+      EndIf
+      If ProjectTargets()\Debugger
+        SetXMLAttribute(*Options, "debug",   "1")
+      EndIf
+      
+      CompilerIf #SpiderBasic
+        SetXMLAttribute(*Options, "optimizejs", Str(ProjectTargets()\OptimizeJS))
+        SetXMLAttribute(*Options, "webserveraddress", ProjectTargets()\WebServerAddress$)
+        SetXMLAttribute(*Options, "windowtheme"  , ProjectTargets()\WindowTheme$)
+        SetXMLAttribute(*Options, "gadgettheme"  , ProjectTargets()\GadgetTheme$)
+        
+        ; Add a new "export" section
+        ;
+        *Export = AppendNode(*Target, "export")
+        SetXMLAttribute(*Export, "webappname"         , ProjectTargets()\WebAppName$)       ; Node won't be created if the value is empty
+        SetXMLAttribute(*Export, "webappicon"         , ProjectTargets()\WebAppIcon$)       ; Node won't be created if the value is empty
+        SetXMLAttribute(*Export, "htmlfilename"       , ProjectTargets()\HtmlFilename$)     ; Node won't be created if the value is empty
+        SetXMLAttribute(*Export, "javascriptfilename" , ProjectTargets()\JavaScriptFilename$) ;
+        SetXMLAttribute(*Export, "javascriptpath"     , ProjectTargets()\JavaScriptPath$)
+        SetXMLAttribute(*Export, "copyjavascriptlibrary"  , Str(ProjectTargets()\CopyJavaScriptLibrary))
+        SetXMLAttribute(*Export, "exportcommandline"  , ProjectTargets()\ExportCommandLine$)
+        SetXMLAttribute(*Export, "exportarguments"    , ProjectTargets()\ExportArguments$)
+        SetXMLAttribute(*Export, "enableresourcedirectory"  , Str(ProjectTargets()\EnableResourceDirectory))
+        SetXMLAttribute(*Export, "resourcedirectory"  , ProjectTargets()\ResourceDirectory$)  ; Node won't be created if the value is empty
+        SetXMLAttribute(*Export, "webappenabledebugger", Str(ProjectTargets()\WebAppEnableDebugger))
+        
+        SetXMLAttribute(*Export, "iosappname"         , ProjectTargets()\iOSAppName$)
+        SetXMLAttribute(*Export, "iosappicon"         , ProjectTargets()\iOSAppIcon$)
+        SetXMLAttribute(*Export, "iosappversion"      , ProjectTargets()\iOSAppVersion$)
+        SetXMLAttribute(*Export, "iosapppackageid"    , ProjectTargets()\iOSAppPackageID$)
+        SetXMLAttribute(*Export, "iosappstartupimage" , ProjectTargets()\iOSAppStartupImage$)
+        SetXMLAttribute(*Export, "iosapporientation"  , Str(ProjectTargets()\iOSAppOrientation))
+        SetXMLAttribute(*Export, "iosappfullscreen"   , Str(ProjectTargets()\iOSAppFullScreen))
+        SetXMLAttribute(*Export, "iosappgeolocation"  , Str(ProjectTargets()\iOSAppGeolocation))
+        SetXMLAttribute(*Export, "iosappoutput"       , ProjectTargets()\iOSAppOutput$)
+        SetXMLAttribute(*Export, "iosappautoupload"   , Str(ProjectTargets()\iOSAppAutoUpload))
+        SetXMLAttribute(*Export, "iosappenableresourcedirectory", Str(ProjectTargets()\iOSAppEnableResourceDirectory))
+        SetXMLAttribute(*Export, "iosappresourcedirectory", ProjectTargets()\iOSAppResourceDirectory$)
+        SetXMLAttribute(*Export, "iosappenabledebugger", Str(ProjectTargets()\iOSAppEnableDebugger))
+        
+        SetXMLAttribute(*Export, "androidappname"         , ProjectTargets()\AndroidAppName$)
+        SetXMLAttribute(*Export, "androidappicon"         , ProjectTargets()\AndroidAppIcon$)
+        SetXMLAttribute(*Export, "androidappversion"      , ProjectTargets()\AndroidAppVersion$)
+        SetXMLAttribute(*Export, "androidapppackageid"    , ProjectTargets()\AndroidAppPackageID$)
+        SetXMLAttribute(*Export, "androidappiapkey"       , ProjectTargets()\AndroidAppIAPKey$)
+        SetXMLAttribute(*Export, "androidappstartupimage" , ProjectTargets()\AndroidAppStartupImage$)
+        SetXMLAttribute(*Export, "androidapporientation"  , Str(ProjectTargets()\AndroidAppOrientation))
+        SetXMLAttribute(*Export, "androidappfullscreen"   , Str(ProjectTargets()\AndroidAppFullScreen))
+        SetXMLAttribute(*Export, "androidappgeolocation"  , Str(ProjectTargets()\AndroidAppGeolocation))
+        SetXMLAttribute(*Export, "androidappoutput"       , ProjectTargets()\AndroidAppOutput$)
+        SetXMLAttribute(*Export, "androidappautoupload"   , Str(ProjectTargets()\AndroidAppAutoUpload))
+        SetXMLAttribute(*Export, "androidappenableresourcedirectory", Str(ProjectTargets()\AndroidAppEnableResourceDirectory))
+        SetXMLAttribute(*Export, "androidappresourcedirectory", ProjectTargets()\AndroidAppResourceDirectory$)
+        SetXMLAttribute(*Export, "androidappenabledebugger", Str(ProjectTargets()\AndroidAppEnableDebugger))
+        
+      CompilerEndIf
+      
+      If ProjectTargets()\EnablePurifier Or ProjectTargets()\PurifierGranularity$
+        *Purifier = AppendNode(*Target, "purifier")
+        SetXMLAttribute(*Purifier, "enable", Str(ProjectTargets()\EnablePurifier))
+        
+        If ProjectTargets()\PurifierGranularity$
+          SetXMLAttribute(*Purifier, "granularity", ProjectTargets()\PurifierGranularity$)
+        EndIf
+      EndIf
+      
+      If ProjectTargets()\TemporaryExePlace
+        *Node = AppendNode(*Target, "temporaryexe")
+        SetXMLAttribute(*Node, "value", "source")
+      EndIf
+      
+      If ProjectTargets()\Subsystem$
+        *Node = AppendNode(*Target, "subsystem")
+        SetXMLAttribute(*Node, "value", ProjectTargets()\Subsystem$)
+      EndIf
+      
+      If ProjectTargets()\LinkerOptions$
+        *Node = AppendNode(*Target, "linker")
+        SetXMLAttribute(*Node, "value", ProjectTargets()\LinkerOptions$)
+      EndIf
+      
+      If ProjectTargets()\IconName$ Or ProjectTargets()\UseIcon
+        *Icon = AppendNode(*Target, "icon", ProjectTargets()\IconName$)
+        SetXMLAttribute(*Icon, "enable", Str(ProjectTargets()\UseIcon))
+      EndIf
+      
+      If ProjectTargets()\ExecutableFormat <> 0 Or ProjectTargets()\CPU <> 0
+        *Format = AppendNode(*Target, "format")
+        Select ProjectTargets()\ExecutableFormat
+          Case 0: SetXMLAttribute(*Format, "exe", "default")
+          Case 1: SetXMLAttribute(*Format, "exe", "console")
+          Case 2: SetXMLAttribute(*Format, "exe", "dll")
+        EndSelect
+        SetXMLAttribute(*Format, "cpu", Str(ProjectTargets()\CPU))
+      EndIf
+      
+      If ProjectTargets()\CustomDebugger
+        *Debugger = AppendNode(*Target, "debugger")
+        SetXMLAttribute(*Debugger, "custom", "1")
+        Select ProjectTargets()\DebuggerType
+          Case 1: SetXMLAttribute(*Debugger, "type", "ide")
+          Case 2: SetXMLAttribute(*Debugger, "type", "standalone")
+          Case 3: SetXMLAttribute(*Debugger, "type", "console")
+        EndSelect
+      EndIf
+      
+      If ProjectTargets()\CustomWarning
+        *Warnings = AppendNode(*Target, "warnings")
+        SetXMLAttribute(*Warnings, "custom", "1")
+        Select ProjectTargets()\WarningMode
+          Case 0: SetXMLAttribute(*Warnings, "type", "ignore")
+          Case 1: SetXMLAttribute(*Warnings, "type", "display")
+          Case 2: SetXMLAttribute(*Warnings, "type", "error")
+        EndSelect
+      EndIf
+      
+      If ProjectTargets()\UseCompileCount Or ProjectTargets()\CompileCount <> 0
+        *CompileCount = AppendNode(*Target, "compilecount")
+        SetXMLAttribute(*CompileCount, "enable", Str(ProjectTargets()\UseCompileCount))
+        SetXMLAttribute(*CompileCount, "value", Str(ProjectTargets()\CompileCount))
+      EndIf
+      
+      If ProjectTargets()\UseBuildCount Or ProjectTargets()\BuildCount <> 0
+        *BuildCount = AppendNode(*Target, "buildcount")
+        SetXMLAttribute(*BuildCount, "enable", Str(ProjectTargets()\UseBuildCount))
+        SetXMLAttribute(*BuildCount, "value", Str(ProjectTargets()\BuildCount))
+      EndIf
+      
+      If ProjectTargets()\UseCreateExe
+        *CreateExe = AppendNode(*Target, "execonstant")
+        SetXMLAttribute(*CreateExe, "enable", "1")
+      EndIf
+      
+      WriteVersion = ProjectTargets()\VersionInfo
+      If ProjectTargets()\VersionInfo
+        ; still include the version info if it is non-empty, even if disabled
+        For i = 0 To 23
+          If ProjectTargets()\VersionField$[i] <> ""
+            WriteVersion = 1
+            Break
+          EndIf
+        Next i
+      EndIf
+      
+      If WriteVersion
+        *Version = AppendNode(*Target, "versioninfo")
+        SetXMLAttribute(*Version, "enable", Str(ProjectTargets()\VersionInfo))
+        For i = 0 To 23
+          If ProjectTargets()\VersionField$[i] <> ""
+            *Node = AppendNode(*Version, "field"+Str(i))
+            SetXMLAttribute(*Node, "value", ProjectTargets()\VersionField$[i])
+          EndIf
+        Next i
+      EndIf
+      
+      If ProjectTargets()\NbResourceFiles > 0
+        *Resources = AppendNode(*Target, "resources")
+        For i = 0 To ProjectTargets()\NbResourceFiles-1
+          *Node = AppendNode(*Resources, "resource")
+          SetXMLAttribute(*Node, "value", ProjectTargets()\ResourceFiles$[i])
+        Next i
+      EndIf
+      
+      If ProjectTargets()\NbConstants > 0
+        *Constants = AppendNode(*Target, "constants")
+        For i = 0 To ProjectTargets()\NbConstants-1
+          *Constant = AppendNode(*Constants, "constant")
+          SetXMLAttribute(*Constant, "value", ProjectTargets()\Constant$[i])
+          SetXMLAttribute(*Constant, "enable", Str(ProjectTargets()\ConstantEnabled[i]))
+        Next i
+      EndIf
+      
+      If ProjectTargets()\Watchlist$
+        AppendNode(*Target, "watchlist", ProjectTargets()\Watchlist$)
+      EndIf
+      
+      If ProjectTargets()\EnabledTools$
+        AppendNode(*Target, "tools", ProjectTargets()\EnabledTools$)
+      EndIf
+    Next ProjectTargets()
+    
+    ; Format the project to a more readable format
+    ;
+    FormatXML(#XML_SaveProject, #PB_XML_ReFormat, 2)
+    
+    ; Save the file
+    ;
+    If SaveXML(#XML_SaveProject, ProjectFile$)
+      Success = #True
+    EndIf
+    
+    FreeXML(#XML_SaveProject)
+  EndIf
+  
+  If Success = #False And ShowErrors
+    MessageRequester(Language("Project", "TitleShort"), Language("Project", "SaveError"), #FLAG_Error)
+  EndIf
+  
+  ProcedureReturn Success
+EndProcedure
+
+Procedure OpenProject()
+  
+  If IsProjectCreation = 0
+    
+    If IsProject
+      Path$ = GetPathPart(ProjectFile$)
+    ElseIf *ActiveSource\FileName$
+      Path$ = GetPathPart(*ActiveSource\FileName$)
+    Else
+      Path$ = SourcePath$
+    EndIf
+    
+    FileName$ = OpenFileRequester(Language("Project","TitleOpen"), Path$, Language("Project","Pattern"), 0)
+    If FileName$ <> ""
+      LoadProject(FileName$) ; closes the old project if still open
+    EndIf
+    
+  EndIf
+  
+EndProcedure
+
+Procedure CloseProject(IsIDEShutdown = #False)
+  If IsProject
+    
+    ; close options
+    If IsWindow(#WINDOW_ProjectOptions)
+      ProjectOptionsEvents(#PB_Event_CloseWindow)
+    EndIf
+    
+    If IsWindow(#WINDOW_Option)
+      ; close these only if they belong to the project (ie there is a project code open)
+      If *ActiveSource\ProjectFile
+        OptionWindowEvents(#PB_Event_CloseWindow)
+      EndIf
+    EndIf
+    
+    
+    If IsWindow(#WINDOW_Build)
+      BuildWindowEvents(#PB_Event_CloseWindow)
+    EndIf
+    
+    ; Is there a debugger running for the project ?
+    ;
+    *Debugger.DebuggerData = FindDebuggerFromID(ProjectDebuggerID)
+    If *Debugger
+      Debugger_Kill(*Debugger)
+    EndIf
+    
+    ; Update the "last open" state of all project files
+    ;
+    ForEach ProjectFiles()
+      If ProjectFiles()\Source
+        ProjectFiles()\LastOpen = #True
+      Else
+        ProjectFiles()\LastOpen = #False
+      EndIf
+    Next ProjectFiles()
+    
+    If ProjectCloseFiles
+      *RealActiveSource = *ActiveSource
+      
+      ; do not walk the FileList() as it gets modified when removing a source
+      ForEach ProjectFiles()
+        If ProjectFiles()\Source
+          If *RealActiveSource = *ActiveSource
+            *RealActiveSource = 0 ; we cannot switch back to this as it will be removed
+          EndIf
+          
+          ; RemoveSource() can trigger a walk of the ProjectFiles() list too,
+          ; So save/restore the position
+          *ProjectFile = @ProjectFiles()
+          
+          ; save/close all codes that belong To the project If the option is set
+          ; NOTE: On IDE shutdown this is done already anyway, so do not do it again
+          ;   as the "do you want to save" question was already asked then (but the code not closed yet)
+          ;
+          If IsIDEShutdown Or CheckSourceSaved(ProjectFiles()\Source) = 1
+            RemoveSource(ProjectFiles()\Source)
+          Else
+            Cancelled = #True ; The user can press "Cancel" when a source has been modified in the project and it doesn't want to close the project anymore
+            Break             ; abort, keep the last source the active one
+          EndIf
+          
+          ChangeCurrentElement(ProjectFiles(), *ProjectFile)
+        EndIf
+      Next ProjectFiles()
+      
+      If *RealActiveSource
+        ChangeCurrentElement(FileList(), *RealActiveSource)
+        ChangeActiveSourcecode(*RealActiveSource)
+      EndIf
+    EndIf
+    
+    ; Don't close the main project panel if the close has been cancelled
+    ;
+    If Cancelled = #False
+      ; unlink all codes (do not keep any data).
+      ForEach FileList()
+        If @FileList() <> *ProjectInfo
+          UnlinkSourceFromProject(@FileList(), #False)
+        EndIf
+      Next FileList()
+      ChangeCurrentElement(FileList(), *ActiveSource)
+      
+      ; Save the project, and do not close if this is impossible
+      ; (also saves the "last open" state)
+      If IsIDEShutdown
+        Result = SaveProject(#False)
+      Else
+        Result = SaveProject(#True)
+      EndIf
+      
+      If Result = #False
+        ProcedureReturn #False
+      EndIf
+      
+      ; clean up the file list
+      ForEach ProjectFiles()
+        ClearProjectFile(@ProjectFiles())
+      Next ProjectFiles()
+      ClearList(ProjectFiles())
+      
+      ClearList(ProjectTargets())
+      ClearList(ProjectLog())
+      
+      ; Important to set this to 0 as it points to invalid memory else and lead to problems
+      *DefaultTarget = 0
+      
+      RemoveProjectInfo()
+      
+      IsProject = 0
+      UpdateProjectPanel()
+      UpdateMenuStates()
+      UpdateMainWindowTitle() ; remove the project name from the title
+      
+      ; Update the menu to reflect the now empty target list
+      StartFlickerFix(#WINDOW_Main)
+      CreateIDEMenu()
+      StopFlickerFix(#WINDOW_Main, 1)
+    Else
+      ProcedureReturn #False ; The project has not been closed.
+    EndIf
+  EndIf
+  
+  ProcedureReturn #True
+EndProcedure
+
+
+Procedure UpdateProjectOptionStates()
+  
+  NoAdd = 1
+  If GetGadgetState(#GADGET_Project_Explorer) <> -1
+    Last  = CountGadgetItems(#GADGET_Project_Explorer)-1
+    
+    For i = 0 To Last
+      If GetGadgetItemState(#GADGET_Project_Explorer, i) & #PB_Explorer_Selected And GetGadgetItemText(#GADGET_Project_Explorer, i, 0) <> ".."
+        NoAdd = 0
+        Break
+      EndIf
+    Next i
+  EndIf
+  
+  DisableGadget(#GADGET_Project_AddFile, NoAdd)
+  
+  Selected = 0
+  FileLoad = 0
+  FileScan = 0
+  FileWarn = 0
+  FilePanel = 0
+  
+  If GetGadgetState(#GADGET_Project_FileList) <> -1
+    Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+    
+    For i = 0 To Last
+      If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+        *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+        Selected + 1
+        
+        If Selected = 1 ; its the first file, so just apply the state
+          FileLoad  = *File\AutoLoad
+          FileScan  = *File\AutoScan
+          FileWarn  = *File\ShowWarning
+          FilePanel = *File\ShowPanel
+        Else ; apply the inconsistent state if an entry does not match
+          If FileLoad <> *File\AutoLoad:    FileLoad = -1:  EndIf
+          If FileScan <> *File\AutoScan:    FileScan = -1:  EndIf
+          If FileWarn <> *File\ShowWarning: FileWarn = -1:  EndIf
+          If FilePanel <> *File\ShowPanel:  FilePanel = -1: EndIf
+        EndIf
+      EndIf
+    Next i
+  EndIf
+  
+  If Selected > 0
+    Disable = 0
+  Else
+    Disable = 1
+  EndIf
+  
+  If IsProjectCreation
+    ; if a project is created, the main window is disabled, so this does not make much sense
+    DisableGadget(#GADGET_Project_ViewFile, 1)
+  Else
+    DisableGadget(#GADGET_Project_ViewFile, Disable)
+  EndIf
+  
+  DisableGadget(#GADGET_Project_RemoveFile, Disable)
+  DisableGadget(#GADGET_Project_FileLoad,   Disable)
+  DisableGadget(#GADGET_Project_FileScan,   Disable)
+  DisableGadget(#GADGET_Project_FileWarn,   Disable)
+  DisableGadget(#GADGET_Project_FilePanel,  Disable)
+  
+  SetGadgetState(#GADGET_Project_FileLoad,  FileLoad)
+  SetGadgetState(#GADGET_Project_FileScan,  FileScan)
+  SetGadgetState(#GADGET_Project_FileWarn,  FileWarn)
+  SetGadgetState(#GADGET_Project_FilePanel, FilePanel)
+  
+EndProcedure
+
+; returns #false if canceled
+;
+Procedure RecursiveAddFiles(ID, Base$, List Files.s())
+  
+  Select MessageRequester(Language("Project","Title"), Language("Project","AddDirectory")+#NewLine+Base$, #PB_MessageRequester_YesNoCancel|#FLAG_Question)
+    Case #PB_MessageRequester_Yes
+      If ExamineDirectory(ID, Base$, "*")
+        While NextDirectoryEntry(ID)
+          Name$ = DirectoryEntryName(ID)
+          
+          If DirectoryEntryType(ID) = #PB_DirectoryEntry_Directory
+            If Name$ <> "." And Name$ <> ".."
+              If RecursiveAddFiles(ID+1, Base$+Name$+#Separator, Files()) = #False
+                FinishDirectory(ID)
+                ProcedureReturn #False ; send the "cancel" out to the main level
+              EndIf
+            EndIf
+            
+          Else
+            AddElement(Files())
+            Files() = Base$ + Name$
+            
+          EndIf
+        Wend
+        FinishDirectory(ID)
+      EndIf
+      ProcedureReturn #True
+      
+    Case #PB_MessageRequester_No
+      ProcedureReturn #True ; skip directory but do not cancel
+      
+    Case #PB_MessageRequester_Cancel
+      ProcedureReturn #False
+      
+  EndSelect
+  
+EndProcedure
+
+; Add a list of files to to the options dialog.
+; the list may include directories and must be Chr(10) separated (like EventDropFiles())
+;
+Procedure AddProjectOptionFiles(FileList$)
+  Protected NewList Files.s()
+  Count = CountString(FileList$, Chr(10)) + 1
+  
+  ; Deselect all items in the gadget, as we only select newly added ones
+  SetGadgetState(#GADGET_Project_FileList, -1)
+  
+  ; First gather recursively all directory content to add
+  ; if directories are included (ask the user for every directory)
+  ;
+  For i = 1 To Count
+    File$ = Trim(StringField(FileList$, i, Chr(10)))
+    
+    If FileSize(File$) = -2
+      If Right(File$, 1) <> #Separator
+        File$ + #Separator
+      EndIf
+      
+      If RecursiveAddFiles(0, File$, Files()) = #False ; #false means user canceled
+        UpdateProjectOptionStates()                    ; reflect the new gadget state
+        ProcedureReturn
+      EndIf
+      
+    Else
+      AddElement(Files())
+      Files() = File$
+      
+    EndIf
+  Next i
+  
+  ; Filter files that are already in the project
+  ;
+  ForEach Files()
+    ForEach ProjectConfig()
+      If IsEqualFile(Files(), ProjectConfig()\FileName$)
+        ; select this file in the file list (as we select all added files)
+        Last = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 1 To Last
+          If GetGadgetItemData(#GADGET_Project_FileList, i) = @ProjectConfig()
+            SetGadgetItemState(#GADGET_Project_FileList, i, #PB_ListIcon_Selected)
+            Break
+          EndIf
+        Next i
+        
+        ; remove this file from the "to add" list
+        DeleteElement(Files())
+        Break
+      EndIf
+    Next ProjectConfig()
+  Next Files()
+  
+  If ListSize(Files()) = 0
+    UpdateProjectOptionStates() ; reflect the new gadget states
+    ProcedureReturn
+  EndIf
+  
+  ; Warn if there are many files to add
+  ;
+  If ListSize(Files()) > 50
+    If MessageRequester(Language("Project","Title"), LanguagePattern("Project","AddManyFiles", "%filecount%", Str(ListSize(Files()))), #PB_MessageRequester_YesNo|#FLAG_Question) = #PB_MessageRequester_No
+      UpdateProjectOptionStates() ; reflect the new gadget states
+      ProcedureReturn
+    EndIf
+  EndIf
+  
+  ; Finally add the files
+  ;
+  LastElement(ProjectConfig())
+  
+  If IsProjectCreation
+    BasePath$ = GetPathPart(NewProjectFile$)
+  Else
+    BasePath$ = GetPathPart(ProjectFile$)
+  EndIf
+  
+  ForEach Files()
+    AddElement(ProjectConfig())
+    ProjectConfig()\FileName$   = Files()
+    ProjectConfig()\AutoLoad    = 0
+    ProjectConfig()\AutoScan    = IsCodeFile(Files())
+    ProjectConfig()\ShowPanel   = 1
+    ProjectConfig()\ShowWarning = 1
+    
+    AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(BasePath$, Files()))
+    Index = CountGadgetItems(#GADGET_Project_FileList)-1
+    SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
+    SetGadgetItemState(#GADGET_Project_FileList, Index, #PB_ListIcon_Selected)
+  Next Files()
+  
+  UpdateProjectOptionStates() ; reflect the new gadget states
+  
+EndProcedure
+
+; for project creation only.
+; Resolve/Change the project filename and the filelist
+;
+Procedure ProjectFileChange(NewFile$)
+  If NewFile$ = ""
+    NewProjectFile$ = ""
+  Else
+    ; Add extension if none present
+    ;
+    If GetExtensionPart(GetFilePart(NewFile$)) = ""
+      NewFile$ + #ProjectFileExtension
+    EndIf
+    
+    ; Resolve the new file by the current directory, because there it would be saved if
+    ; we did not resolve anything. (the user should use a full path anyway)
+    ;
+    NewProjectFile$ = ResolveRelativePath(GetCurrentDirectory(), NewFile$)
+    
+    If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
+      SetGadgetText(#GADGET_Project_File, NewProjectFile$)
+    EndIf
+  EndIf
+  
+  BasePath$ = GetPathPart(NewProjectFile$)
+  Last = CountGadgetItems(#GADGET_Project_FileList)-1
+  For i = 0 To Last
+    *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+    SetGadgetItemText(#GADGET_Project_FileList, i, CreateRelativePath(BasePath$, *File\FileName$), 0)
+  Next i
+EndProcedure
+
+Procedure ProjectOptionsEvents(EventID)
+  Quit = 0
+  
+  If EventID = #PB_Event_Menu     ; Little wrapper to map the shortcut events (identified as menu)
+    EventID  = #PB_Event_Gadget   ; to normal gadget events...
+    EventGadgetID = EventMenu()
+  Else
+    EventGadgetID = EventGadget()
+  EndIf
+  
+  
+  If EventID = #PB_Event_GadgetDrop
+    Select EventGadget()
+        
+      Case #GADGET_Project_Name
+        SetGadgetText(#GADGET_Project_Name, RemoveString(EventDropText(), #NewLine))
+        
+      Case #GADGET_Project_Comments
+        SetGadgetText(#GADGET_Project_Comments, EventDropText())
+        
+      Case #GADGET_Project_FileList
+        AddProjectOptionFiles(EventDropFiles())
+        
+    EndSelect
+    
+  ElseIf EventID = #PB_Event_Gadget
+    Select EventGadgetID
+        
+      Case #GADGET_Project_Ok
+        ProjectOK = 1
+        
+        ; Some required checks
+        If Trim(GetGadgetText(#GADGET_Project_Name)) = ""
+          ProjectOK = 0
+          MessageRequester(Language("Project","Title"), Language("Project","NeedName"))
+          
+        ElseIf IsProjectCreation
+          
+          ; this also resolves relative names etc
+          If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
+            ProjectFileChange(GetGadgetText(#GADGET_Project_File))
+          EndIf
+          
+          If NewProjectFile$ = ""
+            ProjectOK = 0
+            MessageRequester(Language("Project","Title"), Language("Project","NeedFile"))
+            
+          ElseIf FileSize(NewProjectFile$) > -1
+            If MessageRequester(Language("Project","TitleNew"), Language("FileStuff","FileExists")+#NewLine+Language("FileStuff","OverWrite"), #PB_MessageRequester_YesNo|#FLAG_Warning) = #PB_MessageRequester_No
+              ProjectOK = 0
+            EndIf
+            
+          EndIf
+          
+          ; check if the filename is a writable location so we do not get the problem later
+          If ProjectOK
+            If OpenFile(#FILE_CheckProject, NewProjectFile$) = 0
+              MessageRequester(Language("Project", "TitleNew"), Language("Project", "SaveError"), #FLAG_Error)
+              ProjectOK = 0
+            Else
+              CloseFile(#FILE_CheckProject)
+            EndIf
+          EndIf
+        EndIf
+        
+        If ProjectOK
+          
+          ; In case we create a new project. Now we have a project data
+          If IsProjectCreation
+            IsProject    = #True
+            ProjectFile$ = NewProjectFile$
+            ProjectShowLog = #True ; always true initially
+            
+            ProjectLastOpenDate    = 0
+            ProjectLastOpenHost$   = ""
+            ProjectLastOpenUser$   = ""
+            ProjectLastOpenEditor$ = ""
+            
+            ; no targets yet (a default one is created below)
+            ClearList(ProjectTargets())
+            ClearList(ProjectFiles()) ; filled with the config below
+            ClearList(ProjectLog())
+            
+            ; add the info source
+            AddProjectInfo()
+            
+            ; switch to the info source, so the user can directly get to the projects compiler options etc
+            FirstElement(FileList())
+            ChangeActiveSourceCode()
+          EndIf
+          
+          ; Update the options
+          ProjectName$     = Trim(GetGadgetText(#GADGET_Project_Name))
+          ProjectComments$ = GetGadgetText(#GADGET_Project_Comments)
+          
+          If GetGadgetState(#GADGET_Project_SetDefault)
+            DefaultProjectFile$ = ProjectFile$
+          ElseIf IsEqualFile(DefaultProjectFile$, ProjectFile$) ; do not unset if this was not the default project
+            DefaultProjectFile$ = ""
+          EndIf
+          
+          ProjectCloseFiles = GetGadgetState(#GADGET_Project_CloseAllFiles)
+          
+          If GetGadgetState(#GADGET_Project_OpenLoadLast)
+            ProjectOpenMode = 0
+          ElseIf GetGadgetState(#GADGET_Project_OpenLoadAll)
+            ProjectOpenMode = 1
+          ElseIf GetGadgetState(#GADGET_Project_OpenLoadDefault)
+            ProjectOpenMode = 2
+          ElseIf GetGadgetState(#GADGET_Project_OpenLoadMain)
+            ProjectOpenMode = 3
+          Else
+            ProjectOpenMode = 4
+          EndIf
+          
+          ; Now remove any file from the real project file list if it is not in the config list
+          ; We do not just do a ClearList() and re-fill it, because the ProjectPanel stores
+          ; pointers to the entries!
+          ;
+          ForEach ProjectFiles()
+            Found = 0
+            ForEach ProjectConfig()
+              If IsEqualFile(ProjectFiles()\Filename$, ProjectConfig()\Filename$)
+                Found = 1
+                Break
+              EndIf
+            Next ProjectConfig()
+            
+            If Found = 0
+              If ProjectFiles()\Source
+                *ProjectFile = @ProjectFiles()
+                UnlinkSourceFromProject(ProjectFiles()\Source, #False)
+                ChangeCurrentElement(ProjectFiles(), *ProjectFile)
+              EndIf
+              ClearProjectFile(@ProjectFiles())
+              DeleteElement(ProjectFiles())
+            EndIf
+          Next ProjectFiles()
+          
+          ; Now add/update the current/new files
+          ForEach ProjectConfig()
+            Found = 0
+            ForEach ProjectFiles()
+              If IsEqualFile(ProjectFiles()\Filename$, ProjectConfig()\Filename$)
+                Found = 1
+                Break
+              EndIf
+            Next ProjectFiles()
+            
+            If Found = 0
+              AddElement(ProjectFiles()) ; add new if needed
+            EndIf
+            
+            ; copy config to file and update the file data (autocomplete etc)
+            CopyProjectConfig(@ProjectConfig(), @ProjectFiles())
+            UpdateProjectFile(@ProjectFiles())
+          Next ProjectConfig()
+          
+          ClearList(ProjectConfig())
+          
+          ; ensure that the project has a default target (if it is new)
+          SetProjectDefaultTarget()
           
           ; Update the menu to reflect the new target list
           StartFlickerFix(#WINDOW_Main)
           CreateIDEMenu()
           StopFlickerFix(#WINDOW_Main, 1)
           
-          ; clear project log
-          ClearList(ProjectLog())
-          
-          ; Check if there is any file open from the project
-          ;
-          *ProjectSource.SourceFile = 0
-          ForEach FileList()
-            If FileList()\ProjectFile
-              If @FileList() = *ActiveSource
-                *ProjectSource = *ActiveSource ; use this and do not look further
-                Break
-              Else
-                *ProjectSource = @FileList() ; continue search to find the last one in the list
-              EndIf
-            EndIf
-          Next FileList()
-          ChangeCurrentElement(FileList(), *ActiveSource)
-          
-          ; if no files from the project are open now, select the Info source
-          ;
-          If *ProjectSource = 0
-            FirstElement(FileList()) ; switch the Project Info
-          Else
-            ChangeCurrentElement(FileList(), *ProjectSource) ; switch to this source
+          If SaveProject(#True)              ; do not save modified sources
+            RecentFiles_AddFile(ProjectFile$, #True) ; add to recent projects in case we create a new project here
+            Quit = 1
           EndIf
-          ChangeActiveSourceCode()
           
+          UpdateMainWindowTitle() ; show name changes
         EndIf
         
-      Else
+      Case #GADGET_Project_Cancel
+        Quit = 1
+        
+      Case #GADGET_Project_Panel
+        ; Update the project file base if it changes on panel switches.
+        ; This way if the user switches to the file panel, he will see the correct relative path always
         ;
-        ; The loading fails here, but we do not display a requester, as the
-        ; check already did that (to ask the user)
-        ;
-        FreeXML(#XML_LoadProject)
-        ProcedureReturn #False
-      EndIf
-      
-    EndIf
-    
-    If Success = #False
-      If CommandlineBuild = 0
-        MessageRequester(Language("Project","TitleShort"), Language("Project","LoadError")+#NewLine+FileName$, #FLAG_Error)
-      Else
-        PrintN(Language("Project","LoadError"))
-        PrintN(FileName$)
-      EndIf
-    ElseIf CommandlineBuild = 0
-      UpdateProjectPanel()
-      UpdateMenuStates() ; updated project related menu stuff
-      UpdateMainWindowTitle() ; put the project name in the title
-    EndIf
-    
-    ; Can exist even on failure
-    If IsXML(#XML_LoadProject)
-      FreeXML(#XML_LoadProject)
-    EndIf
-    
-    ProcedureReturn Success
-  EndProcedure
-  
-  
-  ; displays an error if it fails, returns true/false
-  ;
-  Procedure SaveProject(ShowErrors)
-    
-    ; The main layout of the project files is as follows:
-    ;
-    ; root: "project"
-    ;  - xmlns     (required): "http://www.purebasic.com/namespace" (important as this is checked!)
-    ;  - version   (required): project file version (starts with 1.0)
-    ;  - minversion(optional): minimum compatible file version (some sections may be unreadable)
-    ;  - creator   (required): full PB version string of the file creator
-    ;
-    ; inside root: "section"
-    ;  - name      (required): section name
-    ;  - minversion(optional): minimum file version compatible with the section
-    ;
-    ; The loading code supports the optional minversion parts from the first version on
-    ; to ensure future compatibility where possible.
-    ;
-    ; The content of each such section depends on the section name.
-    ; See the save code for more info on that
-    
-    BasePath$ = GetPathPart(ProjectFile$)
-    Success   = #False
-    
-    If CreateXML(#XML_SaveProject, #PB_UTF8)
-      
-      ; Generate main node
-      ;
-      *Main = CreateXMLNode(RootXMLNode(#XML_SaveProject), "project")
-      SetXMLAttribute(*Main, "xmlns",   #ProjectFileNamespace$)
-      SetXMLAttribute(*Main, "version", #Project_VersionString)
-      SetXMLAttribute(*Main, "creator", DefaultCompiler\VersionString$)
-      
-      ; User-changable configuration
-      ;
-      *Config = NewSection(*Main, "config")
-      *Options = AppendNode(*Config, "options")
-      SetXMLAttribute(*Options, "closefiles", Str(ProjectCloseFiles))
-      SetXMLAttribute(*Options, "openmode",   Str(ProjectOpenMode))
-      SetXMLAttribute(*Options, "name",       ProjectName$)
-      
-      If ProjectComments$
-        AppendNode(*Config, "comment", ProjectComments$)
-      EndIf
-      
-      If AutoCloseBuildWindow
-        *BuildWindow = AppendNode(*Config, "buildwindow")
-        SetXMLAttribute(*BuildWindow, "autoclose", "1")
-      EndIf
-      
-      ; Automatically managed data
-      ;
-      *ConfigData = NewSection(*Main, "data")
-      *ViewPath = AppendNode(*ConfigData, "explorer")
-      SetXMLAttribute(*ViewPath, "view",    CreateRelativePath(BasePath$, ProjectExplorerPath$))
-      SetXMLAttribute(*ViewPath, "pattern", Str(ProjectExplorerPattern))
-      
-      *Showlog = AppendNode(*ConfigData, "log")
-      SetXMLAttribute(*ShowLog, "show", Str(ProjectShowLog))
-      
-      ; For the ProjectInfo
-      ;
-      *LastOpen = AppendNode(*ConfigData, "lastopen")
-      SetXMLAttribute(*LastOpen, "date", FormatDate("%yyyy-%mm-%dd %hh:%ii", Date()))
-      SetXMLAttribute(*LastOpen, "user", UserName())
-      SetXMLAttribute(*LastOpen, "host", ComputerName())
-      
-      ; Project file list
-      ;
-      *Files = NewSection(*Main, "files")
-      
-      ; Make sure Project panel expanded states are up to date
-      StoreProjectPanelStates()
-      
-      ForEach ProjectFiles()
-        *File = AppendNode(*Files, "file")
-        SetXMLAttribute(*File, "name", CreateRelativePath(BasePath$, ProjectFiles()\FileName$))
-        
-        *FileConfig = AppendNode(*File, "config")
-        SetXMLAttribute(*FileConfig, "load",     Str(ProjectFiles()\AutoLoad))
-        SetXMLAttribute(*FileConfig, "scan",     Str(ProjectFiles()\AutoScan))
-        SetXMLAttribute(*FileConfig, "panel",    Str(ProjectFiles()\ShowPanel))
-        SetXMLAttribute(*FileConfig, "warn",     Str(ProjectFiles()\ShowWarning))
-        SetXMLAttribute(*FileConfig, "lastopen", Str(ProjectFiles()\LastOpen))
-        
-        If ProjectFiles()\ShowPanel
-          SetXMLAttribute(*FileConfig, "panelstate", ProjectFiles()\PanelState$)
-        EndIf
-        
-        ; files are saved in CloseProject() before this, so its ok
-        If ProjectFiles()\ShowWarning
-          *Fingerprint = AppendNode(*File, "fingerprint")
-          SetXMLAttribute(*Fingerprint, "md5", FileFingerprint(ProjectFiles()\FileName$, #PB_Cipher_MD5))
-        EndIf
-      Next ProjectFiles()
-      
-      ; Project target list
-      ; We only write keys that have non-default values to not blow up the file
-      ;
-      *Targets = NewSection(*Main, "targets")
-      
-      ForEach ProjectTargets()
-        *Target = AppendNode(*Targets, "target")
-        SetXMLAttribute(*Target, "name", ProjectTargets()\Name$)
-        SetXMLAttribute(*Target, "enabled", Str(ProjectTargets()\IsEnabled))
-        SetXMLAttribute(*Target, "default", Str(ProjectTargets()\IsDefault))
-        
-        ; these are always set
-        *Node = AppendNode(*Target, "inputfile")
-        SetXMLAttribute(*Node, "value", ProjectTargets()\MainFile$)
-        
-        *Node = AppendNode(*Target, "outputfile")
-        SetXMLAttribute(*Node, "value", ProjectTargets()\OutputFile$)
-        
-        If ProjectTargets()\CustomCompiler
-          *Node = AppendNode(*Target, "compiler")
-          SetXMLAttribute(*Node, "version", ProjectTargets()\CompilerVersion$)
-        EndIf
-        
-        If ProjectTargets()\CommandLine$
-          *Node = AppendNode(*Target, "commandline")
-          SetXMLAttribute(*Node, "value", ProjectTargets()\CommandLine$)
-        EndIf
-        If ProjectTargets()\ExecutableName$
-          ; this is a full path, so make it relative
-          *Node = AppendNode(*Target, "executable")
-          SetXMLAttribute(*Node, "value", CreateRelativePath(BasePath$, ProjectTargets()\ExecutableName$))
-        EndIf
-        If ProjectTargets()\CurrentDirectory$
-          *Node = AppendNode(*Target, "directory")
-          SetXMLAttribute(*Node, "value", ProjectTargets()\CurrentDirectory$) ; It's already a relative path
-        EndIf
-        
-        *Options = AppendNode(*Target, "options")
-        If ProjectTargets()\EnableASM
-          SetXMLAttribute(*Options, "asm",     "1")
-        EndIf
-        If ProjectTargets()\EnableUnicode
-          ; write back the found value for compatibility with pre-5.50 versions
-          SetXMLAttribute(*Options, "unicode", "1")
-        EndIf
-        If ProjectTargets()\EnableThread
-          SetXMLAttribute(*Options, "thread",  "1")
-        EndIf
-        If ProjectTargets()\EnableXP
-          SetXMLAttribute(*Options, "xpskin",  "1")
-        EndIf
-        If ProjectTargets()\EnableAdmin
-          SetXMLAttribute(*Options, "admin",   "1")
-        EndIf
-        If ProjectTargets()\EnableUser
-          SetXMLAttribute(*Options, "user",    "1")
-        EndIf
-        If ProjectTargets()\DPIAware
-          SetXMLAttribute(*Options, "dpiaware",  "1")
-        EndIf
-        If ProjectTargets()\EnableOnError
-          SetXMLAttribute(*Options, "onerror", "1")
-        EndIf
-        If ProjectTargets()\Debugger
-          SetXMLAttribute(*Options, "debug",   "1")
-        EndIf
-        
-        CompilerIf #SpiderBasic
-          SetXMLAttribute(*Options, "optimizejs", Str(ProjectTargets()\OptimizeJS))
-          SetXMLAttribute(*Options, "webserveraddress", ProjectTargets()\WebServerAddress$)
-          SetXMLAttribute(*Options, "windowtheme"  , ProjectTargets()\WindowTheme$)
-          SetXMLAttribute(*Options, "gadgettheme"  , ProjectTargets()\GadgetTheme$)
-          
-          ; Add a new "export" section
-          ;
-          *Export = AppendNode(*Target, "export")
-          SetXMLAttribute(*Export, "webappname"         , ProjectTargets()\WebAppName$)       ; Node won't be created if the value is empty
-          SetXMLAttribute(*Export, "webappicon"         , ProjectTargets()\WebAppIcon$)       ; Node won't be created if the value is empty
-          SetXMLAttribute(*Export, "htmlfilename"       , ProjectTargets()\HtmlFilename$)     ; Node won't be created if the value is empty
-          SetXMLAttribute(*Export, "javascriptfilename" , ProjectTargets()\JavaScriptFilename$) ;
-          SetXMLAttribute(*Export, "javascriptpath"     , ProjectTargets()\JavaScriptPath$)
-          SetXMLAttribute(*Export, "copyjavascriptlibrary"  , Str(ProjectTargets()\CopyJavaScriptLibrary))
-          SetXMLAttribute(*Export, "exportcommandline"  , ProjectTargets()\ExportCommandLine$)
-          SetXMLAttribute(*Export, "exportarguments"    , ProjectTargets()\ExportArguments$)
-          SetXMLAttribute(*Export, "enableresourcedirectory"  , Str(ProjectTargets()\EnableResourceDirectory))
-          SetXMLAttribute(*Export, "resourcedirectory"  , ProjectTargets()\ResourceDirectory$)  ; Node won't be created if the value is empty
-          SetXMLAttribute(*Export, "webappenabledebugger", Str(ProjectTargets()\WebAppEnableDebugger))
-          
-          SetXMLAttribute(*Export, "iosappname"         , ProjectTargets()\iOSAppName$)
-          SetXMLAttribute(*Export, "iosappicon"         , ProjectTargets()\iOSAppIcon$)
-          SetXMLAttribute(*Export, "iosappversion"      , ProjectTargets()\iOSAppVersion$)
-          SetXMLAttribute(*Export, "iosapppackageid"    , ProjectTargets()\iOSAppPackageID$)
-          SetXMLAttribute(*Export, "iosappstartupimage" , ProjectTargets()\iOSAppStartupImage$)
-          SetXMLAttribute(*Export, "iosapporientation"  , Str(ProjectTargets()\iOSAppOrientation))
-          SetXMLAttribute(*Export, "iosappfullscreen"   , Str(ProjectTargets()\iOSAppFullScreen))
-          SetXMLAttribute(*Export, "iosappgeolocation"  , Str(ProjectTargets()\iOSAppGeolocation))
-          SetXMLAttribute(*Export, "iosappoutput"       , ProjectTargets()\iOSAppOutput$)
-          SetXMLAttribute(*Export, "iosappautoupload"   , Str(ProjectTargets()\iOSAppAutoUpload))
-          SetXMLAttribute(*Export, "iosappenableresourcedirectory", Str(ProjectTargets()\iOSAppEnableResourceDirectory))
-          SetXMLAttribute(*Export, "iosappresourcedirectory", ProjectTargets()\iOSAppResourceDirectory$)
-          SetXMLAttribute(*Export, "iosappenabledebugger", Str(ProjectTargets()\iOSAppEnableDebugger))
-          
-          SetXMLAttribute(*Export, "androidappname"         , ProjectTargets()\AndroidAppName$)
-          SetXMLAttribute(*Export, "androidappicon"         , ProjectTargets()\AndroidAppIcon$)
-          SetXMLAttribute(*Export, "androidappversion"      , ProjectTargets()\AndroidAppVersion$)
-          SetXMLAttribute(*Export, "androidapppackageid"    , ProjectTargets()\AndroidAppPackageID$)
-          SetXMLAttribute(*Export, "androidappiapkey"       , ProjectTargets()\AndroidAppIAPKey$)
-          SetXMLAttribute(*Export, "androidappstartupimage" , ProjectTargets()\AndroidAppStartupImage$)
-          SetXMLAttribute(*Export, "androidapporientation"  , Str(ProjectTargets()\AndroidAppOrientation))
-          SetXMLAttribute(*Export, "androidappfullscreen"   , Str(ProjectTargets()\AndroidAppFullScreen))
-          SetXMLAttribute(*Export, "androidappgeolocation"  , Str(ProjectTargets()\AndroidAppGeolocation))
-          SetXMLAttribute(*Export, "androidappoutput"       , ProjectTargets()\AndroidAppOutput$)
-          SetXMLAttribute(*Export, "androidappautoupload"   , Str(ProjectTargets()\AndroidAppAutoUpload))
-          SetXMLAttribute(*Export, "androidappenableresourcedirectory", Str(ProjectTargets()\AndroidAppEnableResourceDirectory))
-          SetXMLAttribute(*Export, "androidappresourcedirectory", ProjectTargets()\AndroidAppResourceDirectory$)
-          SetXMLAttribute(*Export, "androidappenabledebugger", Str(ProjectTargets()\AndroidAppEnableDebugger))
-          
-        CompilerEndIf
-        
-        If ProjectTargets()\EnablePurifier Or ProjectTargets()\PurifierGranularity$
-          *Purifier = AppendNode(*Target, "purifier")
-          SetXMLAttribute(*Purifier, "enable", Str(ProjectTargets()\EnablePurifier))
-          
-          If ProjectTargets()\PurifierGranularity$
-            SetXMLAttribute(*Purifier, "granularity", ProjectTargets()\PurifierGranularity$)
+        If IsProjectCreation
+          If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
+            ProjectFileChange(NewProjectFile$)
           EndIf
         EndIf
         
-        If ProjectTargets()\TemporaryExePlace
-          *Node = AppendNode(*Target, "temporaryexe")
-          SetXMLAttribute(*Node, "value", "source")
-        EndIf
+      Case #GADGET_Project_OpenOptions
+        OpenOptionWindow(#True)
         
-        If ProjectTargets()\Subsystem$
-          *Node = AppendNode(*Target, "subsystem")
-          SetXMLAttribute(*Node, "value", ProjectTargets()\Subsystem$)
-        EndIf
-        
-        If ProjectTargets()\LinkerOptions$
-          *Node = AppendNode(*Target, "linker")
-          SetXMLAttribute(*Node, "value", ProjectTargets()\LinkerOptions$)
-        EndIf
-        
-        If ProjectTargets()\IconName$ Or ProjectTargets()\UseIcon
-          *Icon = AppendNode(*Target, "icon", ProjectTargets()\IconName$)
-          SetXMLAttribute(*Icon, "enable", Str(ProjectTargets()\UseIcon))
-        EndIf
-        
-        If ProjectTargets()\ExecutableFormat <> 0 Or ProjectTargets()\CPU <> 0
-          *Format = AppendNode(*Target, "format")
-          Select ProjectTargets()\ExecutableFormat
-            Case 0: SetXMLAttribute(*Format, "exe", "default")
-            Case 1: SetXMLAttribute(*Format, "exe", "console")
-            Case 2: SetXMLAttribute(*Format, "exe", "dll")
-          EndSelect
-          SetXMLAttribute(*Format, "cpu", Str(ProjectTargets()\CPU))
-        EndIf
-        
-        If ProjectTargets()\CustomDebugger
-          *Debugger = AppendNode(*Target, "debugger")
-          SetXMLAttribute(*Debugger, "custom", "1")
-          Select ProjectTargets()\DebuggerType
-            Case 1: SetXMLAttribute(*Debugger, "type", "ide")
-            Case 2: SetXMLAttribute(*Debugger, "type", "standalone")
-            Case 3: SetXMLAttribute(*Debugger, "type", "console")
-          EndSelect
-        EndIf
-        
-        If ProjectTargets()\CustomWarning
-          *Warnings = AppendNode(*Target, "warnings")
-          SetXMLAttribute(*Warnings, "custom", "1")
-          Select ProjectTargets()\WarningMode
-            Case 0: SetXMLAttribute(*Warnings, "type", "ignore")
-            Case 1: SetXMLAttribute(*Warnings, "type", "display")
-            Case 2: SetXMLAttribute(*Warnings, "type", "error")
-          EndSelect
-        EndIf
-        
-        If ProjectTargets()\UseCompileCount Or ProjectTargets()\CompileCount <> 0
-          *CompileCount = AppendNode(*Target, "compilecount")
-          SetXMLAttribute(*CompileCount, "enable", Str(ProjectTargets()\UseCompileCount))
-          SetXMLAttribute(*CompileCount, "value", Str(ProjectTargets()\CompileCount))
-        EndIf
-        
-        If ProjectTargets()\UseBuildCount Or ProjectTargets()\BuildCount <> 0
-          *BuildCount = AppendNode(*Target, "buildcount")
-          SetXMLAttribute(*BuildCount, "enable", Str(ProjectTargets()\UseBuildCount))
-          SetXMLAttribute(*BuildCount, "value", Str(ProjectTargets()\BuildCount))
-        EndIf
-        
-        If ProjectTargets()\UseCreateExe
-          *CreateExe = AppendNode(*Target, "execonstant")
-          SetXMLAttribute(*CreateExe, "enable", "1")
-        EndIf
-        
-        WriteVersion = ProjectTargets()\VersionInfo
-        If ProjectTargets()\VersionInfo
-          ; still include the version info if it is non-empty, even if disabled
-          For i = 0 To 23
-            If ProjectTargets()\VersionField$[i] <> ""
-              WriteVersion = 1
-              Break
-            EndIf
-          Next i
-        EndIf
-        
-        If WriteVersion
-          *Version = AppendNode(*Target, "versioninfo")
-          SetXMLAttribute(*Version, "enable", Str(ProjectTargets()\VersionInfo))
-          For i = 0 To 23
-            If ProjectTargets()\VersionField$[i] <> ""
-              *Node = AppendNode(*Version, "field"+Str(i))
-              SetXMLAttribute(*Node, "value", ProjectTargets()\VersionField$[i])
-            EndIf
-          Next i
-        EndIf
-        
-        If ProjectTargets()\NbResourceFiles > 0
-          *Resources = AppendNode(*Target, "resources")
-          For i = 0 To ProjectTargets()\NbResourceFiles-1
-            *Node = AppendNode(*Resources, "resource")
-            SetXMLAttribute(*Node, "value", ProjectTargets()\ResourceFiles$[i])
-          Next i
-        EndIf
-        
-        If ProjectTargets()\NbConstants > 0
-          *Constants = AppendNode(*Target, "constants")
-          For i = 0 To ProjectTargets()\NbConstants-1
-            *Constant = AppendNode(*Constants, "constant")
-            SetXMLAttribute(*Constant, "value", ProjectTargets()\Constant$[i])
-            SetXMLAttribute(*Constant, "enable", Str(ProjectTargets()\ConstantEnabled[i]))
-          Next i
-        EndIf
-        
-        If ProjectTargets()\Watchlist$
-          AppendNode(*Target, "watchlist", ProjectTargets()\Watchlist$)
-        EndIf
-        
-        If ProjectTargets()\EnabledTools$
-          AppendNode(*Target, "tools", ProjectTargets()\EnabledTools$)
-        EndIf
-      Next ProjectTargets()
-      
-      ; Format the project to a more readable format
-      ;
-      FormatXML(#XML_SaveProject, #PB_XML_ReFormat, 2)
-      
-      ; Save the file
-      ;
-      If SaveXML(#XML_SaveProject, ProjectFile$)
-        Success = #True
-      EndIf
-      
-      FreeXML(#XML_SaveProject)
-    EndIf
-    
-    If Success = #False And ShowErrors
-      MessageRequester(Language("Project", "TitleShort"), Language("Project", "SaveError"), #FLAG_Error)
-    EndIf
-    
-    ProcedureReturn Success
-  EndProcedure
-  
-  Procedure OpenProject()
-    
-    If IsProjectCreation = 0
-      
-      If IsProject
-        Path$ = GetPathPart(ProjectFile$)
-      ElseIf *ActiveSource\FileName$
-        Path$ = GetPathPart(*ActiveSource\FileName$)
-      Else
-        Path$ = SourcePath$
-      EndIf
-      
-      FileName$ = OpenFileRequester(Language("Project","TitleOpen"), Path$, Language("Project","Pattern"), 0)
-      If FileName$ <> ""
-        LoadProject(FileName$) ; closes the old project if still open
-      EndIf
-      
-    EndIf
-    
-  EndProcedure
-  
-  Procedure CloseProject(IsIDEShutdown = #False)
-    If IsProject
-      
-      ; close options
-      If IsWindow(#WINDOW_ProjectOptions)
-        ProjectOptionsEvents(#PB_Event_CloseWindow)
-      EndIf
-      
-      If IsWindow(#WINDOW_Option)
-        ; close these only if they belong to the project (ie there is a project code open)
-        If *ActiveSource\ProjectFile
-          OptionWindowEvents(#PB_Event_CloseWindow)
-        EndIf
-      EndIf
-      
-      
-      If IsWindow(#WINDOW_Build)
-        BuildWindowEvents(#PB_Event_CloseWindow)
-      EndIf
-      
-      ; Is there a debugger running for the project ?
-      ;
-      *Debugger.DebuggerData = FindDebuggerFromID(ProjectDebuggerID)
-      If *Debugger
-        Debugger_Kill(*Debugger)
-      EndIf
-      
-      ; Update the "last open" state of all project files
-      ;
-      ForEach ProjectFiles()
-        If ProjectFiles()\Source
-          ProjectFiles()\LastOpen = #True
+      Case #GADGET_Project_ChooseFile
+        File$ = GetGadgetText(#GADGET_Project_File)
+        If File$ = ""
+          File$ = SourceDirectory$
         Else
-          ProjectFiles()\LastOpen = #False
-        EndIf
-      Next ProjectFiles()
-      
-      If ProjectCloseFiles
-        *RealActiveSource = *ActiveSource
-        
-        ; do not walk the FileList() as it gets modified when removing a source
-        ForEach ProjectFiles()
-          If ProjectFiles()\Source
-            If *RealActiveSource = *ActiveSource
-              *RealActiveSource = 0 ; we cannot switch back to this as it will be removed
-            EndIf
-            
-            ; RemoveSource() can trigger a walk of the ProjectFiles() list too,
-            ; So save/restore the position
-            *ProjectFile = @ProjectFiles()
-            
-            ; save/close all codes that belong To the project If the option is set
-            ; NOTE: On IDE shutdown this is done already anyway, so do not do it again
-            ;   as the "do you want to save" question was already asked then (but the code not closed yet)
-            ;
-            If IsIDEShutdown Or CheckSourceSaved(ProjectFiles()\Source) = 1
-              RemoveSource(ProjectFiles()\Source)
-            Else
-              Cancelled = #True ; The user can press "Cancel" when a source has been modified in the project and it doesn't want to close the project anymore
-              Break             ; abort, keep the last source the active one
-            EndIf
-            
-            ChangeCurrentElement(ProjectFiles(), *ProjectFile)
-          EndIf
-        Next ProjectFiles()
-        
-        If *RealActiveSource
-          ChangeCurrentElement(FileList(), *RealActiveSource)
-          ChangeActiveSourcecode(*RealActiveSource)
-        EndIf
-      EndIf
-      
-      ; Don't close the main project panel if the close has been cancelled
-      ;
-      If Cancelled = #False
-        ; unlink all codes (do not keep any data).
-        ForEach FileList()
-          If @FileList() <> *ProjectInfo
-            UnlinkSourceFromProject(@FileList(), #False)
-          EndIf
-        Next FileList()
-        ChangeCurrentElement(FileList(), *ActiveSource)
-        
-        ; Save the project, and do not close if this is impossible
-        ; (also saves the "last open" state)
-        If IsIDEShutdown
-          Result = SaveProject(#False)
-        Else
-          Result = SaveProject(#True)
+          ; always resolve from the CurrentDirectory() as there is no basepath for project files
+          File$ = ResolveRelativePath(GetCurrentDirectory(), File$)
         EndIf
         
-        If Result = #False
-          ProcedureReturn #False
+        File$ = SaveFileRequester(Language("Project","TitleSave"), File$, Language("Project","Pattern"), 0)
+        If File$ <> ""
+          If GetExtensionPart(GetFilePart(File$)) = ""
+            If SelectedFilePattern() = 0 ; project files
+              File$ + #ProjectFileExtension
+            EndIf
+          EndIf
+          
+          ProjectFileChange(File$)
         EndIf
         
-        ; clean up the file list
-        ForEach ProjectFiles()
-          ClearProjectFile(@ProjectFiles())
-        Next ProjectFiles()
-        ClearList(ProjectFiles())
-        
-        ClearList(ProjectTargets())
-        ClearList(ProjectLog())
-        
-        ; Important to set this to 0 as it points to invalid memory else and lead to problems
-        *DefaultTarget = 0
-        
-        RemoveProjectInfo()
-        
-        IsProject = 0
-        UpdateProjectPanel()
-        UpdateMenuStates()
-        UpdateMainWindowTitle() ; remove the project name from the title
-        
-        ; Update the menu to reflect the now empty target list
-        StartFlickerFix(#WINDOW_Main)
-        CreateIDEMenu()
-        StopFlickerFix(#WINDOW_Main, 1)
-      Else
-        ProcedureReturn #False ; The project has not been closed.
-      EndIf
-    EndIf
-    
-    ProcedureReturn #True
-  EndProcedure
-  
-  
-  Procedure UpdateProjectOptionStates()
-    
-    NoAdd = 1
-    If GetGadgetState(#GADGET_Project_Explorer) <> -1
-      Last  = CountGadgetItems(#GADGET_Project_Explorer)-1
-      
-      For i = 0 To Last
-        If GetGadgetItemState(#GADGET_Project_Explorer, i) & #PB_Explorer_Selected And GetGadgetItemText(#GADGET_Project_Explorer, i, 0) <> ".."
-          NoAdd = 0
-          Break
-        EndIf
-      Next i
-    EndIf
-    
-    DisableGadget(#GADGET_Project_AddFile, NoAdd)
-    
-    Selected = 0
-    FileLoad = 0
-    FileScan = 0
-    FileWarn = 0
-    FilePanel = 0
-    
-    If GetGadgetState(#GADGET_Project_FileList) <> -1
-      Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-      
-      For i = 0 To Last
-        If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-          *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-          Selected + 1
-          
-          If Selected = 1 ; its the first file, so just apply the state
-            FileLoad  = *File\AutoLoad
-            FileScan  = *File\AutoScan
-            FileWarn  = *File\ShowWarning
-            FilePanel = *File\ShowPanel
-          Else ; apply the inconsistent state if an entry does not match
-            If FileLoad <> *File\AutoLoad:    FileLoad = -1:  EndIf
-            If FileScan <> *File\AutoScan:    FileScan = -1:  EndIf
-            If FileWarn <> *File\ShowWarning: FileWarn = -1:  EndIf
-            If FilePanel <> *File\ShowPanel:  FilePanel = -1: EndIf
-          EndIf
-        EndIf
-      Next i
-    EndIf
-    
-    If Selected > 0
-      Disable = 0
-    Else
-      Disable = 1
-    EndIf
-    
-    If IsProjectCreation
-      ; if a project is created, the main window is disabled, so this does not make much sense
-      DisableGadget(#GADGET_Project_ViewFile, 1)
-    Else
-      DisableGadget(#GADGET_Project_ViewFile, Disable)
-    EndIf
-    
-    DisableGadget(#GADGET_Project_RemoveFile, Disable)
-    DisableGadget(#GADGET_Project_FileLoad,   Disable)
-    DisableGadget(#GADGET_Project_FileScan,   Disable)
-    DisableGadget(#GADGET_Project_FileWarn,   Disable)
-    DisableGadget(#GADGET_Project_FilePanel,  Disable)
-    
-    SetGadgetState(#GADGET_Project_FileLoad,  FileLoad)
-    SetGadgetState(#GADGET_Project_FileScan,  FileScan)
-    SetGadgetState(#GADGET_Project_FileWarn,  FileWarn)
-    SetGadgetState(#GADGET_Project_FilePanel, FilePanel)
-    
-  EndProcedure
-  
-  ; returns #false if canceled
-  ;
-  Procedure RecursiveAddFiles(ID, Base$, List Files.s())
-    
-    Select MessageRequester(Language("Project","Title"), Language("Project","AddDirectory")+#NewLine+Base$, #PB_MessageRequester_YesNoCancel|#FLAG_Question)
-      Case #PB_MessageRequester_Yes
-        If ExamineDirectory(ID, Base$, "*")
-          While NextDirectoryEntry(ID)
-            Name$ = DirectoryEntryName(ID)
-            
-            If DirectoryEntryType(ID) = #PB_DirectoryEntry_Directory
-              If Name$ <> "." And Name$ <> ".."
-                If RecursiveAddFiles(ID+1, Base$+Name$+#Separator, Files()) = #False
-                  FinishDirectory(ID)
-                  ProcedureReturn #False ; send the "cancel" out to the main level
-                EndIf
-              EndIf
-              
-            Else
-              AddElement(Files())
-              Files() = Base$ + Name$
-              
-            EndIf
-          Wend
-          FinishDirectory(ID)
-        EndIf
-        ProcedureReturn #True
-        
-      Case #PB_MessageRequester_No
-        ProcedureReturn #True ; skip directory but do not cancel
-        
-      Case #PB_MessageRequester_Cancel
-        ProcedureReturn #False
-        
-    EndSelect
-    
-  EndProcedure
-  
-  ; Add a list of files to to the options dialog.
-  ; the list may include directories and must be Chr(10) separated (like EventDropFiles())
-  ;
-  Procedure AddProjectOptionFiles(FileList$)
-    Protected NewList Files.s()
-    Count = CountString(FileList$, Chr(10)) + 1
-    
-    ; Deselect all items in the gadget, as we only select newly added ones
-    SetGadgetState(#GADGET_Project_FileList, -1)
-    
-    ; First gather recursively all directory content to add
-    ; if directories are included (ask the user for every directory)
-    ;
-    For i = 1 To Count
-      File$ = Trim(StringField(FileList$, i, Chr(10)))
-      
-      If FileSize(File$) = -2
-        If Right(File$, 1) <> #Separator
-          File$ + #Separator
-        EndIf
-        
-        If RecursiveAddFiles(0, File$, Files()) = #False ; #false means user canceled
-          UpdateProjectOptionStates()                    ; reflect the new gadget state
-          ProcedureReturn
-        EndIf
-        
-      Else
-        AddElement(Files())
-        Files() = File$
-        
-      EndIf
-    Next i
-    
-    ; Filter files that are already in the project
-    ;
-    ForEach Files()
-      ForEach ProjectConfig()
-        If IsEqualFile(Files(), ProjectConfig()\FileName$)
-          ; select this file in the file list (as we select all added files)
-          Last = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 1 To Last
-            If GetGadgetItemData(#GADGET_Project_FileList, i) = @ProjectConfig()
-              SetGadgetItemState(#GADGET_Project_FileList, i, #PB_ListIcon_Selected)
-              Break
-            EndIf
-          Next i
-          
-          ; remove this file from the "to add" list
-          DeleteElement(Files())
-          Break
-        EndIf
-      Next ProjectConfig()
-    Next Files()
-    
-    If ListSize(Files()) = 0
-      UpdateProjectOptionStates() ; reflect the new gadget states
-      ProcedureReturn
-    EndIf
-    
-    ; Warn if there are many files to add
-    ;
-    If ListSize(Files()) > 50
-      If MessageRequester(Language("Project","Title"), LanguagePattern("Project","AddManyFiles", "%filecount%", Str(ListSize(Files()))), #PB_MessageRequester_YesNo|#FLAG_Question) = #PB_MessageRequester_No
-        UpdateProjectOptionStates() ; reflect the new gadget states
-        ProcedureReturn
-      EndIf
-    EndIf
-    
-    ; Finally add the files
-    ;
-    LastElement(ProjectConfig())
-    
-    If IsProjectCreation
-      BasePath$ = GetPathPart(NewProjectFile$)
-    Else
-      BasePath$ = GetPathPart(ProjectFile$)
-    EndIf
-    
-    ForEach Files()
-      AddElement(ProjectConfig())
-      ProjectConfig()\FileName$   = Files()
-      ProjectConfig()\AutoLoad    = 0
-      ProjectConfig()\AutoScan    = IsCodeFile(Files())
-      ProjectConfig()\ShowPanel   = 1
-      ProjectConfig()\ShowWarning = 1
-      
-      AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(BasePath$, Files()))
-      Index = CountGadgetItems(#GADGET_Project_FileList)-1
-      SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
-      SetGadgetItemState(#GADGET_Project_FileList, Index, #PB_ListIcon_Selected)
-    Next Files()
-    
-    UpdateProjectOptionStates() ; reflect the new gadget states
-    
-  EndProcedure
-  
-  ; for project creation only.
-  ; Resolve/Change the project filename and the filelist
-  ;
-  Procedure ProjectFileChange(NewFile$)
-    If NewFile$ = ""
-      NewProjectFile$ = ""
-    Else
-      ; Add extension if none present
-      ;
-      If GetExtensionPart(GetFilePart(NewFile$)) = ""
-        NewFile$ + #ProjectFileExtension
-      EndIf
-      
-      ; Resolve the new file by the current directory, because there it would be saved if
-      ; we did not resolve anything. (the user should use a full path anyway)
-      ;
-      NewProjectFile$ = ResolveRelativePath(GetCurrentDirectory(), NewFile$)
-      
-      If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
-        SetGadgetText(#GADGET_Project_File, NewProjectFile$)
-      EndIf
-    EndIf
-    
-    BasePath$ = GetPathPart(NewProjectFile$)
-    Last = CountGadgetItems(#GADGET_Project_FileList)-1
-    For i = 0 To Last
-      *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-      SetGadgetItemText(#GADGET_Project_FileList, i, CreateRelativePath(BasePath$, *File\FileName$), 0)
-    Next i
-  EndProcedure
-  
-  Procedure ProjectOptionsEvents(EventID)
-    Quit = 0
-    
-    If EventID = #PB_Event_Menu     ; Little wrapper to map the shortcut events (identified as menu)
-      EventID  = #PB_Event_Gadget   ; to normal gadget events...
-      EventGadgetID = EventMenu()
-    Else
-      EventGadgetID = EventGadget()
-    EndIf
-    
-    
-    If EventID = #PB_Event_GadgetDrop
-      Select EventGadget()
-          
-        Case #GADGET_Project_Name
-          SetGadgetText(#GADGET_Project_Name, RemoveString(EventDropText(), #NewLine))
-          
-        Case #GADGET_Project_Comments
-          SetGadgetText(#GADGET_Project_Comments, EventDropText())
-          
-        Case #GADGET_Project_FileList
-          AddProjectOptionFiles(EventDropFiles())
-          
-      EndSelect
-      
-    ElseIf EventID = #PB_Event_Gadget
-      Select EventGadgetID
-          
-        Case #GADGET_Project_Ok
-          ProjectOK = 1
-          
-          ; Some required checks
-          If Trim(GetGadgetText(#GADGET_Project_Name)) = ""
-            ProjectOK = 0
-            MessageRequester(Language("Project","Title"), Language("Project","NeedName"))
-            
-          ElseIf IsProjectCreation
-            
-            ; this also resolves relative names etc
-            If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
-              ProjectFileChange(GetGadgetText(#GADGET_Project_File))
-            EndIf
-            
-            If NewProjectFile$ = ""
-              ProjectOK = 0
-              MessageRequester(Language("Project","Title"), Language("Project","NeedFile"))
-              
-            ElseIf FileSize(NewProjectFile$) > -1
-              If MessageRequester(Language("Project","TitleNew"), Language("FileStuff","FileExists")+#NewLine+Language("FileStuff","OverWrite"), #PB_MessageRequester_YesNo|#FLAG_Warning) = #PB_MessageRequester_No
-                ProjectOK = 0
-              EndIf
-              
-            EndIf
-            
-            ; check if the filename is a writable location so we do not get the problem later
-            If ProjectOK
-              If OpenFile(#FILE_CheckProject, NewProjectFile$) = 0
-                MessageRequester(Language("Project", "TitleNew"), Language("Project", "SaveError"), #FLAG_Error)
-                ProjectOK = 0
-              Else
-                CloseFile(#FILE_CheckProject)
-              EndIf
-            EndIf
-          EndIf
-          
-          If ProjectOK
-            
-            ; In case we create a new project. Now we have a project data
-            If IsProjectCreation
-              IsProject    = #True
-              ProjectFile$ = NewProjectFile$
-              ProjectShowLog = #True ; always true initially
-              
-              ProjectLastOpenDate    = 0
-              ProjectLastOpenHost$   = ""
-              ProjectLastOpenUser$   = ""
-              ProjectLastOpenEditor$ = ""
-              
-              ; no targets yet (a default one is created below)
-              ClearList(ProjectTargets())
-              ClearList(ProjectFiles()) ; filled with the config below
-              ClearList(ProjectLog())
-              
-              ; add the info source
-              AddProjectInfo()
-              
-              ; switch to the info source, so the user can directly get to the projects compiler options etc
-              FirstElement(FileList())
-              ChangeActiveSourceCode()
-            EndIf
-            
-            ; Update the options
-            ProjectName$     = Trim(GetGadgetText(#GADGET_Project_Name))
-            ProjectComments$ = GetGadgetText(#GADGET_Project_Comments)
-            
-            If GetGadgetState(#GADGET_Project_SetDefault)
-              DefaultProjectFile$ = ProjectFile$
-            ElseIf IsEqualFile(DefaultProjectFile$, ProjectFile$) ; do not unset if this was not the default project
-              DefaultProjectFile$ = ""
-            EndIf
-            
-            ProjectCloseFiles = GetGadgetState(#GADGET_Project_CloseAllFiles)
-            
-            If GetGadgetState(#GADGET_Project_OpenLoadLast)
-              ProjectOpenMode = 0
-            ElseIf GetGadgetState(#GADGET_Project_OpenLoadAll)
-              ProjectOpenMode = 1
-            ElseIf GetGadgetState(#GADGET_Project_OpenLoadDefault)
-              ProjectOpenMode = 2
-            ElseIf GetGadgetState(#GADGET_Project_OpenLoadMain)
-              ProjectOpenMode = 3
-            Else
-              ProjectOpenMode = 4
-            EndIf
-            
-            ; Now remove any file from the real project file list if it is not in the config list
-            ; We do not just do a ClearList() and re-fill it, because the ProjectPanel stores
-            ; pointers to the entries!
-            ;
-            ForEach ProjectFiles()
-              Found = 0
-              ForEach ProjectConfig()
-                If IsEqualFile(ProjectFiles()\Filename$, ProjectConfig()\Filename$)
-                  Found = 1
-                  Break
-                EndIf
-              Next ProjectConfig()
-              
-              If Found = 0
-                If ProjectFiles()\Source
-                  *ProjectFile = @ProjectFiles()
-                  UnlinkSourceFromProject(ProjectFiles()\Source, #False)
-                  ChangeCurrentElement(ProjectFiles(), *ProjectFile)
-                EndIf
-                ClearProjectFile(@ProjectFiles())
-                DeleteElement(ProjectFiles())
-              EndIf
-            Next ProjectFiles()
-            
-            ; Now add/update the current/new files
-            ForEach ProjectConfig()
-              Found = 0
-              ForEach ProjectFiles()
-                If IsEqualFile(ProjectFiles()\Filename$, ProjectConfig()\Filename$)
-                  Found = 1
-                  Break
-                EndIf
-              Next ProjectFiles()
-              
-              If Found = 0
-                AddElement(ProjectFiles()) ; add new if needed
-              EndIf
-              
-              ; copy config to file and update the file data (autocomplete etc)
-              CopyProjectConfig(@ProjectConfig(), @ProjectFiles())
-              UpdateProjectFile(@ProjectFiles())
-            Next ProjectConfig()
-            
-            ClearList(ProjectConfig())
-            
-            ; ensure that the project has a default target (if it is new)
-            SetProjectDefaultTarget()
-            
-            ; Update the menu to reflect the new target list
-            StartFlickerFix(#WINDOW_Main)
-            CreateIDEMenu()
-            StopFlickerFix(#WINDOW_Main, 1)
-            
-            If SaveProject(#True)              ; do not save modified sources
-              RecentFiles_AddFile(ProjectFile$, #True) ; add to recent projects in case we create a new project here
-              Quit = 1
-            EndIf
-            
-            UpdateMainWindowTitle() ; show name changes
-          EndIf
-          
-        Case #GADGET_Project_Cancel
-          Quit = 1
-          
-        Case #GADGET_Project_Panel
-          ; Update the project file base if it changes on panel switches.
-          ; This way if the user switches to the file panel, he will see the correct relative path always
-          ;
-          If IsProjectCreation
-            If GetGadgetText(#GADGET_Project_File) <> NewProjectFile$
-              ProjectFileChange(NewProjectFile$)
-            EndIf
-          EndIf
-          
-        Case #GADGET_Project_OpenOptions
-          OpenOptionWindow(#True)
-          
-        Case #GADGET_Project_ChooseFile
-          File$ = GetGadgetText(#GADGET_Project_File)
-          If File$ = ""
-            File$ = SourceDirectory$
-          Else
-            ; always resolve from the CurrentDirectory() as there is no basepath for project files
-            File$ = ResolveRelativePath(GetCurrentDirectory(), File$)
-          EndIf
-          
-          File$ = SaveFileRequester(Language("Project","TitleSave"), File$, Language("Project","Pattern"), 0)
-          If File$ <> ""
-            If GetExtensionPart(GetFilePart(File$)) = ""
-              If SelectedFilePattern() = 0 ; project files
-                File$ + #ProjectFileExtension
-              EndIf
-            EndIf
-            
-            ProjectFileChange(File$)
-          EndIf
-          
-        Case #GADGET_Project_Explorer
-          If EventType() = #PB_EventType_DragStart
-            Last  = CountGadgetItems(#GADGET_Project_Explorer)-1
-            Base$ = GetGadgetText(#GADGET_Project_Explorer)
-            All$  = ""
-            For i = 0 To Last
-              State = GetGadgetItemState(#GADGET_Project_Explorer, i)
-              If State & #PB_Explorer_Selected
-                Name$ = GetGadgetItemText(#GADGET_Project_Explorer, i, 0)
-                If Name$ <> ".."
-                  If State & #PB_Explorer_Directory
-                    All$ + Base$ + Name$ + #Separator + Chr(10)
-                  Else
-                    All$ + Base$ + Name$ + Chr(10)
-                  EndIf
-                EndIf
-              EndIf
-            Next i
-            
-            If All$ <> ""
-              DragFiles(Left(All$, Len(All$)-1), #PB_Drag_Copy) ; cut the final Chr(10)
-            EndIf
-            
-          Else
-            If ProjectExplorerPath$ <> GetGadgetText(#GADGET_Project_Explorer)
-              ProjectExplorerPath$ = GetGadgetText(#GADGET_Project_Explorer)
-              SetGadgetText(#GADGET_Project_ExplorerCombo, ProjectExplorerPath$)
-            EndIf
-            UpdateProjectOptionStates() ; update this on all changes (enables the "Add" button)
-          EndIf
-          
-          CompilerIf #CompileWindows
-            ; adjust the column size to any scrollbar changes etc
-            SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-          CompilerEndIf
-          
-        Case #GADGET_Project_ExplorerCombo
-          If ProjectExplorerPath$ <> GetGadgetText(#GADGET_Project_ExplorerCombo)
-            ProjectExplorerPath$ = GetGadgetText(#GADGET_Project_ExplorerCombo)
-            SetGadgetText(#GADGET_Project_Explorer, ProjectExplorerPath$)
-            UpdateProjectOptionStates()
-          EndIf
-          
-        Case #GADGET_Project_ExplorerPattern ; not present on OSX
-          If ProjectExplorerPattern <> GetGadgetState(#GADGET_Project_ExplorerPattern)
-            ProjectExplorerPattern = GetGadgetState(#GADGET_Project_ExplorerPattern)
-            SetGadgetText(#GADGET_Project_Explorer, StringField(ExplorerPatternStrings$, ProjectExplorerPattern+1, "|"))
-            UpdateProjectOptionStates()
-          EndIf
-          
-        Case #GADGET_Project_FileList
-          UpdateProjectOptionStates()
-          
-        Case #GADGET_Project_AddFile
+      Case #GADGET_Project_Explorer
+        If EventType() = #PB_EventType_DragStart
           Last  = CountGadgetItems(#GADGET_Project_Explorer)-1
           Base$ = GetGadgetText(#GADGET_Project_Explorer)
           All$  = ""
@@ -2316,422 +2266,473 @@ Procedure IsPureBasicFile(FileName$)
             If State & #PB_Explorer_Selected
               Name$ = GetGadgetItemText(#GADGET_Project_Explorer, i, 0)
               If Name$ <> ".."
-                If State & #PB_Explorer_Directory And Right(Name$, 1) <> #Separator
-                  Name$ + #Separator ; drive names already have this!
+                If State & #PB_Explorer_Directory
+                  All$ + Base$ + Name$ + #Separator + Chr(10)
+                Else
+                  All$ + Base$ + Name$ + Chr(10)
                 EndIf
-                All$ + Base$ + Name$ + Chr(10)
               EndIf
             EndIf
           Next i
           
           If All$ <> ""
-            AddProjectOptionFiles(Left(All$, Len(All$)-1)) ; cut the final Chr(10)
+            DragFiles(Left(All$, Len(All$)-1), #PB_Drag_Copy) ; cut the final Chr(10)
           EndIf
           
-        Case #GADGET_Project_RemoveFile
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = Last To 0 Step -1 ; step backwards to not modify indexes of other items!
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              ChangeCurrentElement(ProjectConfig(), GetGadgetItemData(#GADGET_Project_FileList, i))
-              DeleteElement(ProjectConfig())
-              RemoveGadgetItem(#GADGET_Project_FileList, i)
+        Else
+          If ProjectExplorerPath$ <> GetGadgetText(#GADGET_Project_Explorer)
+            ProjectExplorerPath$ = GetGadgetText(#GADGET_Project_Explorer)
+            SetGadgetText(#GADGET_Project_ExplorerCombo, ProjectExplorerPath$)
+          EndIf
+          UpdateProjectOptionStates() ; update this on all changes (enables the "Add" button)
+        EndIf
+        
+        CompilerIf #CompileWindows
+          ; adjust the column size to any scrollbar changes etc
+          SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
+        CompilerEndIf
+        
+      Case #GADGET_Project_ExplorerCombo
+        If ProjectExplorerPath$ <> GetGadgetText(#GADGET_Project_ExplorerCombo)
+          ProjectExplorerPath$ = GetGadgetText(#GADGET_Project_ExplorerCombo)
+          SetGadgetText(#GADGET_Project_Explorer, ProjectExplorerPath$)
+          UpdateProjectOptionStates()
+        EndIf
+        
+      Case #GADGET_Project_ExplorerPattern ; not present on OSX
+        If ProjectExplorerPattern <> GetGadgetState(#GADGET_Project_ExplorerPattern)
+          ProjectExplorerPattern = GetGadgetState(#GADGET_Project_ExplorerPattern)
+          SetGadgetText(#GADGET_Project_Explorer, StringField(ExplorerPatternStrings$, ProjectExplorerPattern+1, "|"))
+          UpdateProjectOptionStates()
+        EndIf
+        
+      Case #GADGET_Project_FileList
+        UpdateProjectOptionStates()
+        
+      Case #GADGET_Project_AddFile
+        Last  = CountGadgetItems(#GADGET_Project_Explorer)-1
+        Base$ = GetGadgetText(#GADGET_Project_Explorer)
+        All$  = ""
+        For i = 0 To Last
+          State = GetGadgetItemState(#GADGET_Project_Explorer, i)
+          If State & #PB_Explorer_Selected
+            Name$ = GetGadgetItemText(#GADGET_Project_Explorer, i, 0)
+            If Name$ <> ".."
+              If State & #PB_Explorer_Directory And Right(Name$, 1) <> #Separator
+                Name$ + #Separator ; drive names already have this!
+              EndIf
+              All$ + Base$ + Name$ + Chr(10)
             EndIf
-          Next i
-          UpdateProjectOptionStates() ; no more selected items
-          
-        Case #GADGET_Project_NewFile
-          If IsProjectCreation
-            If NewProjectFile$ <> ""
-              Path$ = GetPathPart(NewProjectFile$)
-            Else
-              Path$ = SourcePath$
-            EndIf
+          EndIf
+        Next i
+        
+        If All$ <> ""
+          AddProjectOptionFiles(Left(All$, Len(All$)-1)) ; cut the final Chr(10)
+        EndIf
+        
+      Case #GADGET_Project_RemoveFile
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = Last To 0 Step -1 ; step backwards to not modify indexes of other items!
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            ChangeCurrentElement(ProjectConfig(), GetGadgetItemData(#GADGET_Project_FileList, i))
+            DeleteElement(ProjectConfig())
+            RemoveGadgetItem(#GADGET_Project_FileList, i)
+          EndIf
+        Next i
+        UpdateProjectOptionStates() ; no more selected items
+        
+      Case #GADGET_Project_NewFile
+        If IsProjectCreation
+          If NewProjectFile$ <> ""
+            Path$ = GetPathPart(NewProjectFile$)
           Else
-            Path$ = GetPathPart(ProjectFile$)
+            Path$ = SourcePath$
+          EndIf
+        Else
+          Path$ = GetPathPart(ProjectFile$)
+        EndIf
+        
+        FileName$ = SaveFileRequester(Language("FileStuff","SaveFileTitle"), Path$, Language("FileStuff","Pattern"), SelectedFilePattern)
+        If FileName$ <> ""
+          SelectedFilePattern = SelectedFilePattern()
+          
+          If GetExtensionPart(GetFilePart(FileName$)) = ""
+            If SelectedFilePattern <= 1  ; (=all pb files or pb sources only)
+              FileName$ + #SourceFileExtension
+            ElseIf SelectedFilePattern = 2 ; (=pbi only)
+              FileName$ + #IncludeFileExtension
+            EndIf
           EndIf
           
-          FileName$ = SaveFileRequester(Language("FileStuff","SaveFileTitle"), Path$, Language("FileStuff","Pattern"), SelectedFilePattern)
+          If FileSize(FileName$) > -1  ; file exist check
+            If MessageRequester(#ProductName$, Language("FileStuff","FileExists")+#NewLine+Language("FileStuff","OverWrite"), #PB_MessageRequester_YesNo|#FLAG_Warning) = #PB_MessageRequester_No
+              FileName$ = "" ; abort
+            EndIf
+          EndIf
+          
           If FileName$ <> ""
-            SelectedFilePattern = SelectedFilePattern()
-            
-            If GetExtensionPart(GetFilePart(FileName$)) = ""
-              If SelectedFilePattern <= 1  ; (=all pb files or pb sources only)
-                FileName$ + #SourceFileExtension
-              ElseIf SelectedFilePattern = 2 ; (=pbi only)
-                FileName$ + #IncludeFileExtension
+            ; Try to create the file, then open it.
+            ; This way we only add the file, if creating was possible
+            If CreateFile(#FILE_SaveSource, FileName$)
+              CloseFile(#FILE_SaveSource)
+              If LoadSourceFile(FileName$)
+                AddProjectOptionFiles(FileName$)
               EndIf
-            EndIf
-            
-            If FileSize(FileName$) > -1  ; file exist check
-              If MessageRequester(#ProductName$, Language("FileStuff","FileExists")+#NewLine+Language("FileStuff","OverWrite"), #PB_MessageRequester_YesNo|#FLAG_Warning) = #PB_MessageRequester_No
-                FileName$ = "" ; abort
-              EndIf
-            EndIf
-            
-            If FileName$ <> ""
-              ; Try to create the file, then open it.
-              ; This way we only add the file, if creating was possible
-              If CreateFile(#FILE_SaveSource, FileName$)
-                CloseFile(#FILE_SaveSource)
-                If LoadSourceFile(FileName$)
-                  AddProjectOptionFiles(FileName$)
-                EndIf
-              Else
-                MessageRequester(#ProductName$, Language("FileStuff","CreateError"), #FLAG_Error)
-              EndIf
-            EndIf
-          EndIf
-          
-        Case #GADGET_Project_OpenFile
-          If IsProjectCreation
-            If NewProjectFile$ <> ""
-              Path$ = GetPathPart(NewProjectFile$)
             Else
-              Path$ = SourcePath$
+              MessageRequester(#ProductName$, Language("FileStuff","CreateError"), #FLAG_Error)
             EndIf
+          EndIf
+        EndIf
+        
+      Case #GADGET_Project_OpenFile
+        If IsProjectCreation
+          If NewProjectFile$ <> ""
+            Path$ = GetPathPart(NewProjectFile$)
           Else
-            Path$ = GetPathPart(ProjectFile$)
+            Path$ = SourcePath$
           EndIf
+        Else
+          Path$ = GetPathPart(ProjectFile$)
+        EndIf
+        
+        FileName$ = OpenFileRequester(Language("FileStuff","OpenFileTitle"), Path$, Language("FileStuff","Pattern"), SelectedFilePattern, #PB_Requester_MultiSelection)
+        If FileName$ <> ""
+          SelectedFilePattern = SelectedFilePattern()
           
-          FileName$ = OpenFileRequester(Language("FileStuff","OpenFileTitle"), Path$, Language("FileStuff","Pattern"), SelectedFilePattern, #PB_Requester_MultiSelection)
-          If FileName$ <> ""
-            SelectedFilePattern = SelectedFilePattern()
+          All$ = ""
+          While FileName$ <> ""
+            All$ + FileName$ + Chr(10)
+            FileName$ = NextSelectedFileName()
+          Wend
+          
+          AddProjectOptionFiles(Left(All$, Len(All$)-1)) ; cut the final Chr(10)
+        EndIf
+        
+      Case #GADGET_Project_ViewFile
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 0 To Last
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
             
-            All$ = ""
-            While FileName$ <> ""
-              All$ + FileName$ + Chr(10)
-              FileName$ = NextSelectedFileName()
-            Wend
-            
-            AddProjectOptionFiles(Left(All$, Len(All$)-1)) ; cut the final Chr(10)
+            If IsCodeFile(*File\FileName$)
+              LoadSourceFile(*File\FileName$) ; will just switch to it if already loaded
+            Else
+              FileViewer_OpenFile(*File\FileName$)
+            EndIf
           EndIf
-          
-        Case #GADGET_Project_ViewFile
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 0 To Last
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-              
-              If IsCodeFile(*File\FileName$)
-                LoadSourceFile(*File\FileName$) ; will just switch to it if already loaded
-              Else
-                FileViewer_OpenFile(*File\FileName$)
-              EndIf
-            EndIf
-          Next i
-          
-        Case #GADGET_Project_FileLoad
-          State = GetGadgetState(#GADGET_Project_FileLoad) ; can only be 1 or 0 (-1 cannot be user set)
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 0 To Last
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-              *File\AutoLoad = State
-            EndIf
-          Next i
-          
-        Case #GADGET_Project_FileScan
-          State = GetGadgetState(#GADGET_Project_FileScan) ; can only be 1 or 0 (-1 cannot be user set)
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 0 To Last
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-              *File\AutoScan = State
-            EndIf
-          Next i
-          
-        Case #GADGET_Project_FileWarn
-          State = GetGadgetState(#GADGET_Project_FileWarn) ; can only be 1 or 0 (-1 cannot be user set)
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 0 To Last
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-              *File\ShowWarning = State
-            EndIf
-          Next i
-          
-        Case #GADGET_Project_FilePanel
-          State = GetGadgetState(#GADGET_Project_FilePanel) ; can only be 1 or 0 (-1 cannot be user set)
-          Last  = CountGadgetItems(#GADGET_Project_FileList)-1
-          For i = 0 To Last
-            If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
-              *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-              *File\ShowPanel = State
-            EndIf
-          Next i
-          
-      EndSelect
-      
-      
-    ElseIf EventID = #PB_Event_SizeWindow
-      ProjectOptionsDialog\SizeUpdate()
-      
-      CompilerIf #CompileWindows
-        ; autosize the explorerlist column
-        SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-        SendMessage_(GadgetID(#GADGET_Project_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-      CompilerEndIf
-      
-    ElseIf EventID = #PB_Event_CloseWindow
-      Quit = 1
-      
-    EndIf
+        Next i
+        
+      Case #GADGET_Project_FileLoad
+        State = GetGadgetState(#GADGET_Project_FileLoad) ; can only be 1 or 0 (-1 cannot be user set)
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 0 To Last
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+            *File\AutoLoad = State
+          EndIf
+        Next i
+        
+      Case #GADGET_Project_FileScan
+        State = GetGadgetState(#GADGET_Project_FileScan) ; can only be 1 or 0 (-1 cannot be user set)
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 0 To Last
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+            *File\AutoScan = State
+          EndIf
+        Next i
+        
+      Case #GADGET_Project_FileWarn
+        State = GetGadgetState(#GADGET_Project_FileWarn) ; can only be 1 or 0 (-1 cannot be user set)
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 0 To Last
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+            *File\ShowWarning = State
+          EndIf
+        Next i
+        
+      Case #GADGET_Project_FilePanel
+        State = GetGadgetState(#GADGET_Project_FilePanel) ; can only be 1 or 0 (-1 cannot be user set)
+        Last  = CountGadgetItems(#GADGET_Project_FileList)-1
+        For i = 0 To Last
+          If GetGadgetItemState(#GADGET_Project_FileList, i) & #PB_ListIcon_Selected
+            *File.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+            *File\ShowPanel = State
+          EndIf
+        Next i
+        
+    EndSelect
     
-    If Quit
-      If IsProjectCreation
-        DisableWindow(#WINDOW_Main, 0)
-      EndIf
-      
-      If MemorizeWindow
-        ProjectOptionsDialog\Close(@ProjectOptionsPosition)
-      Else
-        ProjectOptionsDialog\Close()
-      EndIf
-      
-      ProjectOptionsDialog = 0
-      IsProjectCreation    = 0
-      
-      ClearList(ProjectConfig())
-      
-      UpdateProjectInfo()
-      UpdateProjectPanel()
-      UpdateMenuStates() ; apply any project changes to the menu
-    EndIf
     
-  EndProcedure
+  ElseIf EventID = #PB_Event_SizeWindow
+    ProjectOptionsDialog\SizeUpdate()
+    
+    CompilerIf #CompileWindows
+      ; autosize the explorerlist column
+      SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
+      SendMessage_(GadgetID(#GADGET_Project_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
+    CompilerEndIf
+    
+  ElseIf EventID = #PB_Event_CloseWindow
+    Quit = 1
+    
+  EndIf
   
-  Procedure OpenProjectOptions(NewProject)
+  If Quit
+    If IsProjectCreation
+      DisableWindow(#WINDOW_Main, 0)
+    EndIf
     
-    If IsWindow(#WINDOW_ProjectOptions) And (NewProject = 0 Or IsProjectCreation)
-      ; cannot open the window when already open
-      ; also cannot create a new project if project creation is in progress
-      SetWindowForeground(#WINDOW_ProjectOptions)
+    If MemorizeWindow
+      ProjectOptionsDialog\Close(@ProjectOptionsPosition)
+    Else
+      ProjectOptionsDialog\Close()
+    EndIf
+    
+    ProjectOptionsDialog = 0
+    IsProjectCreation    = 0
+    
+    ClearList(ProjectConfig())
+    
+    UpdateProjectInfo()
+    UpdateProjectPanel()
+    UpdateMenuStates() ; apply any project changes to the menu
+  EndIf
+  
+EndProcedure
+
+Procedure OpenProjectOptions(NewProject)
+  
+  If IsWindow(#WINDOW_ProjectOptions) And (NewProject = 0 Or IsProjectCreation)
+    ; cannot open the window when already open
+    ; also cannot create a new project if project creation is in progress
+    SetWindowForeground(#WINDOW_ProjectOptions)
+    ProcedureReturn
+  EndIf
+  
+  If NewProject
+    ; We need to close the previous project before opening a new one.
+    ; This also ensures that any old ProjectOptions gets closed
+    ;
+    If CloseProject() = 0
       ProcedureReturn
     EndIf
+  EndIf
+  
+  ProjectOptionsDialog = OpenDialog(?Dialog_ProjectOptions, WindowID(#WINDOW_Main), @ProjectOptionsPosition)
+  If ProjectOptionsDialog
+    EnsureWindowOnDesktop(#WINDOW_ProjectOptions)
+    
+    ; Reduce flickering a lot on Windows while resizing
+    SmartWindowRefresh(#WINDOW_ProjectOptions, #True)
+    
+    EnableGadgetDrop(#GADGET_Project_Name,     #PB_Drop_Text,  #PB_Drag_Copy)
+    EnableGadgetDrop(#GADGET_Project_Comments, #PB_Drop_Text,  #PB_Drag_Copy)
+    EnableGadgetDrop(#GADGET_Project_FileList, #PB_Drop_Files, #PB_Drag_Copy)
+    
+    CompilerIf #CompileMac = 0 ; mac has only 1 column anyway
+      RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
+      RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
+      RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
+    CompilerEndIf
+    
+    CompilerIf #CompileWindows
+      ; autosize the explorerlist column
+      SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
+      SendMessage_(GadgetID(#GADGET_Project_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
+    CompilerEndIf
     
     If NewProject
-      ; We need to close the previous project before opening a new one.
-      ; This also ensures that any old ProjectOptions gets closed
+      IsProjectCreation = 1
+      SetWindowTitle(#WINDOW_ProjectOptions, Language("Project","TitleNew"))
+      SetGadgetText(#GADGET_Project_Ok, Language("Project", "CreateProject"))
+      
+      HideGadget(#GADGET_Project_OpenOptions, 1)
+      HideGadget(#GADGET_Project_FileStatic, 1)
+      HideGadget(#GADGET_Project_File, 0)
+      HideGadget(#GADGET_Project_ChooseFile, 0)
+      
+      ; set the project defaults
       ;
-      If CloseProject() = 0
+      NewProjectFile$ = ""
+      SetGadgetText(#GADGET_Project_File, "")
+      SetGadgetText(#GADGET_Project_Name, Language("Project", "DefaultName"))
+      
+      SetGadgetState(#GADGET_Project_CloseAllFiles, 1)
+      SetGadgetState(#GADGET_Project_OpenLoadLast, 1)
+      
+      ProjectExplorerPattern = 0 ; default pattern is "PB files"
+      ProjectExplorerPath$   = SourcePath$
+      
+      ClearList(ProjectConfig()) ; no files in the list yet
+      
+      ProjectOptionsDialog\GuiUpdate() ; to resize from the new strings
+      
+      DisableWindow(#WINDOW_Main, 1)
+      SetActiveGadget(#GADGET_Project_File)
+      
+    Else
+      IsProjectCreation = 0
+      
+      SetGadgetText(#GADGET_Project_FileStatic, ProjectFile$)
+      SetGadgetText(#GADGET_Project_Name,       ProjectName$)
+      SetGadgetText(#GADGET_Project_Comments,   ProjectComments$)
+      
+      SetGadgetState(#GADGET_Project_SetDefault,    IsEqualFile(ProjectFile$, DefaultProjectFile$))
+      SetGadgetState(#GADGET_Project_CloseAllFiles, ProjectCloseFiles)
+      
+      Select ProjectOpenMode
+        Case 0:  SetGadgetState(#GADGET_Project_OpenLoadLast,    1)
+        Case 1:  SetGadgetState(#GADGET_Project_OpenLoadAll,     1)
+        Case 2:  SetGadgetState(#GADGET_Project_OpenLoadDefault, 1)
+        Case 3:  SetGadgetState(#GADGET_Project_OpenLoadMain,    1)
+        Default: SetGadgetState(#GADGET_Project_OpenLoadNone,    1)
+      EndSelect
+      
+      BasePath$ = GetPathPart(ProjectFile$)
+      
+      ; copy file list and add it to the gadget
+      ClearList(ProjectConfig())
+      ForEach ProjectFiles()
+        AddElement(ProjectConfig())
+        CopyProjectConfig(@ProjectFiles(), @ProjectConfig())
+        
+        AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(BasePath$, ProjectConfig()\FileName$))
+        Index = CountGadgetItems(#GADGET_Project_FileList)-1
+        SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
+      Next ProjectFiles()
+      
+    EndIf
+    
+    ; This also fills the explorer pattern in the project options and sets the correct state
+    UpdateExplorerPatterns()
+    SetGadgetText(#GADGET_Project_Explorer, ProjectExplorerPath$+StringField(ExplorerPatternStrings$, ProjectExplorerPattern+1, "|"))
+    SetGadgetText(#GADGET_Project_ExplorerCombo, ProjectExplorerPath$)
+    
+    UpdateProjectOptionStates() ; disable some buttons as needed
+  EndIf
+  
+EndProcedure
+
+
+Procedure UpdateProjectOptionsWindow()
+  
+  ProjectOptionsDialog\LanguageUpdate()
+  
+  If IsProjectCreation
+    SetWindowTitle(#WINDOW_ProjectOptions, Language("Project","TitleNew"))
+    SetGadgetText(#GADGET_Project_Ok, Language("Project", "CreateProject"))
+  EndIf
+  
+  ProjectOptionsDialog\GuiUpdate()
+  
+EndProcedure
+
+
+Procedure AddProjectFile()
+  If IsProject And *ActiveSource <> *ProjectInfo And *ActiveSource\ProjectFile = 0
+    
+    If *ActiveSource\FileName$ = "" ; file not saved yet
+      If SaveSourceAs() <= 0        ; check for user abort too
         ProcedureReturn
       EndIf
     EndIf
     
-    ProjectOptionsDialog = OpenDialog(?Dialog_ProjectOptions, WindowID(#WINDOW_Main), @ProjectOptionsPosition)
-    If ProjectOptionsDialog
-      EnsureWindowOnDesktop(#WINDOW_ProjectOptions)
+    If IsWindow(#WINDOW_ProjectOptions)
+      ; Config dialog is open, so add the file there
       
-      ; Reduce flickering a lot on Windows while resizing
-      SmartWindowRefresh(#WINDOW_ProjectOptions, #True)
-      
-      EnableGadgetDrop(#GADGET_Project_Name,     #PB_Drop_Text,  #PB_Drag_Copy)
-      EnableGadgetDrop(#GADGET_Project_Comments, #PB_Drop_Text,  #PB_Drag_Copy)
-      EnableGadgetDrop(#GADGET_Project_FileList, #PB_Drop_Files, #PB_Drag_Copy)
-      
-      CompilerIf #CompileMac = 0 ; mac has only 1 column anyway
-        RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
-        RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
-        RemoveGadgetColumn(#GADGET_Project_Explorer, 1)
-      CompilerEndIf
-      
-      CompilerIf #CompileWindows
-        ; autosize the explorerlist column
-        SendMessage_(GadgetID(#GADGET_Project_Explorer), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-        SendMessage_(GadgetID(#GADGET_Project_FileList), #LVM_SETCOLUMNWIDTH, 0, #LVSCW_AUTOSIZE_USEHEADER)
-      CompilerEndIf
-      
-      If NewProject
-        IsProjectCreation = 1
-        SetWindowTitle(#WINDOW_ProjectOptions, Language("Project","TitleNew"))
-        SetGadgetText(#GADGET_Project_Ok, Language("Project", "CreateProject"))
-        
-        HideGadget(#GADGET_Project_OpenOptions, 1)
-        HideGadget(#GADGET_Project_FileStatic, 1)
-        HideGadget(#GADGET_Project_File, 0)
-        HideGadget(#GADGET_Project_ChooseFile, 0)
-        
-        ; set the project defaults
-        ;
-        NewProjectFile$ = ""
-        SetGadgetText(#GADGET_Project_File, "")
-        SetGadgetText(#GADGET_Project_Name, Language("Project", "DefaultName"))
-        
-        SetGadgetState(#GADGET_Project_CloseAllFiles, 1)
-        SetGadgetState(#GADGET_Project_OpenLoadLast, 1)
-        
-        ProjectExplorerPattern = 0 ; default pattern is "PB files"
-        ProjectExplorerPath$   = SourcePath$
-        
-        ClearList(ProjectConfig()) ; no files in the list yet
-        
-        ProjectOptionsDialog\GuiUpdate() ; to resize from the new strings
-        
-        DisableWindow(#WINDOW_Main, 1)
-        SetActiveGadget(#GADGET_Project_File)
-        
-      Else
-        IsProjectCreation = 0
-        
-        SetGadgetText(#GADGET_Project_FileStatic, ProjectFile$)
-        SetGadgetText(#GADGET_Project_Name,       ProjectName$)
-        SetGadgetText(#GADGET_Project_Comments,   ProjectComments$)
-        
-        SetGadgetState(#GADGET_Project_SetDefault,    IsEqualFile(ProjectFile$, DefaultProjectFile$))
-        SetGadgetState(#GADGET_Project_CloseAllFiles, ProjectCloseFiles)
-        
-        Select ProjectOpenMode
-          Case 0:  SetGadgetState(#GADGET_Project_OpenLoadLast,    1)
-          Case 1:  SetGadgetState(#GADGET_Project_OpenLoadAll,     1)
-          Case 2:  SetGadgetState(#GADGET_Project_OpenLoadDefault, 1)
-          Case 3:  SetGadgetState(#GADGET_Project_OpenLoadMain,    1)
-          Default: SetGadgetState(#GADGET_Project_OpenLoadNone,    1)
-        EndSelect
-        
-        BasePath$ = GetPathPart(ProjectFile$)
-        
-        ; copy file list and add it to the gadget
-        ClearList(ProjectConfig())
-        ForEach ProjectFiles()
-          AddElement(ProjectConfig())
-          CopyProjectConfig(@ProjectFiles(), @ProjectConfig())
-          
-          AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(BasePath$, ProjectConfig()\FileName$))
-          Index = CountGadgetItems(#GADGET_Project_FileList)-1
-          SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
-        Next ProjectFiles()
-        
-      EndIf
-      
-      ; This also fills the explorer pattern in the project options and sets the correct state
-      UpdateExplorerPatterns()
-      SetGadgetText(#GADGET_Project_Explorer, ProjectExplorerPath$+StringField(ExplorerPatternStrings$, ProjectExplorerPattern+1, "|"))
-      SetGadgetText(#GADGET_Project_ExplorerCombo, ProjectExplorerPath$)
-      
-      UpdateProjectOptionStates() ; disable some buttons as needed
-    EndIf
-    
-  EndProcedure
-  
-  
-  Procedure UpdateProjectOptionsWindow()
-    
-    ProjectOptionsDialog\LanguageUpdate()
-    
-    If IsProjectCreation
-      SetWindowTitle(#WINDOW_ProjectOptions, Language("Project","TitleNew"))
-      SetGadgetText(#GADGET_Project_Ok, Language("Project", "CreateProject"))
-    EndIf
-    
-    ProjectOptionsDialog\GuiUpdate()
-    
-  EndProcedure
-  
-  
-  Procedure AddProjectFile()
-    If IsProject And *ActiveSource <> *ProjectInfo And *ActiveSource\ProjectFile = 0
-      
-      If *ActiveSource\FileName$ = "" ; file not saved yet
-        If SaveSourceAs() <= 0        ; check for user abort too
-          ProcedureReturn
+      ; Check if the file exists (check in the gadget, so we directly have the index)
+      exists = 0
+      last   = CountGadgetItems(#GADGET_Project_FileList)-1
+      For i = 0 To last
+        *ConfigFile.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+        If IsEqualFile(*ConfigFile\FileName$, *ActiveSource\FileName$)
+          exists = 1
+          SetGadgetState(#GADGET_Project_FileList, i)
+          Break
         EndIf
+      Next i
+      
+      If exists = 0
+        LastElement(ProjectConfig())
+        AddElement(ProjectConfig())
+        ProjectConfig()\FileName$   = *ActiveSource\FileName$
+        ProjectConfig()\AutoLoad    = 0
+        ProjectConfig()\AutoScan    = 1
+        ProjectConfig()\ShowPanel   = 1
+        ProjectConfig()\ShowWarning = 1
+        
+        AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(GetPathPart(ProjectFile$) , *ActiveSource\FileName$))
+        Index = CountGadgetItems(#GADGET_Project_FileList)-1
+        SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
+        SetGadgetState(#GADGET_Project_FileList, Index)
       EndIf
       
-      If IsWindow(#WINDOW_ProjectOptions)
-        ; Config dialog is open, so add the file there
-        
-        ; Check if the file exists (check in the gadget, so we directly have the index)
-        exists = 0
-        last   = CountGadgetItems(#GADGET_Project_FileList)-1
-        For i = 0 To last
-          *ConfigFile.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-          If IsEqualFile(*ConfigFile\FileName$, *ActiveSource\FileName$)
-            exists = 1
-            SetGadgetState(#GADGET_Project_FileList, i)
-            Break
-          EndIf
-        Next i
-        
-        If exists = 0
-          LastElement(ProjectConfig())
-          AddElement(ProjectConfig())
-          ProjectConfig()\FileName$   = *ActiveSource\FileName$
-          ProjectConfig()\AutoLoad    = 0
-          ProjectConfig()\AutoScan    = 1
-          ProjectConfig()\ShowPanel   = 1
-          ProjectConfig()\ShowWarning = 1
-          
-          AddGadgetItem(#GADGET_Project_FileList, -1, CreateRelativePath(GetPathPart(ProjectFile$) , *ActiveSource\FileName$))
-          Index = CountGadgetItems(#GADGET_Project_FileList)-1
-          SetGadgetItemData(#GADGET_Project_FileList, Index, @ProjectConfig())
-          SetGadgetState(#GADGET_Project_FileList, Index)
+      
+      UpdateProjectOptionStates()                 ; reflect the new gadget states
+      SetGadgetState(#GADGET_Project_Panel, 1)    ; so the user notices that the config is open
+      SetWindowForeground(#WINDOW_ProjectOptions)
+      SetActiveGadget(#GADGET_Project_FileList)
+      
+    Else
+      ; No config window, add the file to the project directly
+      LastElement(ProjectFiles())
+      
+      AddElement(ProjectFiles())
+      ProjectFiles()\FileName$   = *ActiveSource\FileName$
+      ProjectFiles()\AutoLoad    = 0
+      ProjectFiles()\AutoScan    = 1
+      ProjectFiles()\ShowPanel   = 1
+      ProjectFiles()\ShowWarning = 1
+      
+      UpdateProjectFile(@ProjectFiles())
+      UpdateMenuStates()                   ; reflect the changed settings
+      UpdateProjectInfo()
+      UpdateProjectPanel()
+      
+    EndIf
+    
+  EndIf
+EndProcedure
+
+Procedure RemoveProjectFile()
+  If IsProject And *ActiveSource <> *ProjectInfo And *ActiveSource\ProjectFile <> 0
+    
+    If IsWindow(#WINDOW_ProjectOptions)
+      ; Config dialog is open, so remove the file there
+      
+      last = CountGadgetItems(#GADGET_Project_FileList)-1
+      For i = 0 To last
+        *ConfigFile.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
+        If IsEqualFile(*ConfigFile\FileName$, *ActiveSource\FileName$)
+          ChangeCurrentElement(ProjectConfig(), *ConfigFile)
+          DeleteElement(ProjectConfig())
+          RemoveGadgetItem(#GADGET_Project_FileList, i)
+          Break
         EndIf
-        
-        
-        UpdateProjectOptionStates()                 ; reflect the new gadget states
-        SetGadgetState(#GADGET_Project_Panel, 1)    ; so the user notices that the config is open
-        SetWindowForeground(#WINDOW_ProjectOptions)
-        SetActiveGadget(#GADGET_Project_FileList)
-        
-      Else
-        ; No config window, add the file to the project directly
-        LastElement(ProjectFiles())
-        
-        AddElement(ProjectFiles())
-        ProjectFiles()\FileName$   = *ActiveSource\FileName$
-        ProjectFiles()\AutoLoad    = 0
-        ProjectFiles()\AutoScan    = 1
-        ProjectFiles()\ShowPanel   = 1
-        ProjectFiles()\ShowWarning = 1
-        
-        UpdateProjectFile(@ProjectFiles())
-        UpdateMenuStates()                   ; reflect the changed settings
-        UpdateProjectInfo()
-        UpdateProjectPanel()
-        
-      EndIf
+      Next i
+      
+      SetGadgetState(#GADGET_Project_FileList, -1)
+      UpdateProjectOptionStates()                 ; reflect the new gadget states
+      SetGadgetState(#GADGET_Project_Panel, 1)    ; so the user notices that the config is open
+      SetWindowForeground(#WINDOW_ProjectOptions)
+      SetActiveGadget(#GADGET_Project_FileList)
+      
+    Else
+      ; No config window, remove the file from the project directly
+      
+      *File.ProjectFile = *ActiveSource\ProjectFile
+      UnlinkSourceFromProject(*ActiveSource, #False)
+      
+      ClearProjectFile(*File)
+      ChangeCurrentElement(ProjectFiles(), *File)
+      DeleteElement(ProjectFiles())
+      
+      UpdateMenuStates()                   ; reflect the changed settings
+      UpdateProjectInfo()
+      UpdateProjectPanel()
       
     EndIf
-  EndProcedure
-  
-  Procedure RemoveProjectFile()
-    If IsProject And *ActiveSource <> *ProjectInfo And *ActiveSource\ProjectFile <> 0
-      
-      If IsWindow(#WINDOW_ProjectOptions)
-        ; Config dialog is open, so remove the file there
-        
-        last = CountGadgetItems(#GADGET_Project_FileList)-1
-        For i = 0 To last
-          *ConfigFile.ProjectFileConfig = GetGadgetItemData(#GADGET_Project_FileList, i)
-          If IsEqualFile(*ConfigFile\FileName$, *ActiveSource\FileName$)
-            ChangeCurrentElement(ProjectConfig(), *ConfigFile)
-            DeleteElement(ProjectConfig())
-            RemoveGadgetItem(#GADGET_Project_FileList, i)
-            Break
-          EndIf
-        Next i
-        
-        SetGadgetState(#GADGET_Project_FileList, -1)
-        UpdateProjectOptionStates()                 ; reflect the new gadget states
-        SetGadgetState(#GADGET_Project_Panel, 1)    ; so the user notices that the config is open
-        SetWindowForeground(#WINDOW_ProjectOptions)
-        SetActiveGadget(#GADGET_Project_FileList)
-        
-      Else
-        ; No config window, remove the file from the project directly
-        
-        *File.ProjectFile = *ActiveSource\ProjectFile
-        UnlinkSourceFromProject(*ActiveSource, #False)
-        
-        ClearProjectFile(*File)
-        ChangeCurrentElement(ProjectFiles(), *File)
-        DeleteElement(ProjectFiles())
-        
-        UpdateMenuStates()                   ; reflect the changed settings
-        UpdateProjectInfo()
-        UpdateProjectPanel()
-        
-      EndIf
-    EndIf
-  EndProcedure
-  
+  EndIf
+EndProcedure

--- a/PureBasicIDE/ZLib.pb
+++ b/PureBasicIDE/ZLib.pb
@@ -83,46 +83,48 @@ CompilerElse
 CompilerEndIf
 
 CompilerIf #PB_Compiler_OS = #PB_OS_Windows
-  ImportC "zlib.lib"
+  #ZLib_Library = "zlib.lib"
+CompilerElse
+  #ZLib_Library = "-lz"
+CompilerEndIf
+
+ImportC #ZLib_Library
+  ; Note: These do not work with zip data, as they expect a zlib header
+  ;       But they are used for non-zip compression (example: EditHistory)
+  ;
+  ; Note also here the Windows/Linux difference on 64bit.
+  ;       It should be ok to use the methods with all INTEGER types as long as they
+  ;       have no garbage in their upper 32bits
+  CompilerIf #PB_Compiler_Processor = #PB_Processor_x64 And #PB_Compiler_OS <> #PB_OS_Windows
+    compress.l(*dest, *destlen.INTEGER, *source, sourcelen.i)
+    compress2.l(*dest, *destlen.INTEGER, *source, sourcelen.i, level.l)
+    uncompress.l(*dest, *destlen.INTEGER, *source, sourcelen.i)
+    compressBound.i(sourcelen.i)
   CompilerElse
-    ImportC "-lz"
-    CompilerEndIf
-    ; Note: These do not work with zip data, as they expect a zlib header
-    ;       But they are used for non-zip compression (example: EditHistory)
-    ;
-    ; Note also here the Windows/Linux difference on 64bit.
-    ;       It should be ok to use the methods with all INTEGER types as long as they
-    ;       have no garbage in their upper 32bits
-    CompilerIf #PB_Compiler_Processor = #PB_Processor_x64 And #PB_Compiler_OS <> #PB_OS_Windows
-      compress.l(*dest, *destlen.INTEGER, *source, sourcelen.i)
-      compress2.l(*dest, *destlen.INTEGER, *source, sourcelen.i, level.l)
-      uncompress.l(*dest, *destlen.INTEGER, *source, sourcelen.i)
-      compressBound.i(sourcelen.i)
-    CompilerElse
-      compress.l(*dest, *destlen.LONG, *source, sourcelen.l)
-      compress2.l(*dest, *destlen.LONG, *source, sourcelen.l, level.l)
-      uncompress.l(*dest, *destlen.LONG, *source, sourcelen.l)
-      compressBound.l(sourcelen.l)
-    CompilerEndIf
-    
-    ; ZEXTERN uLong ZEXPORT compressBound OF((uLong sourceLen));
-    
-    ; According to zlib.h, calling inflateInit2
-    ; with a negative window size enters "raw mode",
-    ; which we need for zip extraction
-    ;
-    ; It also notes that it needs an extra input byte in this mode to finish
-    ; properly. (to be checked)
-    ;
-    inflateInit2_.l(*stream.z_stream, windowBits.l, *version, streamsize.l)
-    inflate.l(*stream.z_stream, flush.l)
-    inflateEnd.l(*stream.z_stream)
-  EndImport
+    compress.l(*dest, *destlen.LONG, *source, sourcelen.l)
+    compress2.l(*dest, *destlen.LONG, *source, sourcelen.l, level.l)
+    uncompress.l(*dest, *destlen.LONG, *source, sourcelen.l)
+    compressBound.l(sourcelen.l)
+  CompilerEndIf
   
-  ; definition of the zlib macro
-  Macro inflateInit2(stream, windowBits)
-    inflateInit2_(stream, windowBits, @"1.2.5", SizeOf(z_stream))
-  EndMacro
+  ; ZEXTERN uLong ZEXPORT compressBound OF((uLong sourceLen));
   
-  
-  
+  ; According to zlib.h, calling inflateInit2
+  ; with a negative window size enters "raw mode",
+  ; which we need for zip extraction
+  ;
+  ; It also notes that it needs an extra input byte in this mode to finish
+  ; properly. (to be checked)
+  ;
+  inflateInit2_.l(*stream.z_stream, windowBits.l, *version, streamsize.l)
+  inflate.l(*stream.z_stream, flush.l)
+  inflateEnd.l(*stream.z_stream)
+EndImport
+
+; definition of the zlib macro
+Macro inflateInit2(stream, windowBits)
+  inflateInit2_(stream, windowBits, @"1.2.5", SizeOf(z_stream))
+EndMacro
+
+
+


### PR DESCRIPTION
This is a new version of PR #47 , based off the latest `master` to solve conflicts, so I will repeat the description here:

> There are some places in the code with "unbalanced" keywords (multiple opening keywords in CompilerIf/CompilerElse blocks, with only one closing keyword). This causes the keyword highlighter, "Go to matching keyword", and the auto-indenter to not work correctly.
> 
> This PR makes tiny code changes to "balance" all keywords. Unfortunately this creates very large diffs because the indentation for the rest of the file is changed (fixed!)

Notes:

- Warning, this looks like a huge `diff` because of all the indentation changes. I recommend you "hide whitespace changes" in `git-gui` or use `?w=1` on GitHub, to review the changes. The "Split" view on GitHub also helps.
- This PR includes `EditHistory.pb` which #47  left out to avoid conflicts (it was already being modified by other Pull Requests)
- If we are serious about standardizing code style, and using the IDE Auto-formatter, then we don't want unbalanced keywords because they leave unfinished indentation toward the end of each file. (`EditHistory.pb` had a "leftover" indentation of 6 spaces)
- This is *not a functional IDE change*, it only cleans up the repo code! It only affects anyone reading or working on the IDE source.