### PR TITLE
Add deactivation of the `Data` checkbox in the Memory Viewer

### DIFF
--- a/PureBasicDebugger/MemoryViewer.pb
+++ b/PureBasicDebugger/MemoryViewer.pb
@@ -376,6 +376,7 @@ Procedure MemoryViewer_Update(*Debugger.DebuggerData, Action, File) ; 0=display 
     HideGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Editor], 0)
     
     DisableGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Display_DataView],1)
+    DisableGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_ChkformatDataSection],1)
   Else
     FreeGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_List]) ; recreate this to change the number of columns
     OpenGadgetList(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Container])
@@ -389,6 +390,7 @@ Procedure MemoryViewer_Update(*Debugger.DebuggerData, Action, File) ; 0=display 
     HideGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Container], 0)
     HideGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Editor], 1)
     DisableGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_Display_DataView],0)
+    DisableGadget(*Debugger\Gadgets[#DEBUGGER_GADGET_Memory_ChkformatDataSection],0)
   EndIf
   
   Select ViewType


### PR DESCRIPTION
Setting the checkbox has no effect if the view type is `Hex` or `String`. Therefore, the checkbox should be deactivated in these cases to avoid confusion.

https://www.purebasic.fr/english/viewtopic.php?p=550837#p550837