### PR TITLE
New indentation option

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -300,7 +300,6 @@ Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_AutoSaveAll
   #GADGET_Preferences_TabLength
   #GADGET_Preferences_RealTab
-  #GADGET_Preferences_TabIndent
   #GADGET_Preferences_MemorizeCursor
   #GADGET_Preferences_SourcePath
   #GADGET_Preferences_GetSourcePath
@@ -351,6 +350,7 @@ Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_ExtraWordChars
   #GADGET_Preferences_ShowWhiteSpace
   #GADGET_Preferences_ShowIndentGuides
+  #GADGET_Preferences_UseTabIndentForSplittedLines
   #GADGET_Preferences_EnableBraceMatch
   #GADGET_Preferences_EnableKeywordMatch
   #GADGET_Preferences_SelectFont
@@ -2449,7 +2449,7 @@ Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProce
 Global FilesPanelMultiline, FilesPanelCloseButtons, FilesPanelNewButton
 Global CurrentZoom, SynchronizingZoom
 Global ExtraWordChars$
-Global TabIndent
+Global UseTabIndentForSplittedLines
 
 ; Dialog Window data
 ;

--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -300,6 +300,7 @@ Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_AutoSaveAll
   #GADGET_Preferences_TabLength
   #GADGET_Preferences_RealTab
+  #GADGET_Preferences_TabIndent
   #GADGET_Preferences_MemorizeCursor
   #GADGET_Preferences_SourcePath
   #GADGET_Preferences_GetSourcePath
@@ -2448,6 +2449,7 @@ Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProce
 Global FilesPanelMultiline, FilesPanelCloseButtons, FilesPanelNewButton
 Global CurrentZoom, SynchronizingZoom
 Global ExtraWordChars$
+Global TabIndent
 
 ; Dialog Window data
 ;

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -768,6 +768,7 @@ DataSection
   Data$ "AutoSaveAll",      "Save all sources with Auto-save"
   Data$ "TabLength",        "Tab Length"
   Data$ "RealTab",          "Use real Tab (ASCII 9)"
+  Data$ "TabIndent",        "Indent with Tab Length"
   Data$ "SourcePath",       "Source Directory"
   Data$ "MemorizeCursor",   "Memorize Cursor position"
   Data$ "MemorizeMarkers",  "Memorize Marker positions"

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -768,7 +768,7 @@ DataSection
   Data$ "AutoSaveAll",      "Save all sources with Auto-save"
   Data$ "TabLength",        "Tab Length"
   Data$ "RealTab",          "Use real Tab (ASCII 9)"
-  Data$ "TabIndent",        "Indent with Tab Length"
+  Data$ "TabIndent",        "Indent with Tab length"
   Data$ "SourcePath",       "Source Directory"
   Data$ "MemorizeCursor",   "Memorize Cursor position"
   Data$ "MemorizeMarkers",  "Memorize Marker positions"

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -768,7 +768,6 @@ DataSection
   Data$ "AutoSaveAll",      "Save all sources with Auto-save"
   Data$ "TabLength",        "Tab Length"
   Data$ "RealTab",          "Use real Tab (ASCII 9)"
-  Data$ "TabIndent",        "Indent with Tab length"
   Data$ "SourcePath",       "Source Directory"
   Data$ "MemorizeCursor",   "Memorize Cursor position"
   Data$ "MemorizeMarkers",  "Memorize Marker positions"
@@ -808,7 +807,7 @@ DataSection
   Data$ "DefaultColors",    "Default Color Schemes"
   Data$ "ShowWhiteSpace",   "Show whitespace characters"
   Data$ "ShowIndentGuides", "Show indentation guides"
-  
+  Data$ "UseTabIndentForSplittedLines", "Use tab indent for splitted lines"
   
   Data$ "Color0",           "ASM Keywords"
   Data$ "Color1",           "Background"

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -77,6 +77,7 @@ Procedure LoadPreferences()
   EnableLineNumbers           = ReadPreferenceLong  ("EnableLineNumbers" ,  1)
   ShowWhiteSpace              = ReadPreferenceLong  ("ShowWhiteSpace"    , 0)
   ShowIndentGuides            = ReadPreferenceLong  ("ShowIndentGuides"  , 0)
