### PR TITLE
Fix AutoComplete and ProcedureBrowser

### DIFF
--- a/PureBasicIDE/AutoComplete.pb
+++ b/PureBasicIDE/AutoComplete.pb
@@ -29,7 +29,6 @@ Global AutoComplete_CurrentModule$
 Global NewMap AutoComplete_LastStructureItem.s()  ; key and value is lowercase
 Global NewMap AutoComplete_LastModuleItem.s()
 
-;- Added by mk-soft; Date 29.05.2020; Linux force redraw TreeView
 Macro AutoComplete_Redraw()
   CompilerIf #CompileLinux
     FlushEvents()
@@ -1064,7 +1063,7 @@ Procedure OpenAutoCompleteWindow()
           CompilerIf #CompileLinuxGtk2
             ; reset scrolling position on linux for a better look
             ; (as we never close the window, a horizontal scroll could remain from the last autocomplete)
-            ; gtk_tree_view_scroll_to_point_(GadgetID(#GADGET_AutoComplete_List), 0, -1) ; scroll x=0 and ignore y
+            gtk_tree_view_scroll_to_point_(GadgetID(#GADGET_AutoComplete_List), 0, -1) ; scroll x=0 and ignore y
           CompilerEndIf
           
           Width = AutoCompleteWindowWidth
@@ -1228,10 +1227,9 @@ Procedure AutoCompleteWindowEvents(EventID)
       Select EventGadgetID
           
         Case #GADGET_AutoComplete_List
-          ;- Added by mk-soft; Date 29.05.2020; Linux Redraw TreeView
           CompilerIf #CompileLinux
             If EventType() = #PB_EventType_FirstCustomValue
-              AutoComplete_WordUpdate()
+              AutoComplete_WordUpdate(EventData())
             EndIf
           CompilerEndIf
           
@@ -1262,7 +1260,7 @@ Procedure AutoComplete_CheckAutoPopup()
     
     Line$ = GetCurrentLine()
     
-    ; Debug "Autocomplete checkautopopup: " + Line$
+    ; Debug "Check autopopup: " + Line$
     
     If Line$
       GetCursorPosition()
@@ -1312,12 +1310,8 @@ Procedure AutoComplete_WordUpdate(IsInitial=#False)
   
   Line$ = GetCurrentLine()
   
-  ; Debug "Autocomplete wordupdate " + Line$
-  
   If Line$
     GetCursorPosition() ; Ensures than the fields are updated
-    
-    ;Debug "Line: "+Line$
     
     Column = *ActiveSource\CurrentColumnChars-1
     found = GetWordBoundary(@Line$, Len(Line$), Column, @StartIndex, @EndIndex, 1)
@@ -1537,11 +1531,9 @@ Procedure AutoComplete_WordUpdate(IsInitial=#False)
   
 EndProcedure
 
-; ****
-
-;- Added by mk-soft; Date 28.05.2020; Linux Redraw TreeView outside Scintilla Callback
 CompilerIf #CompileLinux
-  Macro AutoComplete_WordUpdate()
-    PostEvent(#PB_Event_Gadget, #WINDOW_AutoComplete, #GADGET_AutoComplete_List, #PB_EventType_FirstCustomValue)
+  ; Move WordUpdate from Scintilla Callback to Event-Loop
+  Macro AutoComplete_WordUpdate(IsInitial=#False)
+    PostEvent(#PB_Event_Gadget, #WINDOW_AutoComplete, #GADGET_AutoComplete_List, #PB_EventType_FirstCustomValue, IsInitial)
   EndMacro
 CompilerEndIf

--- a/PureBasicIDE/AutoComplete.pb
+++ b/PureBasicIDE/AutoComplete.pb
@@ -1545,9 +1545,3 @@ CompilerIf #CompileLinux
     PostEvent(#PB_Event_Gadget, #WINDOW_AutoComplete, #GADGET_AutoComplete_List, #PB_EventType_FirstCustomValue)
   EndMacro
 CompilerEndIf
-
-; IDE Options = PureBasic 5.72 (MacOS X - x64)
-; CursorPosition = 1547
-; FirstLine = 1516
-; Folding = -----
-; EnableXP

--- a/PureBasicIDE/ProcedureBrowser.pb
+++ b/PureBasicIDE/ProcedureBrowser.pb
@@ -613,9 +613,3 @@ AvailablePanelTools()\NeedDestroyFunction  = 1
 AvailablePanelTools()\ToolID$              = "ProcedureBrowser"
 AvailablePanelTools()\PanelTitle$          = "ProcedureBrowserShort"
 AvailablePanelTools()\ToolName$            = "ProcedureBrowserLong"
-
-; IDE Options = PureBasic 5.72 (MacOS X - x64)
-; CursorPosition = 615
-; FirstLine = 584
-; Folding = ----
-; EnableXP

--- a/PureBasicIDE/ProcedureBrowser.pb
+++ b/PureBasicIDE/ProcedureBrowser.pb
@@ -150,7 +150,12 @@ Procedure UpdateProcedureList()
     
     ; Lock the list update, as on GTK2 it's really slow
     ; Note: we may not call SetGadgetState() after this!
-    CompilerIf #CompileLinux
+    
+    ;- Author : mk-soft
+    ;  Date   : 22.05.2020
+    ;  Bugfix : Linux Crash with g_object. Disabale optimize
+    
+    CompilerIf 0; #CompileLinux
       CompilerIf #GtkVersion = 1
         gtk_clist_freeze_(GadgetID(#GADGET_ProcedureBrowser)) ; on gtk1, its a clist
       CompilerElse
@@ -186,7 +191,11 @@ Procedure UpdateProcedureList()
       EndIf
     Next ProcedureList()
     
-    CompilerIf #CompileLinux
+    ;- Author : mk-soft
+    ;  Date   : 22.05.2020
+    ;  Bugfix : Linux Crash with g_object. Disabale optimize
+    
+    CompilerIf 0; #CompileLinux
       CompilerIf #GtkVersion = 1
         gtk_clist_thaw_(GadgetID(#GADGET_ProcedureBrowser))
       CompilerElse
@@ -201,6 +210,11 @@ Procedure UpdateProcedureList()
     EndIf
     
     ;StopGadgetFlickerFix(#GADGET_ProcedureBrowser)
+    
+    ;- Added by mk-soft; Date 22.05.2020
+    CompilerIf #CompileLinux
+      SetGadgetState(#GADGET_ProcedureBrowser, -1)
+    CompilerEndIf
     
   EndIf
   
@@ -229,7 +243,7 @@ Procedure JumpToProcedure() ; return 1 if a jump was done
   Protected *Found.SourceItem
   
   If *ActiveSource\IsCode = 0
-    ProcedureReturn
+    ProcedureReturn 0
   EndIf
   
   ; update the information
@@ -461,7 +475,7 @@ Procedure ProcedureBrowser_EventHandler(*Entry.ToolsPanelEntry, EventGadgetID)
         ; Unfold the procedure block if it was folded
         SendEditorMessage(#SCI_ENSUREVISIBLE, ProcedureList()\Line)
         
-        CompilerIf #CompileMac
+        CompilerIf #CompileMac Or #CompileLinux ;- Added by mk-soft; Date 22.05.2020
           ; remove selection so the we won't get more jumps to the procedure start! (OSX specific problem)
           SetGadgetState(#GADGET_ProcedureBrowser, -1)
         CompilerEndIf
@@ -599,3 +613,9 @@ AvailablePanelTools()\NeedDestroyFunction  = 1
 AvailablePanelTools()\ToolID$              = "ProcedureBrowser"
 AvailablePanelTools()\PanelTitle$          = "ProcedureBrowserShort"
 AvailablePanelTools()\ToolName$            = "ProcedureBrowserLong"
+
+; IDE Options = PureBasic 5.72 (MacOS X - x64)
+; CursorPosition = 615
+; FirstLine = 584
+; Folding = ----
+; EnableXP

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -2272,6 +2272,8 @@ EndProcedure
 
 Procedure RemoveSource(*Source.SourceFile = 0)
   
+  FlushEvents()
+  
   If *Source = 0
     *Source = *ActiveSource
   EndIf


### PR DESCRIPTION
Linux fix AutoComplete Redraw TreeView.
Linux fix ProcedureBrowser Crash. The g_object is not valid.
