### PR TITLE
Make Scintilla word chars a user preference

### DIFF
--- a/PureBasicIDE/CodeViewer.pb
+++ b/PureBasicIDE/CodeViewer.pb
@@ -214,7 +214,7 @@ EndProcedure
 Procedure InitCodeViewer(Gadget, LineNumbers)
   ScintillaSendMessage(Gadget, #SCI_CLEARCMDKEY, #SCK_TAB) ; to enable the window shortcuts
   ScintillaSendMessage(Gadget, #SCI_CLEARCMDKEY, #SCK_RETURN)
-  ScintillaSendMessage(Gadget, #SCI_SETWORDCHARS, 0, ToAscii("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#.*")) ; for simpler selecting
+  ApplyWordChars(Gadget)
   ScintillaSendMessage(Gadget, #SCI_SETMARGINWIDTHN, 1, 0)
   
   If LineNumbers

--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -347,6 +347,7 @@ Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_EnableCaseCorrection
   #GADGET_Preferences_EnableLineNumbers
   ;  #GADGET_Preferences_EnableMarkers
+  #GADGET_Preferences_ExtraWordChars
   #GADGET_Preferences_ShowWhiteSpace
   #GADGET_Preferences_ShowIndentGuides
   #GADGET_Preferences_EnableBraceMatch
@@ -1939,6 +1940,8 @@ EndEnumeration
 
 #ZOOM_Default = 0
 
+#WORDCHARS_Default = "$#*%"
+
 
 
 ;
@@ -2444,6 +2447,7 @@ Global EnableBraceMatch, EnableKeywordMatch, ShowWhiteSpace, ShowIndentGuides, M
 Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProcedure, FormSkin, FormSkinVersion
 Global FilesPanelMultiline, FilesPanelCloseButtons, FilesPanelNewButton
 Global CurrentZoom, SynchronizingZoom
+Global ExtraWordChars$
 
 ; Dialog Window data
 ;

--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -131,6 +131,7 @@ Declare UpdateHighlighting()                                   ; highlight every
 Declare StreamTextIn(*Buffer, Length)                          ; put the given buffer into the current source
 Declare StreamTextOut(*Buffer, Length)                         ; get the contents of the current source into the buffer
 Declare GetSourceLength()                                      ; get the source length in bytes
+Declare ApplyWordChars(Gadget = #PB_All)                       ; update the word chars for a specific ScintillaGadget, or all sources if #PB_All
 Declare RefreshEditorGadget()                                  ; redraw the editorgadget
 Declare ChangeActiveLine(Line, TopOffset)                      ; change the currently active line
 Declare SetBackgroundColor(Gadget = -1)                        ; set the bacground color fur this source (also for linenumbers)

--- a/PureBasicIDE/DiffWindow.pb
+++ b/PureBasicIDE/DiffWindow.pb
@@ -682,7 +682,7 @@ Procedure OpenDiffWindow()
       For Gadget = #GADGET_Diff_File1 To #GADGET_Diff_File2
         ScintillaSendMessage(Gadget, #SCI_CLEARCMDKEY, #SCK_TAB) ; to enable the window shortcuts
         ScintillaSendMessage(Gadget, #SCI_CLEARCMDKEY, #SCK_RETURN)
-        ScintillaSendMessage(Gadget, #SCI_SETWORDCHARS, 0, ToAscii("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$@#.*")) ; for simpler selecting
+        ApplyWordChars(Gadget)
         ScintillaSendMessage(Gadget, #SCI_SETCARETLINEVISIBLE, 0, 0)
         
         ; margin for line numbers, this is hidden in UpdateDiffGadget() if it is disabled

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -802,6 +802,7 @@ DataSection
   Data$ "EnableKeywordMatch","Enable marking of matching Keywords"
   Data$ "EnableLineNumbers","Display Line numbers"
   Data$ "EnableMarkers",    "Enable Line Markers"
+  Data$ "ExtraWordChars",   "Extra characters included in word selection"
   Data$ "SelectFont",       "Select Font"
   Data$ "DefaultColors",    "Default Color Schemes"
   Data$ "ShowWhiteSpace",   "Show whitespace characters"

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -137,6 +137,8 @@ Procedure LoadPreferences()
   
   CodeFileExtensions$ = ReadPreferenceString("CodeFileExtensions", "")
   
+  ExtraWordChars$ = ReadPreferenceString("ExtraWordChars", #WORDCHARS_Default)
+  
   ; Init the color values with the PB defaults
   ;
   Restore DefaultColorSchemes
@@ -1101,6 +1103,8 @@ Procedure SavePreferences()
     
     WritePreferenceString("CodeFileExtensions", CodeFileExtensions$)
     
+    WritePreferenceString("ExtraWordChars", ExtraWordChars$)
+    
     ; Save the color values
     ;
     Restore ColorKeys
@@ -1765,6 +1769,7 @@ Procedure IsPreferenceChanged()
   If FilesHistorySize      <> Val(GetGadgetText(#GADGET_Preferences_FileHistorySize)): ProcedureReturn 1: EndIf
   If EnableLineNumbers     <> GetGadgetState(#GADGET_Preferences_EnableLineNumbers): ProcedureReturn 1: EndIf
   ;  If EnableMarkers         <> GetGadgetState(#GADGET_Preferences_EnableMarkers): ProcedureReturn 1: EndIf
+  If ExtraWordChars$       <> GetGadgetText(#GADGET_Preferences_ExtraWordChars) : ProcedureReturn 1 : EndIf
   If ShowWhiteSpace        <> GetGadgetState(#GADGET_Preferences_ShowWhiteSpace): ProcedureReturn 1: EndIf
   If ShowIndentGuides      <> GetGadgetState(#GADGET_Preferences_ShowIndentGuides): ProcedureReturn 1: EndIf
   If EnableBraceMatch      <> GetGadgetState(#GADGET_Preferences_EnableBraceMatch): ProcedureReturn 1: EndIf
@@ -2146,6 +2151,7 @@ Procedure ApplyPreferences()
   FilesHistorySize      = Val(GetGadgetText(#GADGET_Preferences_FileHistorySize))
   EnableLineNumbers     = GetGadgetState(#GADGET_Preferences_EnableLineNumbers)
   ;  EnableMarkers         = GetGadgetState(#GADGET_Preferences_EnableMarkers)
+  ExtraWordChars$       = GetGadgetText(#GADGET_Preferences_ExtraWordChars)
   ShowWhiteSpace        = GetGadgetState(#GADGET_Preferences_ShowWhiteSpace)
   ShowIndentGuides      = GetGadgetState(#GADGET_Preferences_ShowIndentGuides)
   EnableBraceMatch      = GetGadgetState(#GADGET_Preferences_EnableBraceMatch)
@@ -2483,6 +2489,9 @@ Procedure ApplyPreferences()
   SetupFileMonitor()
   
   ApplyPrefsTheme()
+  
+  ; Update Scintilla word chars
+  ApplyWordChars()
   
   ; remove the old shortcuts from all debugger windows
   Debugger_RemoveExtraShortcuts()
@@ -2901,6 +2910,7 @@ Procedure OpenPreferencesWindow()
   SetGadgetState(#GADGET_Preferences_EnableBraceMatch, EnableBraceMatch)
   SetGadgetState(#GADGET_Preferences_EnableKeywordMatch, EnableKeywordMatch)
   SetGadgetState(#GADGET_Preferences_EnableFolding, EnableFolding)
+  SetGadgetText(#GADGET_Preferences_ExtraWordChars, ExtraWordChars$)
   
   
   ;   If EnableColoring = 0

--- a/PureBasicIDE/WindowsMisc.pb
+++ b/PureBasicIDE/WindowsMisc.pb
@@ -791,7 +791,7 @@ CompilerIf #CompileWindows
   
   Procedure AutoComplete_AdjustWindowSize(MaxWidth, MaxHeight)
     ;
-    ; Note: on windows there is no horitzontal scrollbar in ListViewGadget, so
+    ; Note: on windows there is no horizontal scrollbar in ListViewGadget, so
     ;   we do not resize in this direction at all
     ;
     NewHeight   = MaxHeight

--- a/PureBasicIDE/dialogs/Preferences.xml
+++ b/PureBasicIDE/dialogs/Preferences.xml
@@ -292,6 +292,12 @@
               <!-- removed 
               <checkbox id="#GADGET_Preferences_EnableMarkers"     lang="Preferences:EnableMarkers" />              
               -->
+              
+              <empty height="5" />
+              <hbox spacing="10" expand="item:2">
+                <text lang="Preferences:ExtraWordChars" text=": " />
+                <string id= "#GADGET_Preferences_ExtraWordChars" />
+              </hbox>
             </vbox>
           </frame>
         </container>


### PR DESCRIPTION
This PR allows the user to customize what characters Scintilla considers "word characters", for example when double-clicking to select a variable name. It also affects Find/Replace > "Whole words only" behavior.

Notes:

- This is a compromise of PR #66 and and #67 , see those discussions
- I left the defaults as-is (`$#*@`). Should we add `%` or remove `@`?
- I added it to the Preferences under Editor > Editing per @t-harter 
- I labeled it "Word characters" but we could use a better description
- This requires you to run `make` again because the Preferences dialog XML changed
- I moved the `SCI_SETWORDCHARS` call into a procedure, so it can be called at Scintilla creation OR applying changed preferences
- Because it's user-customizable now, I added some basic checks (disallow whitespace characters, interpret an empty setting string as "use defaults")
- `A-Z` `a-z` `0-9` `_` are always automatically included
- The IDE also includes characters 192-255 (existing behavior), is this still correct?