### PR TITLE
New editor shortcut functions

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -1046,6 +1046,9 @@ Enumeration 0
   #MENU_MoveLinesUp
   #MENU_MoveLinesDown
   
+  #MENU_DeleteLines
+  #MENU_DuplicateSelection
+  
   #MENU_AutoComplete
   #MENU_AutoComplete_OK ; can now have a custom shortcut too
   #MENU_AutoComplete_Abort

--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -944,6 +944,7 @@ Enumeration 0
   #MENU_Cut
   #MENU_Copy
   #MENU_Paste
+  #MENU_PasteAsComment
   #MENU_CommentSelection
   #MENU_UnCommentSelection
   #MENU_AutoIndent

--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -1043,6 +1043,9 @@ Enumeration 0
   #MENU_SelectBlock
   #MENU_DeselectBlock
   
+  #MENU_MoveLinesUp
+  #MENU_MoveLinesDown
+  
   #MENU_AutoComplete
   #MENU_AutoComplete_OK ; can now have a custom shortcut too
   #MENU_AutoComplete_Abort

--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -155,6 +155,7 @@ Declare Redo()
 Declare Cut()
 Declare Copy()
 Declare Paste()
+Declare PasteAsComment()
 Declare SelectAll()
 Declare AddMarker()                       ; handle the marker functionality
 Declare ClearMarkers()

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -1598,6 +1598,8 @@ DataSection
   Data$ "DeselectBlock",    "Revert to previous code block selection"
   Data$ "MoveLinesUp",      "Move selected lines up"
   Data$ "MoveLinesDown",    "Move selected lines down"
+  Data$ "DeleteLines",      "Delete selected lines"
+  Data$ "DuplicateSelection","Duplicate selection"
   Data$ "AutoComplete",     "Display the AutoComplete Window"
   Data$ "AutoCompleteConfirm","Insert the selected AutoComplete word"
   Data$ "AutoCompleteAbort",  "Close the AutoComplete Window"

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -420,6 +420,7 @@ DataSection
   Data$ "Cut",              "Cu&t"
   Data$ "Copy",             "&Copy"
   Data$ "Paste",            "&Paste"
+  Data$ "PasteComment",     "Paste as comment"
   Data$ "InsertComment",    "I&nsert comments"
   Data$ "RemoveComment",    "Re&move comments"
   Data$ "AutoIndent",       "Format indentation"

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -1596,6 +1596,8 @@ DataSection
   Data$ "ShiftCommentLeft", "Shift comments to the left"
   Data$ "SelectBlock",      "Select surrounding code block"
   Data$ "DeselectBlock",    "Revert to previous code block selection"
+  Data$ "MoveLinesUp",      "Move selected lines up"
+  Data$ "MoveLinesDown",    "Move selected lines down"
   Data$ "AutoComplete",     "Display the AutoComplete Window"
   Data$ "AutoCompleteConfirm","Insert the selected AutoComplete word"
   Data$ "AutoCompleteAbort",  "Close the AutoComplete Window"

--- a/PureBasicIDE/ScintillaHilightning.pb
+++ b/PureBasicIDE/ScintillaHilightning.pb
@@ -3408,6 +3408,22 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     ;UpdateFoldingMarks(*ActiveSource\EditorGadget, lineOld, lineNew)
   EndProcedure
   