+  UseTabIndentForSplittedLines = ReadPreferenceLong ("UseTabIndentForSplittedLines", 0)
   AutoSave                    = ReadPreferenceLong  ("AutoSave"          , 1)
   AutoSaveAll                 = ReadPreferenceLong  ("AutoSaveAll"       , 1)
   SaveProjectSettings         = ReadPreferenceLong  ("SaveSettingsMode"  , 0)
@@ -84,7 +85,6 @@ Procedure LoadPreferences()
   ShowMainToolbar             = ReadPreferenceLong  ("ShowToolbar"       , 1)
   TabLength                   = ReadPreferenceLong  ("TabLength"         , 2)
   RealTab                     = ReadPreferenceLong  ("RealTab"           , 0)
-  TabIndent                   = ReadPreferenceLong  ("TabIndent"         , 0)
   MemorizeCursor              = ReadPreferenceLong  ("MemorizeCursor"    , 1)
   MemorizeMarkers             = ReadPreferenceLong  ("MemorizeMarkers"   , 1)
   SelectedFilePattern         = ReadPreferenceLong  ("LastFilePattern"   , 0)
@@ -1066,6 +1066,7 @@ Procedure SavePreferences()
     WritePreferenceLong  ("EnableLineNumbers",    EnableLineNumbers)
     ;WritePreferenceLong  ("EnableMarkers",        EnableMarkers)
     WritePreferenceLong  ("ShowWhiteSpace",       ShowWhiteSpace)
+    WritePreferenceLong  ("UseTabIndentForSplittedLines", UseTabIndentForSplittedLines)
     WritePreferenceLong  ("ShowIndentGuides",     ShowIndentGuides)
     WritePreferenceLong  ("AutoSave",             AutoSave)
     WritePreferenceLong  ("AutoSaveAll",          AutoSaveAll)
@@ -1074,7 +1075,6 @@ Procedure SavePreferences()
     WritePreferenceLong  ("ShowToolbar",          ShowMainToolbar)
     WritePreferenceLong  ("TabLength",            TabLength)
     WritePreferenceLong  ("RealTab",              RealTab)
-    WritePreferenceLong  ("TabIndent",            TabIndent)
     WritePreferenceLong  ("MemorizeCursor",       MemorizeCursor)
     WritePreferenceLong  ("MemorizeMarkers",      MemorizeMarkers)
     WritePreferenceLong  ("LastFilePattern",      SelectedFilePattern)
