### PR TITLE
Replace the window `#WINDOW_Form_Parent` with a dialog window

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -80,7 +80,7 @@ EndEnumeration
 
 ;- Windows
 ;
-Enumeration 1 ; 0 is reserved
+Runtime Enumeration 1 ; 0 is reserved
   #WINDOW_Startup
   #WINDOW_Main
   #WINDOW_About
@@ -123,7 +123,7 @@ EndEnumeration
 
 ;- Gadgets
 ;
-Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
+Runtime Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_FilesPanel     ; now a custom drawn CanvasGadget
   #GADGET_ToolsPanel
   #GADGET_ToolsPanelFake ; for hidden toolspanel
@@ -160,8 +160,10 @@ Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #Form_Splitter_OK
   #Form_Splitter_Cancel
   
+  #GADGET_Form_Parent_Select_Text
   #GADGET_Form_Parent_Select
   #GADGET_Form_Parent_SelectItem
+  #GADGET_Form_Parent_SelectItem_Text
   #GADGET_Form_Parent_OK
   #GADGET_Form_Parent_Cancel
   

--- a/PureBasicIDE/FormDesigner/FormParent.xml
+++ b/PureBasicIDE/FormDesigner/FormParent.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dialogs>
+  <window id='#WINDOW_Form_Parent' flags='#PB_Window_SystemMenu | #PB_Window_WindowCentered'>
+    <vbox spacing='10'>
+      <empty/>
+      <gridbox colspacing='15' rowspacing='15' columns='4'>
+        <empty/>
+        <text id='#GADGET_Form_Parent_Select_Text' flags='#PB_Text_Right'/>
+        <combobox id='#GADGET_Form_Parent_Select' height='22' width='250'/>
+        <empty/>
+        <empty/>
+        <text id='#GADGET_Form_Parent_SelectItem_Text' flags='#PB_Text_Right'/>
+        <combobox id='#GADGET_Form_Parent_SelectItem' height='22' width='250'/>
+        <empty/>
+      </gridbox>
+      <empty/>
+      <hbox>
+        <empty/>
+        <button id='#GADGET_Form_Parent_Cancel'/>
+        <button id='#GADGET_Form_Parent_OK'/>
+        <empty/>
+      </hbox>
+      <empty/>
+    </vbox>
+  </window>
+</dialogs>

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -6175,16 +6175,26 @@ Procedure FD_UpdateSelectParent()
   
 EndProcedure
 Procedure FD_InitSelectParent(parent_gadget)
+  Protected xml
+  
+  xml = CatchXML(#PB_Any, ?FormParent_Start, ?FormParent_End - ?FormParent_Start)
+  If XMLStatus(xml) <> #PB_XML_Success Or Not CreateDialog(#WINDOW_Form_Parent)
+    ProcedureReturn
+  EndIf
+  
+  If Not OpenXMLDialog(#WINDOW_Form_Parent, xml, "", #PB_Ignore, #PB_Ignore, #PB_Ignore, #PB_Ignore, WindowID(#WINDOW_Main))
+    FreeDialog(#WINDOW_Form_Parent)
+    ProcedureReturn
+  EndIf
+  
   DisableWindow(#WINDOW_Main,1)
-  OpenWindow(#WINDOW_Form_Parent, 0, 0, 482, 150, Language("Form","Parent"), #PB_Window_SystemMenu | #PB_Window_WindowCentered,WindowID(#WINDOW_Main))
   
-  Text_0 = TextGadget(#PB_Any, 20, 24, 180, 22, Language("Form","Parent"), #PB_Text_Right)
-  ComboBoxGadget(#GADGET_Form_Parent_Select, 210, 20, 250, 30)
-  Text_1 = TextGadget(#PB_Any, 20, 64, 180, 22, Language("Form","ParentItem"), #PB_Text_Right)
-  ComboBoxGadget(#GADGET_Form_Parent_SelectItem, 210, 60, 250, 30)
-  
-  ButtonGadget(#GADGET_Form_Parent_OK, 235, 108, 120, 25, Language("Form","OK"))
-  ButtonGadget(#GADGET_Form_Parent_Cancel, 125, 108, 100, 25, Language("Form","Cancel"))
+  SetWindowTitle(#WINDOW_Form_Parent, Language("Form","Parent"))
+  SetGadgetText(#GADGET_Form_Parent_Select_Text, Language("Form","Parent"))
+  SetGadgetText(#GADGET_Form_Parent_SelectItem_Text, Language("Form","ParentItem"))
+  SetGadgetText(#GADGET_Form_Parent_OK, Language("Form","OK"))
+  SetGadgetText(#GADGET_Form_Parent_Cancel, Language("Form","Cancel"))
+  RefreshDialog(#WINDOW_Form_Parent)
   
   i = 0
   selected = 0
@@ -6217,9 +6227,16 @@ Procedure FD_InitSelectParent(parent_gadget)
   EndIf
   
   FD_UpdateSelectParent()
+  
+  DataSection
+    FormParent_Start:
+    IncludeBinary "FormParent.xml"
+    FormParent_End:
+  EndDataSection
 EndProcedure
 Procedure FD_CloseSelectParent()
   CloseWindow(#WINDOW_Form_Parent)
+  FreeDialog(#WINDOW_Form_Parent)
   DisableWindow(#WINDOW_Main,0)
 EndProcedure
 Procedure FD_EventSelectParent(EventID)


### PR DESCRIPTION
By using the Dialog-Lib the window and the contained gadgets are automatically adjusted in size and position according to the contents. This avoids an oversized window with too much empty space on all
operating systems.

Improvement of pull request #50.

PB 572 b1: IDE Formdesigner display problem setting parent
https://www.purebasic.fr/english/viewtopic.php?f=4&t=74526