+  Procedure PasteAsComment()
+    ClipboardText$ = GetClipboardText()
+    If ClipboardText$ <> ""
+      ClipboardText$ = ReplaceString(ClipboardText$, #CRLF$, #LF$)
+      ClipboardText$ = ReplaceString(ClipboardText$, #CR$,   #LF$)
+      NumLines = 1 + CountString(ClipboardText$, #LF$)
+      For i = 1 To NumLines
+        If i > 1
+          NewText$ + #LF$
+        EndIf
+        NewText$ + "; " + StringField(ClipboardText$, i, #LF$)
+      Next i
+      InsertCodeString(NewText$)
+    EndIf
+  EndProcedure
+  
   Procedure SelectAll()
     SendEditorMessage(#SCI_SELECTALL, 0, 0)
   EndProcedure

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -665,6 +665,8 @@ CompilerIf #CompileLinux | #CompileWindows
   #SHORTCUT_DeselectBlock      = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_M
   #SHORTCUT_MoveLinesUp        = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_Up
   #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_Down
+  #SHORTCUT_DeleteLines        = 0
+  #SHORTCUT_DuplicateSelection = #PB_Shortcut_Control | #PB_Shortcut_D
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = 0 ; Alt+V already used by VD!
   #SHORTCUT_ColorPicker        = 0 ; Alt+P is for Menu/&Project
@@ -727,6 +729,8 @@ CompilerElse
   #SHORTCUT_DeselectBlock      = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_M
   #SHORTCUT_MoveLinesUp        = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_Up
   #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_Down
+  #SHORTCUT_DeleteLines        = 0
+  #SHORTCUT_DuplicateSelection = #PB_Shortcut_Command | #PB_Shortcut_D
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_V
   #SHORTCUT_ColorPicker        = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_M
@@ -876,6 +880,8 @@ DataSection
   Data$ "", "DeselectBlock":       Data.l #SHORTCUT_DeselectBlock
   Data$ "", "MoveLinesUp":         Data.l #SHORTCUT_MoveLinesUp
   Data$ "", "MoveLinesDown":       Data.l #SHORTCUT_MoveLinesDown
+  Data$ "", "DeleteLines":         Data.l #SHORTCUT_DeleteLines
+  Data$ "", "DuplicateSelection":  Data.l #SHORTCUT_DuplicateSelection
   Data$ "", "AutoComplete":        Data.l #SHORTCUT_AutoComplete
   Data$ "", "AutoCompleteConfirm": Data.l #SHORTCUT_AutoCompleteConfirm
   Data$ "", "AutoCompleteAbort":   Data.l #SHORTCUT_AutoCompleteAbort

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -663,6 +663,8 @@ CompilerIf #CompileLinux | #CompileWindows
   #SHORTCUT_ShiftCommentLeft   = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_E
   #SHORTCUT_SelectBlock        = #PB_Shortcut_Control | #PB_Shortcut_M
   #SHORTCUT_DeselectBlock      = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_M
+  #SHORTCUT_MoveLinesUp        = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_Up
+  #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_Down
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = 0 ; Alt+V already used by VD!
   #SHORTCUT_ColorPicker        = 0 ; Alt+P is for Menu/&Project
@@ -723,6 +725,8 @@ CompilerElse
   #SHORTCUT_ShiftCommentLeft   = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_E
   #SHORTCUT_SelectBlock        = #PB_Shortcut_Command | #PB_Shortcut_M
   #SHORTCUT_DeselectBlock      = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_M
+  #SHORTCUT_MoveLinesUp        = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_Up
+  #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_Down
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_V
   #SHORTCUT_ColorPicker        = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_M
@@ -870,6 +874,8 @@ DataSection
   Data$ "", "ShiftCommentLeft":    Data.l #SHORTCUT_ShiftCommentLeft
   Data$ "", "SelectBlock":         Data.l #SHORTCUT_SelectBlock
   Data$ "", "DeselectBlock":       Data.l #SHORTCUT_DeselectBlock
+  Data$ "", "MoveLinesUp":         Data.l #SHORTCUT_MoveLinesUp
+  Data$ "", "MoveLinesDown":       Data.l #SHORTCUT_MoveLinesDown
   Data$ "", "AutoComplete":        Data.l #SHORTCUT_AutoComplete
   Data$ "", "AutoCompleteConfirm": Data.l #SHORTCUT_AutoCompleteConfirm
   Data$ "", "AutoCompleteAbort":   Data.l #SHORTCUT_AutoCompleteAbort

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -633,6 +633,7 @@ CompilerIf #CompileLinux | #CompileWindows
   #SHORTCUT_Cut                = #PB_Shortcut_Control | #PB_Shortcut_X
   #SHORTCUT_Copy               = #PB_Shortcut_Control | #PB_Shortcut_C
   #SHORTCUT_Paste              = #PB_Shortcut_Control | #PB_Shortcut_V
+  #SHORTCUT_PasteAsComment     = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_V
   #SHORTCUT_CommentSelection   = #PB_Shortcut_Control | #PB_Shortcut_B
   #SHORTCUT_UnCommentSelection = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_B ; Avoid 'Alt+B' shorcut as it conflict with german menu title: https://www.purebasic.fr/english/viewtopic.php?f=23&t=37098
   #SHORTCUT_SelectAll          = #PB_Shortcut_Control | #PB_Shortcut_A
@@ -697,6 +698,7 @@ CompilerElse
   #SHORTCUT_Cut                = #PB_Shortcut_Command | #PB_Shortcut_X
   #SHORTCUT_Copy               = #PB_Shortcut_Command | #PB_Shortcut_C
   #SHORTCUT_Paste              = #PB_Shortcut_Command | #PB_Shortcut_V
+  #SHORTCUT_PasteAsComment     = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_V
   #SHORTCUT_CommentSelection   = #PB_Shortcut_Command | #PB_Shortcut_B
   #SHORTCUT_UnCommentSelection = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_B
   #SHORTCUT_SelectAll          = #PB_Shortcut_Command | #PB_Shortcut_A
@@ -789,6 +791,7 @@ DataSection
   Data$ "Edit", "Cut":            Data.l #SHORTCUT_Cut
   Data$ "Edit", "Copy":           Data.l #SHORTCUT_Copy
   Data$ "Edit", "Paste":          Data.l #SHORTCUT_Paste
+  Data$ "Edit", "PasteComment":   Data.l #SHORTCUT_PasteAsComment
   Data$ "Edit", "InsertComment":  Data.l #SHORTCUT_CommentSelection
   Data$ "Edit", "RemoveComment":  Data.l #SHORTCUT_UnCommentSelection
   Data$ "Edit", "AutoIndent":     Data.l #SHORTCUT_AutoIndent

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1385,6 +1385,23 @@ Procedure MainMenuEvent(MenuItemID)
         SendEditorMessage(#SCI_MOVESELECTEDLINESDOWN)
       EndIf
     
+    Case #MENU_DeleteLines
+      If *ActiveSource And *ActiveSource\IsForm = 0
+        ; Do this manually, because the built-in Scintilla functions have drawbacks:
+        ; #SCI_LINECUT can delete multiple selected lines (nice!) but overwrites your clipboard
+        ; #SCI_LINEDELETE does not touch the clipboard, but can only delete 1 line at a time
+        StartLine  = SendEditorMessage(#SCI_LINEFROMPOSITION, SendEditorMessage(#SCI_GETSELECTIONSTART))
+        EndLine    = SendEditorMessage(#SCI_LINEFROMPOSITION, SendEditorMessage(#SCI_GETSELECTIONEND))
+        RangeStart = SendEditorMessage(#SCI_POSITIONFROMLINE, StartLine)
+        RangeEnd   = SendEditorMessage(#SCI_POSITIONFROMLINE, EndLine) + SendEditorMessage(#SCI_LINELENGTH, EndLine)
+        SendEditorMessage(#SCI_DELETERANGE, RangeStart, RangeEnd - RangeStart)
+      EndIf
+    
+    Case #MENU_DuplicateSelection
+      If *ActiveSource And *ActiveSource\IsForm = 0
+        SendEditorMessage(#SCI_SELECTIONDUPLICATE)
+      EndIf
+    
     Case #MENU_ToggleFolds
       *ActiveSource\ToggleFolds = 1-*ActiveSource\ToggleFolds
       LineCount = GetLinesCount(*ActiveSource)-1

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -72,6 +72,7 @@ Procedure CreateIDEMenu()
     ShortcutMenuItem(#MENU_Cut  , Language("MenuItem","Cut"))
     ShortcutMenuItem(#MENU_Copy , Language("MenuItem","Copy"))
     ShortcutMenuItem(#MENU_Paste, Language("MenuItem","Paste"))
+    ShortcutMenuItem(#MENU_PasteAsComment, Language("MenuItem","PasteComment"))
     MenuBar()
     ShortcutMenuItem(#MENU_CommentSelection,   Language("MenuItem","InsertComment"))
     ShortcutMenuItem(#MENU_UnCommentSelection, Language("MenuItem","RemoveComment"))
@@ -300,6 +301,7 @@ Procedure CreateIDEPopupMenu()
     ShortcutMenuItem(#MENU_Cut  , Language("MenuItem", "Cut"))
     ShortcutMenuItem(#MENU_Copy , Language("MenuItem", "Copy"))
     ShortcutMenuItem(#MENU_Paste, Language("MenuItem", "Paste"))
+    ShortcutMenuItem(#MENU_PasteAsComment, Language("MenuItem", "PasteComment"))
     MenuBar()
     ShortcutMenuItem(#MENU_CommentSelection,   Language("MenuItem", "InsertComment"))
     ShortcutMenuItem(#MENU_UnCommentSelection, Language("MenuItem", "RemoveComment"))
@@ -1143,6 +1145,11 @@ Procedure MainMenuEvent(MenuItemID)
         FD_PasteEvent()
       Else
         Paste()
+      EndIf
+      
+    Case #MENU_PasteAsComment
+      If *ActiveSource And *ActiveSource\IsForm = 0
+        PasteAsComment()
       EndIf
       
     Case #MENU_CommentSelection

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1375,6 +1375,16 @@ Procedure MainMenuEvent(MenuItemID)
     Case #MENU_DeselectBlock
       DeselectBlock()
       
+    Case #MENU_MoveLinesUp
+      If *ActiveSource And *ActiveSource\IsForm = 0
+        SendEditorMessage(#SCI_MOVESELECTEDLINESUP)
+      EndIf
+    
+    Case #MENU_MoveLinesDown
+      If *ActiveSource And *ActiveSource\IsForm = 0
+        SendEditorMessage(#SCI_MOVESELECTEDLINESDOWN)
+      EndIf
+    
     Case #MENU_ToggleFolds
       *ActiveSource\ToggleFolds = 1-*ActiveSource\ToggleFolds
       LineCount = GetLinesCount(*ActiveSource)-1


### PR DESCRIPTION
This PR adds 5 new user-configurable keyboard shortcuts, most are built-in Scintilla functions:

- Move selected lines up
- Move selected lines down
- Delete selected lines
- Duplicate selection
- Paste as comment

Notes / judgment calls:

- `Paste as comment` is specific to PB syntax, so it's a custom function. The other 4 are just calls to Scintilla functions. See comments in `UserInterface.pb`
- Based on Scintilla's defaults and other text editors, I gave 4 of the 5 default defined shortcuts, except `Delete selected lines`, which the user has to set.
- Another judgment call, I added `Paste as comment` to the menus under `Paste`. The other 4 are not in the menus, so they are grouped at the bottom of the preferences list (near `Shift comments to the right/left`).
- The new shortcut names are only in English! I did not translate any of them.
