### PR TITLE
[macOS] Dark mode fix for form designer

### DIFF
--- a/PureBasicIDE/FormDesigner/FormManagement.pb
+++ b/PureBasicIDE/FormDesigner/FormManagement.pb
@@ -273,7 +273,12 @@ Procedure FormPanel_CreateFunction(*Entry.ToolsPanelEntry, PanelItemID)
   grid_SetGadgetAttribute(propgrid, #Grid_Caption_Row, 1)
   grid_SetGadgetAttribute(propgrid, #Grid_Caption_Col, 1)
   grid_SetGadgetAttribute(propgrid, #Grid_Disable_Delete, 1)
-  grid_SetGadgetColor(propgrid, #Grid_Color_LineLight, RGB(238, 238, 238))
+  
+  CompilerIf #CompileMac
+    grid_SetGadgetColor(propgrid, #Grid_Color_LineLight, GetCocoaColor("systemGrayColor"))
+  CompilerElse
+    grid_SetGadgetColor(propgrid, #Grid_Color_LineLight, RGB(238, 238, 238))
+  CompilerEndIf
   
   propgrid_combo = grid_CreateComboBox(propgrid)
   propgrid_proccombo = grid_CreateComboBox(propgrid)

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -202,12 +202,18 @@ EndProcedure
 Procedure PropGridAddNode(grid, row, title.s)
   grid_InsertRow(grid, row)
   grid_SetRowData(grid, row, -100)
-  grid_SetCellBackColor(grid, 0, row, RGB(238, 238, 238))
   grid_SetCellType(grid, 0, row, #Grid_Cell_Custom)
   grid_SetCellState(grid, 0, row, @PropGridFoldImgProc())
   
-  grid_SetCellBackColor(grid, 1, row, RGB(238, 238, 238))
-  grid_SetCellBackColor(grid, 2, row, RGB(238, 238, 238))
+  CompilerIf #CompileMac
+    grid_SetCellBackColor(grid, 0, row, GetCocoaColor("controlBackgroundColor"))
+    grid_SetCellBackColor(grid, 1, row, GetCocoaColor("controlBackgroundColor"))
+    grid_SetCellBackColor(grid, 2, row, GetCocoaColor("controlBackgroundColor"))
+  CompilerElse
+    grid_SetCellBackColor(grid, 0, row, RGB(238, 238, 238))
+    grid_SetCellBackColor(grid, 1, row, RGB(238, 238, 238))
+    grid_SetCellBackColor(grid, 2, row, RGB(238, 238, 238))
+  CompilerEndIf
   
   grid_SetCellString(grid, 1, row, title)
   grid_SetSelectionStyle(grid, 1, row, "", -1, 1, -1, -1, -1, -1, 0, Len(title))
@@ -219,7 +225,11 @@ Procedure PropGridAddNode(grid, row, title.s)
 EndProcedure
 Procedure PropGridAddItem(grid, row, title.s, value.s = "")
   grid_InsertRow(grid, row)
-  grid_SetCellBackColor(grid, 0, row, RGB(238, 238, 238))
+  CompilerIf #CompileMac
+    grid_SetCellBackColor(grid, 0, row, GetCocoaColor("controlBackgroundColor"))
+  CompilerElse
+    grid_SetCellBackColor(grid, 0, row, RGB(238, 238, 238))
+  CompilerEndIf
   grid_SetCellString(grid, 1, row, title)
   grid_SetCellString(grid, 2, row, value)
   grid_SetCellLockState(grid,0,row,1)


### PR DESCRIPTION
As I wrote [here](https://github.com/fantaisie-software/purebasic/pull/41#issuecomment-583028184), Form Designer needs a little fix to support dark mode. This PR makes it follow macOS system colors.