### PR TITLE
UnxUtils Alternatives

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,18 +1,27 @@
 # Build Instructions
 
-Welcome to __[PureBasic OpenSource Projects]__!
+How to build the __[PureBasic OpenSource Projects]__.
 
-For now, to be able to compile the sources, you will need Windows, as it's the only supported OS (will change soon).
+Currently, the only supported toolchain is that for the Windows OS (this will change soon), therefore these instructions only cover building the PureBasic IDE for Windows.
+
 That said, you can try to compile on Linux/OSX as the makefile contains all the required info to do so.
 
-# 1. Install UnxUtils
+For more detailed information, see also the following pages on the [project Wiki]:
 
-[UnxUtils] is a collection of the most important GNU utilities ported to Windows.
-You can download it here:
+- [Building on Windows]
+- [Building on Linux]
+- [Building on macOS]
 
-- https://sourceforge.net/projects/unxutils/
 
-Don't forget to add `<UnxUtilsInstallPath>\usr\local\wbin` to your [PATH].
+# 1. Get the GNU Dependencies
+
+The build scripts require some Unix utilities from the [GnuWin] project to be present on the system.
+
+[ChrisRfr] has kindly prepared an _ad hoc_ package with all the required tools:
+
+- [`UnixTools-4-Win.zip`][UnixTools-4-Win.zip]
+
+Download the Zip archive, unpack it and add it to your [PATH]  (full instructions inside the Zip file).
 
 # 2. Install VisualStudio C++ 2013 Community Edition
 
@@ -31,25 +40,26 @@ We use an old SDK version (7.0) but a newer version might also work.
 
 # 4. Tune the launch script
 
-Create a copy of "`Window-x64.cmd`" or "`Window-x86.cmd`" and edit it:
+Create a copy of the `Window-x64.cmd` or `Window-x86.cmd` script and edit it:
 
 - Set `PUREBASIC_HOME` to a working PureBasic installation.
-- Check all the other paths to see if they match you local system.
+- Check all the other paths to see if they match your local system.
 
 
 # 5. Launch the makefile
 
-- Double-click on `Window-x64.cmd` and go in PureBasicIDE directory.
+- Double-click on `Window-x64.cmd`.
+- Go to the [`PureBasicIDE`][PureBasicIDE] directory.
 - Type: `make`.
 
 If all is setup correctly, it should compile all the dependencies and the IDE.
-A 'Build' directory will be created with all temporary files in it.
+A `Build` directory will be created with all temporary files in it.
 
 Once you have successfully launched the `make` once, you can then use
 PureBasic to open the "`PureBasic IDE.pbp`" project file and
 run it from PureBasic itself (be sure to adjust the constants in 'Compilers Options.../Contants')
 
-- The `#BUILD_DIRECTORY` constant must point to the Build/x64/ide/ folder created before by the 'make'
+- The `#BUILD_DIRECTORY` constant must point to the `Build/x64/ide/` folder created before by the execution of `make`.
 
 Don't hesitate to [drop a word] to improve this build guide, as right now it's very slim!
 
@@ -66,17 +76,37 @@ Have fun hacking,
 [The Fantaisie Software Team]: https://www.purebasic.com/support.php "More info about the Fantaisie Software Team"
 [PureBasic OpenSource Projects]: https://github.com/fantaisie-software/purebasic
 
+<!-- repo files and folders -->
+
+[PureBasicIDE]: ./PureBasicIDE/ "Navigate to the 'PureBasicIDE/' folder"
+
 <!-- 3rd party websites -->
 
-[UnxUtils]: http://unxutils.sourceforge.net "Visit UnxUtils website"
+[GnuWin]: http://gnuwin32.sourceforge.net/ "Visit the website of the GnuWin project at SourceForge"
+
 
 <!-- references -->
 
 [PATH]: https://en.wikipedia.org/wiki/PATH_(variable) "See Wikipedia page on 'PATH (variable)'"
 
