### PR TITLE
Fix selection of binary numbers

### DIFF
--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -3349,7 +3349,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     ; add *@$# to the word characters, so they get included in the selection
     ; when you double-click a word (to so select constants/variables easily)
     
-    WordChars$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#*"
+    WordChars$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#*%"
     For k = 192 To 255
       WordChars$+Chr(k) ; For ASCII mode, to have "é, à" etc. (https://www.purebasic.fr/english/viewtopic.php?f=4&t=57421)
     Next


### PR DESCRIPTION
:warning: Resolve the merge conflict carefully to avoid reversing the changes of the other PR (#67).

---

When binary numbers were selected by double-clicking, the prefix (%) of the binary numbers was not also selected.

When a binary number including the prefix (%) was selected, further occurrences of this binary number were not highlighted in the code.

Side effect:
If the character '%' is used as an operator in the current case and the variables and numbers are directly adjacent to the operator (without spaces), the variables/numbers directly adjacent and the operator are selected.

Bug in IDE - double click to select problem
https://www.purebasic.fr/english/viewtopic.php?f=24&t=74723

double click select binary value including %
https://www.purebasic.fr/english/viewtopic.php?f=3&t=74741