### PR TITLE
Fix re-enable buttons bug in window 'Find in Files' (#WINDOW_Grep)

### DIFF
--- a/PureBasicIDE/GrepWindow.pb
+++ b/PureBasicIDE/GrepWindow.pb
@@ -548,8 +548,9 @@ Procedure GrepWindowEvents(EventID)
               
               If IsGadget(#GADGET_GrepOutput_Current) ; the window could have been closed!
                 SetGadgetText(#GADGET_GrepOutput_Current, "")
-                DisableGrepWindow(#False)
               EndIf
+              
+              DisableGrepWindow(#False)
               
             Else
               MessageRequester(Language("Find","Info"), Language("Find","NeedString")+".", #FLAG_WARNING)


### PR DESCRIPTION
If the output window (#WINDOW_GrepOutput) was closed during a running
search, it was still possible to abort the search with a click on the
Stop button, but the Start and Cancel button was then not re-enabled.

https://www.purebasic.fr/english/viewtopic.php?f=4&t=71539