### PR TITLE
Add zoom keyboard shorcuts

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -1933,6 +1933,8 @@ EndEnumeration
 #INDENT_Block     = 1
 #INDENT_Sensitive = 2
 
+#ZOOM_Default = 0
+
 
 
 ;
@@ -2437,6 +2439,7 @@ Global InitialSourceLine, MemorizeMarkers, LanguageFile$, ToolsPanelWidth_Hidden
 Global EnableBraceMatch, EnableKeywordMatch, ShowWhiteSpace, ShowIndentGuides, MonitorFileChanges
 Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProcedure, FormSkin, FormSkinVersion
 Global FilesPanelMultiline, FilesPanelCloseButtons, FilesPanelNewButton
+Global CurrentZoom, SynchronizingZoom
 
 ; Dialog Window data
 ;

--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -1050,6 +1050,10 @@ Enumeration 0
   #MENU_DeleteLines
   #MENU_DuplicateSelection
   
+  #MENU_ZoomIn
+  #MENU_ZoomOut
+  #MENU_ZoomDefault
+  
   #MENU_AutoComplete
   #MENU_AutoComplete_OK ; can now have a custom shortcut too
   #MENU_AutoComplete_Abort
@@ -2665,7 +2669,7 @@ Global Dim FoldEnd$(#MAX_FoldWords)
 
 Global Dim ConfigLines$(#MAX_ConfigLines) ; for temporary storage of source settings while loading/saving
 
-#NbShortcutKeys  = 103
+#NbShortcutKeys  = 107
 
 
 Global Dim ShortcutNames.s(#NbShortcutKeys)

--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -156,6 +156,8 @@ Declare Cut()
 Declare Copy()
 Declare Paste()
 Declare PasteAsComment()
+Declare ZoomStep(Direction)
+Declare ZoomDefault()
 Declare SelectAll()
 Declare AddMarker()                       ; handle the marker functionality
 Declare ClearMarkers()

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -1601,6 +1601,9 @@ DataSection
   Data$ "MoveLinesDown",    "Move selected lines down"
   Data$ "DeleteLines",      "Delete selected lines"
   Data$ "DuplicateSelection","Duplicate selection"
+  Data$ "ZoomIn",           "Zoom in"
+  Data$ "ZoomOut",          "Zoom out"
+  Data$ "ZoomDefault",      "Zoom default"
   Data$ "AutoComplete",     "Display the AutoComplete Window"
   Data$ "AutoCompleteConfirm","Insert the selected AutoComplete word"
   Data$ "AutoCompleteAbort",  "Close the AutoComplete Window"
@@ -1648,6 +1651,8 @@ DataSection
   Data$ "Key103",           "Divide"
   Data$ "Key104",           "Num Lock"
   Data$ "Key105",           "Scroll Lock"
+  Data$ "Key106",           "Plus"
+  Data$ "Key107",           "Minus"
   
   
   ; ===================================================

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -99,6 +99,9 @@ Procedure LoadPreferences()
   LastUpdateCheck             = ReadPreferenceLong  ("LastUpdateCheck", 0)
   EnableMenuIcons             = ReadPreferenceLong  ("EnableMenuIcons", 1)
   
+  ; Force a default starting zoom
+  CurrentZoom = #ZOOM_Default
+  
   ; Removed options: always enabled now (todo: remove the old code later)
   EnableColoring = 1
   EnableMarkers = 1

--- a/PureBasicIDE/ScintillaHilightning.pb
+++ b/PureBasicIDE/ScintillaHilightning.pb
@@ -3450,6 +3450,18 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     SendEditorMessage(#SCI_SELECTALL, 0, 0)
   EndProcedure
   
+  Procedure ZoomStep(Direction)
+    If Direction > 0
+      SendEditorMessage(#SCI_ZOOMIN)
+    ElseIf Direction < 0
+      SendEditorMessage(#SCI_ZOOMOUT)
+    EndIf
+  EndProcedure
+  
+  Procedure ZoomDefault()
+    SendEditorMessage(#SCI_SETZOOM, #ZOOM_Default)
+  EndProcedure
+  
   Procedure AddMarker()
     
     UpdateCursorPosition()

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -668,6 +668,15 @@ CompilerIf #CompileLinux | #CompileWindows
   #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Control | #PB_Shortcut_Shift | #PB_Shortcut_Down
   #SHORTCUT_DeleteLines        = 0
   #SHORTCUT_DuplicateSelection = #PB_Shortcut_Control | #PB_Shortcut_D
+  CompilerIf #PB_Compiler_OS   = #PB_OS_Windows
+    #SHORTCUT_ZoomIn           = #PB_Shortcut_Control | #VK_OEM_PLUS
+    #SHORTCUT_ZoomOut          = #PB_Shortcut_Control | #VK_OEM_MINUS
+    #SHORTCUT_ZoomDefault      = #PB_Shortcut_Control | #PB_Shortcut_0
+  CompilerElse
+    #SHORTCUT_ZoomIn           = 0
+    #SHORTCUT_ZoomOut          = 0
+    #SHORTCUT_ZoomDefault      = #PB_Shortcut_Control | #PB_Shortcut_0
+  CompilerEndIf
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = 0 ; Alt+V already used by VD!
   #SHORTCUT_ColorPicker        = 0 ; Alt+P is for Menu/&Project
@@ -733,6 +742,9 @@ CompilerElse
   #SHORTCUT_MoveLinesDown      = #PB_Shortcut_Command | #PB_Shortcut_Shift | #PB_Shortcut_Down
   #SHORTCUT_DeleteLines        = 0
   #SHORTCUT_DuplicateSelection = #PB_Shortcut_Command | #PB_Shortcut_D
+  #SHORTCUT_ZoomIn             = 0
+  #SHORTCUT_ZoomOut            = 0
+  #SHORTCUT_ZoomDefault        = #PB_Shortcut_Command | #PB_Shortcut_0
   #SHORTCUT_ProcedureListUpdate= #PB_Shortcut_F12
   #SHORTCUT_VariableViewer     = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_V
   #SHORTCUT_ColorPicker        = #PB_Shortcut_Command | #PB_Shortcut_Alt | #PB_Shortcut_M
@@ -885,6 +897,9 @@ DataSection
   Data$ "", "MoveLinesDown":       Data.l #SHORTCUT_MoveLinesDown
   Data$ "", "DeleteLines":         Data.l #SHORTCUT_DeleteLines
   Data$ "", "DuplicateSelection":  Data.l #SHORTCUT_DuplicateSelection
+  Data$ "", "ZoomIn":              Data.l #SHORTCUT_ZoomIn
+  Data$ "", "ZoomOut":             Data.l #SHORTCUT_ZoomOut
+  Data$ "", "ZoomDefault":         Data.l #SHORTCUT_ZoomDefault
   Data$ "", "AutoComplete":        Data.l #SHORTCUT_AutoComplete
   Data$ "", "AutoCompleteConfirm": Data.l #SHORTCUT_AutoCompleteConfirm
   Data$ "", "AutoCompleteAbort":   Data.l #SHORTCUT_AutoCompleteAbort
@@ -1023,8 +1038,15 @@ DataSection
   Data.l #PB_Shortcut_Separator
   Data.l #PB_Shortcut_Subtract
   Data.l #PB_Shortcut_Decimal
-  Data.l #PB_Shortcut_Divide
+  Data.l #PB_Shortcut_Divide ; Key103
   Data.l #PB_Shortcut_Numlock
-  Data.l #PB_Shortcut_Scroll
+  Data.l #PB_Shortcut_Scroll ; Key105
+  CompilerIf #CompileWindows
+    Data.l #VK_OEM_PLUS
+    Data.l #VK_OEM_MINUS ; Key107
+  CompilerElse
+    Data.l '='
+    Data.l '-' ; Key107
+  CompilerEndIf
   
 EndDataSection

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -43,7 +43,7 @@ Procedure BuildShortcutNamesTable()
   Next i
   
   ; other keys
-  For index = 71 To #NbShortcutKeys-1
+  For index = 71 To #NbShortcutKeys
     ShortcutNames(index) = Language("Shortcuts","Key"+Str(index))
     Read.l ShortcutValues(index)
   Next index
@@ -73,7 +73,7 @@ EndProcedure
 Procedure GetBaseKeyIndex(Shortcut)
   
   If Shortcut
-    For i = 0 To #NbShortcutKeys-1
+    For i = 0 To #NbShortcutKeys
       If Shortcut & ~(#PB_Shortcut_Control|#PB_Shortcut_Alt|#PB_Shortcut_Shift|#PB_Shortcut_Command) = ShortcutValues(i)
         ProcedureReturn i
       EndIf

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1386,12 +1386,12 @@ Procedure MainMenuEvent(MenuItemID)
       If *ActiveSource And *ActiveSource\IsForm = 0
         SendEditorMessage(#SCI_MOVESELECTEDLINESUP)
       EndIf
-    
+      
     Case #MENU_MoveLinesDown
       If *ActiveSource And *ActiveSource\IsForm = 0
         SendEditorMessage(#SCI_MOVESELECTEDLINESDOWN)
       EndIf
-    
+      
     Case #MENU_DeleteLines
       If *ActiveSource And *ActiveSource\IsForm = 0
         ; Do this manually, because the built-in Scintilla functions have drawbacks:
@@ -1403,12 +1403,27 @@ Procedure MainMenuEvent(MenuItemID)
         RangeEnd   = SendEditorMessage(#SCI_POSITIONFROMLINE, EndLine) + SendEditorMessage(#SCI_LINELENGTH, EndLine)
         SendEditorMessage(#SCI_DELETERANGE, RangeStart, RangeEnd - RangeStart)
       EndIf
-    
+      
     Case #MENU_DuplicateSelection
       If *ActiveSource And *ActiveSource\IsForm = 0
         SendEditorMessage(#SCI_SELECTIONDUPLICATE)
       EndIf
-    
+      
+    Case #MENU_ZoomIn
+      If *ActiveSource And *ActiveSource\IsForm = 0 And *ActiveSource <> *ProjectInfo
+        ZoomStep(1)
+      EndIf
+      
+    Case #MENU_ZoomOut
+      If *ActiveSource And *ActiveSource\IsForm = 0 And *ActiveSource <> *ProjectInfo
+        ZoomStep(-1)
+      EndIf
+      
+    Case #MENU_ZoomDefault
+      If *ActiveSource And *ActiveSource\IsForm = 0 And *ActiveSource <> *ProjectInfo
+        ZoomDefault()
+      EndIf
+      
     Case #MENU_ToggleFolds
       *ActiveSource\ToggleFolds = 1-*ActiveSource\ToggleFolds
       LineCount = GetLinesCount(*ActiveSource)-1


### PR DESCRIPTION
This PR does three related things: 

1. Add 3 zoom keyboard shortcuts (Zoom In, Out, Default) based on Scintilla's zoom functions
2. Synchronize zoom across all open files
3. Fix a bug in the shortcut table (the last item was not being used)

Shortcuts notes:

- On Windows, I *really* think zoom should use the standard Ctrl+Plus Ctrl+Minus hotkeys, so I defaulted them to `#VK_OEM_PLUS` and `#VK_OEM_MINUS`. I know these are not native PB constants, but Microsoft guarantees they're correct on all keyboard regions, unlike the brackets, semicolon, etc.
- I extended the shortcut name table from 103 to 107. 104-105 were already listed as NumLock and ScrollLock but not being used (any reason?). 106-107 are now the Plus and Minus keys (different from NumPad Add and Subtract).
- On Mac/Linux I did not define default zoom in/out hotkeys. They can be set by the user.

Synchronization notes:

- You can already zoom the IDE with Ctrl+Mousewheel but it only zooms the active tab. In some programs like a web browser, that makes sense. In a code editor, using all the same font and size, I expect them to zoom together.
- This PR synchronizes the zoom across all open Scintillas. If it's a problem, we can make it a user preference.

Bug fix notes:

- There was an off-by-one error. The last entry in the shortcut table was not being used.
- In the 5.71 IDE preferences, try setting an action to the very last defined shortcut (NumPad Divide) and it will display as blank in the list. This fixes that.