### PR TITLE
Fix selection of words with the address-of-operator '@'

### DIFF
--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -3349,7 +3349,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     ; add *@$# to the word characters, so they get included in the selection
     ; when you double-click a word (to so select constants/variables easily)
     
-    WordChars$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#*"
+    WordChars$ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$#*"
     For k = 192 To 255
       WordChars$+Chr(k) ; For ASCII mode, to have "é, à" etc. (https://www.purebasic.fr/english/viewtopic.php?f=4&t=57421)
     Next


### PR DESCRIPTION
:warning: Resolve the merge conflict carefully to avoid reversing the changes of the other PR (#66).

---

If a word was selected, the other occurrences of this word in the code were only highlighted if they were not directly adjacent to the address-of-operator (with spaces after the address-of-operator).

IDE - Highlighting selected Variables
https://www.purebasic.fr/english/viewtopic.php?f=4&t=69291