+<!-- Wiki Links -->
+
+
+[project Wiki]: https://github.com/fantaisie-software/purebasic/wiki/ "Visit the PureBasic OpenSource Projects Wiki"
+
+[Building on Windows]: https://github.com/fantaisie-software/purebasic/wiki/Building-on-Windows "Wiki page on building the PureBasic IDE under Windows"
+[Building on Linux]: https://github.com/fantaisie-software/purebasic/wiki/Building-on-Linux "Wiki page on building the PureBasic IDE under Linux"
+[Building on macOS]: https://github.com/fantaisie-software/purebasic/wiki/Building-on-macOS "Wiki page on building the PureBasic IDE under macOS"
+
 <!-- download links -->
 
 [MS Visual Studio 2013 download page]: https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2013-and-other-products "Go to the download page of MSVS 2013"
 [Windows SDK for Windows 7 download page]: https://www.microsoft.com/en-us/download/details.aspx?id=8279
+[UnixTools-4-Win.zip]: https://github.com/fantaisie-software/purebasic/wiki/UnixTools-4-Win.zip "Download the ZIP file with the GNU dependencies for Windows"
+
+<!-- people -->
+
+[ChrisRfr]: https://github.com/ChrisRfr "View @ChrisRfr's GitHub profile"
+
 
 <!-- EOF -->

--- a/README.md
+++ b/README.md
@@ -146,11 +146,12 @@ The list is quite long, and we refer you to the Acknowledgements section of the 
 Here follows a list of people who contributed to the assets found in this repository.
 The list is still in the making and incomplete, and we apologise for any temporary omissions.
 
-- __[Gary «Kale» Willoughby]__ — for designing the [default theme] of the PureBasic IDE.
-- __[Timo «Freak» Harter]__ — for the IDE, the Debugger, many commands and great ideas. PureBasic wouldn't be the same without him!
+- __[ChrisRfr]__ — for having prepared the _ad hoc_ package with all the required GNU dependencies for building the IDE under Windows.
 - __[Danilo Krahn]__ — For his huge work on the editor and on the core commands set, and the tons of nice suggestions about code optimization and size reduction.
 - __Fabien Laboureur__ — for designing the [SpiderBasic logo].
 - __[Gaetan Dupont-Panon]__ — For the wonderful new visual designer, which really rocks on Windows, Linux and OS X!
+- __[Gary «Kale» Willoughby]__ — for designing the [default theme] of the PureBasic IDE.
+- __[Timo «Freak» Harter]__ — for the IDE, the Debugger, many commands and great ideas. PureBasic wouldn't be the same without him!
 
 
 # License
@@ -248,11 +249,12 @@ work in the PureBasic package.
 
 <!-- people -->
 
+[ChrisRfr]: https://github.com/ChrisRfr "View @ChrisRfr's GitHub profile"
 [Danilo Krahn]: https://github.com/D-a-n-i-l-o "View Danilo Krahn's GitHub profile"
+[Gaetan Dupont-Panon]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=186 "Visit Gaetan Dupont-Panon's profile on the PureBasic Forums"
 [Gary «Kale» Willoughby]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit Gary «Kale» Willoughby's profile on the PureBasic Forums"
 [Mark James]: https://twitter.com/markjames "Visit Mark James's profile on Twitter"
 [Timo «Freak» Harter]: https://github.com/t-harter "View Timo «Freak» Harter's GitHub profile"
 [Wimer Hazenberg]: https://www.monokai.nl/ "Visit Wimer Hazenberg's website"
-[Gaetan Dupont-Panon]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=186 "Visit Gaetan Dupont-Panon's profile on the PureBasic Forums"
 
 <!-- EOF -->


### PR DESCRIPTION
* In the `BUILD.md` document (see #30):
    * Refer Windows users to the new Zip archive with the required GNU utilities, prepared by @ChrisRfr, downloadable from the Wiki.
    * Drop all references to the UnxUtils package.
    * Polish document contents.
* In main `README.md` document:
    * Credit @ChrisRfr in the Acknowledgements section. (see #30)
    * Sort credited people alphabetically.