### PR TITLE
Fix highlight of matching word at end of file

### DIFF
--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -2527,7 +2527,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
       SelectionLength = selEnd-selStart
       
       ; Look for repetitions of the selection
-      While *Pointer < *BufferEnd
+      While *Pointer <= *BufferEnd
         If CompareMemoryString(*Pointer, *Selection, #PB_String_NoCase, SelectionLength, #PB_UTF8) = #PB_String_Equal
           Position = *Pointer-*BufferStart
           ; don't mark the selection itself and check that this is a whole word before marking it


### PR DESCRIPTION
This fixes a minor bug in the "Repeated Selections Background" feature.

If you select a word (such as `EndIf`) it highlights all other occurrences. But if it occurs at the *very end of the file* (no newline) that one is not highlighted.

This fixes it by changing the boundary of the `While` loop from a `<` to `<=` check.

For example, if the selection length is 5 (`EndIf`) and the source length is 100 bytes, the final check of the loop should be bytes `95–99` (0-based). Previously it was stopping the loop one byte before that.