### PR TITLE
Fix Memory Viewer 'Display Hex values' setting

### DIFF
--- a/PureBasicDebugger/MemoryViewer.pb
+++ b/PureBasicDebugger/MemoryViewer.pb
@@ -9,7 +9,7 @@ Global Dim MemoryViewer_Chars.s(31)
 #MEMORY_VIEW_TABLE_DATA_HEX = 1
 #MEMORY_VIEW_TABLE_DATA_OCT = 2
 
-Global MemoryViewTableData.i = MemoryIsHex
+Global MemoryViewTableData.i
 
 Procedure.s OCT(number.q)
   Protected Oct.s=Space(23)
@@ -687,6 +687,8 @@ Procedure UpdateMemoryViewerWindowState(*Debugger.DebuggerData)
 EndProcedure
 
 Procedure OpenMemoryViewerWindow(*Debugger.DebuggerData)
+  
+  MemoryViewTableData = MemoryIsHex
   
   If *Debugger\Windows[#DEBUGGER_WINDOW_Memory]
     SetWindowForeground(*Debugger\Windows[#DEBUGGER_WINDOW_Memory])


### PR DESCRIPTION
The Memory Viewer setting 'Display Hex values' was set when compiling the IDE and not at runtime when opening the Memory Viewer. As a result, changing this setting had no effect.

[PB 5.71 x64] "Display Hex values" and MemoryViewer
https://www.purebasic.fr/english/viewtopic.php?f=23&t=74272