### PR TITLE
Bug fix for "Find Previous" freezing

### DIFF
--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -3823,6 +3823,15 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
           Else
             MessageRequester(#ProductName$, Language("Find","NoMoreMatches")+".", #FLAG_Info)
           EndIf
+          
+        ElseIf Result <> -1 And Success = 0 And Mode <> 3
+          ; If an occurrence was found, but ignored (comment or string), must continue
+          If Reverse
+            Find\chrg\cpMin = Result - StringByteLength(FindSearchString$, StringMode)
+          Else
+            Find\chrg\cpMin = Result + StringByteLength(FindSearchString$, StringMode)
+          EndIf
+          
         EndIf
         
       Until Result = -1 Or (Success And Mode <> 3)


### PR DESCRIPTION
This PR fixes the IDE freezing (infinite loop) when performing a Find Previous with "Don't search in comments" or "Don't search in strings" checked.

If you perform a Find Previous, and find an occurrence, but it's ignored (comment or string), then the loop repeats the search in the same position forever. This PR handles that case and ensures the search location is moved correctly.

Somebody from the PB team should review this, because they know better than I do how the Find/Replace system works.

Simple dummy code to test it:

    ifififif
    ; if
     "if"
    ifififif

Try searching for `if`, Forward and Backward, with and without "Don't search in comments" and "Don't search in strings" checked.

Forum posts:  
https://www.purebasic.fr/english/viewtopic.php?f=4&t=70161  
https://www.purebasic.fr/english/viewtopic.php?f=4&t=74810