### PR TITLE
[macOS] Revert TabBarGadget tab colors

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -707,13 +707,8 @@ Procedure AddProjectInfo()
         AddTabBarGadgetItem(#GADGET_FilesPanel, 0, Language("Project", "TabTitle"))
       EndIf
       
-      CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-      CompilerElse
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-        SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
-      CompilerEndIf
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+      SetTabBarGadgetItemColor(#GADGET_FilesPanel, 0, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
       
       SetTabBarGadgetItemImage(#GADGET_FilesPanel, 0, OptionalImageID(#IMAGE_FilePanel_Project))
       

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -46,41 +46,22 @@ Procedure RefreshSourceTitle(*Source.SourceFile)
   
   SetTabBarGadgetItemText(#GADGET_FilesPanel, Index, GetSourceTitle(*Source))
   
-  CompilerIf #PB_Compiler_OS = #PB_OS_MacOS
-    If *Source = *ProjectInfo
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-    ElseIf *Source\IsForm And *Source\ProjectFile
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-    ElseIf *Source\IsForm
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-    ElseIf *Source\ProjectFile
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlAccentColor"))
-    Else
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, GetCocoaColor("textColor"))
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, GetCocoaColor("controlBackgroundColor"))
-    EndIf
-  CompilerElse
-    If *Source = *ProjectInfo
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
-    ElseIf *Source\IsForm And *Source\ProjectFile
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormProjectFile)
-    ElseIf *Source\IsForm
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormFile)
-    ElseIf *Source\ProjectFile
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectFile)
-    Else
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
-      SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #PB_Default)
-    EndIf
-  CompilerEndIf
+  If *Source = *ProjectInfo
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectInfo)
+  ElseIf *Source\IsForm And *Source\ProjectFile
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormProjectFile)
+  ElseIf *Source\IsForm
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_FormFile)
+  ElseIf *Source\ProjectFile
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #COLOR_ProjectFile)
+  Else
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_FrontColor, #COLOR_FilePanelFront)
+    SetTabBarGadgetItemColor(#GADGET_FilesPanel, Index, #PB_Gadget_BackColor, #PB_Default)
+  EndIf
 EndProcedure
 
 ; get the title string for the current element in FileList()

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -634,8 +634,6 @@ Procedure CustomizeTabBarGadget()
         EndIf
       EndIf
       \BorderColor   = GetCocoaColor("systemGrayColor")
-      \FaceColor     = GetCocoaColor("controlBackgroundColor")
-      \TextColor     = GetCocoaColor("textColor")
     EndWith
   CompilerEndIf
   


### PR DESCRIPTION
There were [some complaints about tab colors combination](https://www.purebasic.fr/english/viewtopic.php?p=557313#p557313) and now i see that it was indeed a bad decision to enforce system color on TabBarGadget. This PR reverts altered tab colors to their original state, all other changes related to dark mode support stay the same, including TabBarGadget background.

![](https://d7.wtf/s/BarbotinePentapolisUnrequited.png)

I still think that TabBarGadget needs an extensive rework to be able to support system themes, maybe someone someday will do that or try to approach this problem differently.