@@ -1774,6 +1774,7 @@ Procedure IsPreferenceChanged()
   If ExtraWordChars$       <> GetGadgetText(#GADGET_Preferences_ExtraWordChars) : ProcedureReturn 1 : EndIf
   If ShowWhiteSpace        <> GetGadgetState(#GADGET_Preferences_ShowWhiteSpace): ProcedureReturn 1: EndIf
   If ShowIndentGuides      <> GetGadgetState(#GADGET_Preferences_ShowIndentGuides): ProcedureReturn 1: EndIf
+  If UseTabIndentForSplittedLines <> GetGadgetState(#GADGET_Preferences_UseTabIndentForSplittedLines): ProcedureReturn 1: EndIf
   If EnableBraceMatch      <> GetGadgetState(#GADGET_Preferences_EnableBraceMatch): ProcedureReturn 1: EndIf
   If EnableKeywordMatch    <> GetGadgetState(#GADGET_Preferences_EnableKeywordMatch): ProcedureReturn 1: EndIf
   If EnableFolding         <> GetGadgetState(#GADGET_Preferences_EnableFolding): ProcedureReturn 1: EndIf
@@ -1785,7 +1786,6 @@ Procedure IsPreferenceChanged()
   If AutoPopupStructures       <> GetGadgetState(#GADGET_Preferences_StructureItems): ProcedureReturn 1: EndIf
   If AutoPopupModules          <> GetGadgetState(#GADGET_Preferences_ModulePrefix): ProcedureReturn 1: EndIf
   If RealTab                   <> GetGadgetState(#GADGET_Preferences_RealTab): ProcedureReturn 1: EndIf
-  If TabIndent                 <> GetGadgetState(#GADGET_Preferences_TabIndent): ProcedureReturn 1: EndIf
   If AutoPopupNormal           <> GetGadgetState(#GADGET_Preferences_AutoPopup): ProcedureReturn 1: EndIf
   If SaveProjectSettings       <> GetGadgetState(#GADGET_Preferences_SaveProjectSettings): ProcedureReturn 1: EndIf
   If OptionErrorLog            <> GetGadgetState(#GADGET_Preferences_ErrorLog): ProcedureReturn 1: EndIf
@@ -2157,6 +2157,7 @@ Procedure ApplyPreferences()
   ExtraWordChars$       = GetGadgetText(#GADGET_Preferences_ExtraWordChars)
   ShowWhiteSpace        = GetGadgetState(#GADGET_Preferences_ShowWhiteSpace)
   ShowIndentGuides      = GetGadgetState(#GADGET_Preferences_ShowIndentGuides)
+  UseTabIndentForSplittedLines = GetGadgetState(#GADGET_Preferences_UseTabIndentForSplittedLines)
   EnableBraceMatch      = GetGadgetState(#GADGET_Preferences_EnableBraceMatch)
   EnableKeywordMatch    = GetGadgetState(#GADGET_Preferences_EnableKeywordMatch)
   EnableFolding         = GetGadgetState(#GADGET_Preferences_EnableFolding)
@@ -2168,7 +2169,6 @@ Procedure ApplyPreferences()
   AutoPopupStructures       = GetGadgetState(#GADGET_Preferences_StructureItems)
   AutoPopupModules          = GetGadgetState(#GADGET_Preferences_ModulePrefix)
   RealTab                   = GetGadgetState(#GADGET_Preferences_RealTab)
-  TabIndent                 = GetGadgetState(#GADGET_Preferences_TabIndent)
   AutoPopupNormal           = GetGadgetState(#GADGET_Preferences_AutoPopup)
   SaveProjectSettings       = GetGadgetState(#GADGET_Preferences_SaveProjectSettings)
   OptionErrorLog            = GetGadgetState(#GADGET_Preferences_ErrorLog)
@@ -2875,7 +2875,6 @@ Procedure OpenPreferencesWindow()
   SetGadgetState(#GADGET_Preferences_MemorizeMarkers, MemorizeMarkers)
   SetGadgetState(#GADGET_Preferences_AlwaysHideLog, AlwaysHideLog)
   SetGadgetState(#GADGET_Preferences_RealTab, RealTab)
-  SetGadgetState(#GADGET_Preferences_TabIndent, TabIndent)
   
   SetGadgetText(#GADGET_Preferences_TabLength, Str(TabLength))
   SetGadgetText(#GADGET_Preferences_SourcePath, SourcePath$)
@@ -2995,6 +2994,7 @@ Procedure OpenPreferencesWindow()
   ;
   SetGadgetState(#GADGET_Preferences_ShowWhiteSpace, ShowWhiteSpace)
   SetGadgetState(#GADGET_Preferences_ShowIndentGuides, ShowIndentGuides)
+  SetGadgetState(#GADGET_Preferences_UseTabIndentForSplittedLines, UseTabIndentForSplittedLines)
   
   If IndentMode = #INDENT_None
     SetGadgetState(#GADGET_Preferences_IndentNo, 1)

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -84,6 +84,7 @@ Procedure LoadPreferences()
   ShowMainToolbar             = ReadPreferenceLong  ("ShowToolbar"       , 1)
   TabLength                   = ReadPreferenceLong  ("TabLength"         , 2)
   RealTab                     = ReadPreferenceLong  ("RealTab"           , 0)
+  TabIndent                   = ReadPreferenceLong  ("TabIndent"         , 0)
   MemorizeCursor              = ReadPreferenceLong  ("MemorizeCursor"    , 1)
   MemorizeMarkers             = ReadPreferenceLong  ("MemorizeMarkers"   , 1)
   SelectedFilePattern         = ReadPreferenceLong  ("LastFilePattern"   , 0)
@@ -1073,6 +1074,7 @@ Procedure SavePreferences()
     WritePreferenceLong  ("ShowToolbar",          ShowMainToolbar)
     WritePreferenceLong  ("TabLength",            TabLength)
     WritePreferenceLong  ("RealTab",              RealTab)
+    WritePreferenceLong  ("TabIndent",            TabIndent)
     WritePreferenceLong  ("MemorizeCursor",       MemorizeCursor)
     WritePreferenceLong  ("MemorizeMarkers",      MemorizeMarkers)
     WritePreferenceLong  ("LastFilePattern",      SelectedFilePattern)
@@ -1783,6 +1785,7 @@ Procedure IsPreferenceChanged()
   If AutoPopupStructures       <> GetGadgetState(#GADGET_Preferences_StructureItems): ProcedureReturn 1: EndIf
   If AutoPopupModules          <> GetGadgetState(#GADGET_Preferences_ModulePrefix): ProcedureReturn 1: EndIf
   If RealTab                   <> GetGadgetState(#GADGET_Preferences_RealTab): ProcedureReturn 1: EndIf
+  If TabIndent                 <> GetGadgetState(#GADGET_Preferences_TabIndent): ProcedureReturn 1: EndIf
   If AutoPopupNormal           <> GetGadgetState(#GADGET_Preferences_AutoPopup): ProcedureReturn 1: EndIf
   If SaveProjectSettings       <> GetGadgetState(#GADGET_Preferences_SaveProjectSettings): ProcedureReturn 1: EndIf
   If OptionErrorLog            <> GetGadgetState(#GADGET_Preferences_ErrorLog): ProcedureReturn 1: EndIf
@@ -2165,6 +2168,7 @@ Procedure ApplyPreferences()
   AutoPopupStructures       = GetGadgetState(#GADGET_Preferences_StructureItems)
   AutoPopupModules          = GetGadgetState(#GADGET_Preferences_ModulePrefix)
   RealTab                   = GetGadgetState(#GADGET_Preferences_RealTab)
+  TabIndent                 = GetGadgetState(#GADGET_Preferences_TabIndent)
   AutoPopupNormal           = GetGadgetState(#GADGET_Preferences_AutoPopup)
   SaveProjectSettings       = GetGadgetState(#GADGET_Preferences_SaveProjectSettings)
   OptionErrorLog            = GetGadgetState(#GADGET_Preferences_ErrorLog)
@@ -2871,6 +2875,7 @@ Procedure OpenPreferencesWindow()
   SetGadgetState(#GADGET_Preferences_MemorizeMarkers, MemorizeMarkers)
   SetGadgetState(#GADGET_Preferences_AlwaysHideLog, AlwaysHideLog)
   SetGadgetState(#GADGET_Preferences_RealTab, RealTab)
+  SetGadgetState(#GADGET_Preferences_TabIndent, TabIndent)
   
   SetGadgetText(#GADGET_Preferences_TabLength, Str(TabLength))
   SetGadgetText(#GADGET_Preferences_SourcePath, SourcePath$)

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -1463,7 +1463,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
   ;
   Procedure.s GetIndentContinuationPrefix(Previous$)
     ; Use this for a simple "block mode" indentation
-    If TabIndent
+    If UseTabIndentForSplittedLines
       If RealTab
         ProcedureReturn GetIndentPrefix(Previous$) + #TAB$
       Else

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -1463,7 +1463,13 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
   ;
   Procedure.s GetIndentContinuationPrefix(Previous$)
     ; Use this for a simple "block mode" indentation
-    ;ProcedureReturn GetIndentPrefix(Previous$) + "    "
+    If TabIndent
+      If RealTab
+        ProcedureReturn GetIndentPrefix(Previous$) + #TAB$
+      Else
+        ProcedureReturn GetIndentPrefix(Previous$) + Space(TabLength)
+      EndIf
+    EndIf
     
     ; the code below assumes a non-empty string
     If Previous$ = ""

--- a/PureBasicIDE/dialogs/Preferences.xml
+++ b/PureBasicIDE/dialogs/Preferences.xml
@@ -251,6 +251,7 @@
                   <hbox spacing="10" expand="item:2">
                     <string id="#GADGET_Preferences_TabLength" flags="#PB_String_Numeric" width="80" />
                     <checkbox id="#GADGET_Preferences_RealTab" lang="Preferences:RealTab" />
+                    <checkbox id="#GADGET_Preferences_TabIndent" lang="Preferences:TabIndent" />
                   </hbox>
 
                   <text lang="Preferences:SourcePath" text=": " />

--- a/PureBasicIDE/dialogs/Preferences.xml
+++ b/PureBasicIDE/dialogs/Preferences.xml
@@ -251,7 +251,6 @@
                   <hbox spacing="10" expand="item:2">
                     <string id="#GADGET_Preferences_TabLength" flags="#PB_String_Numeric" width="80" />
                     <checkbox id="#GADGET_Preferences_RealTab" lang="Preferences:RealTab" />
-                    <checkbox id="#GADGET_Preferences_TabIndent" lang="Preferences:TabIndent" />
                   </hbox>
 
                   <text lang="Preferences:SourcePath" text=": " />
@@ -428,6 +427,7 @@
                   <vbox expand="no" align="top">
                     <checkbox id="#GADGET_Preferences_ShowIndentGuides" lang="Preferences:ShowIndentGuides" />
                     <checkbox id="#GADGET_Preferences_ShowWhiteSpace" lang="Preferences:ShowWhiteSpace" />
+                    <checkbox id="#GADGET_Preferences_UseTabIndentForSplittedLines" lang="Preferences:UseTabIndentForSplittedLines" />
 
                     <!-- currently not implemented! -->
                     <checkbox id="#GADGET_Preferences_BackspaceUnindent" lang="Preferences:BackspaceUnindent" invisible="yes"/>


### PR DESCRIPTION
This patch introduces a new option in Preferences/Editor to indent selected source code with [Strg] + [i] based on the Tab length instead of the next function key word (default):

![grafik](https://user-images.githubusercontent.com/63706073/80584512-108de300-8a12-11ea-8648-8191ffa994a4.png)

This is the current indentation behaviour:

![](https://abload.de/img/indentationdefaultbckj2.png)

This would be the indentation with the new option "Indent with Tab length" enabled and a Tab width of 2:

![](https://abload.de/img/indentation2spacesj4jkm.png)

I had posted this request already in the PureBasic forum:
https://www.purebasic.fr/english/viewtopic.php?f=14&t=74151&start=71

Unfortunately there are also the following changes in the folder _catalogs_ necessary. The folder _catalogs_ is currently not contained in the purebasic repository!

English _catalogs/Editor.catalog_:
Insert in line 337:
`TabIndent              = Indent with Tab length`

German _catalogs/Deutsch/Editor.catalog_:
Insert in line 337:
`TabIndent              = Einrücken mit Tab-Länge`

French _catalogs/Francais/Editor.catalog_:
Insert in line 337:
`TabIndent            = Indentation avec taille des tabulation`

Spanish _catalogs/Spanish/Editor.catalog_:
Insert in line 302:
`TabIndent            = Hendidura con la anchura de la pestaña`

Italian _catalogs/Italian/Editor.catalog_:
Insert in line 321:
`TabIndent           = Incavo con Lunghezza Tabulatore`

I have translated the French, Spanish and Italian description with DeepL. It would be nice if native speakers of the respective language would check the translation.