### PR TITLE
Prevent crash while loading a project

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -2609,6 +2609,7 @@ Global NbIndentKeywords, IndentMode, BackspaceUnindent
 
 Global ProjectOptionsDialog.DialogWindow, ProjectOptionsPosition.DialogPosition
 Global IsProject = 0, IsProjectCreation = 0, NewProjectFile$
+Global IsProjectBusy = 0
 Global ProjectFile$, ProjectName$, ProjectComments$, DefaultProjectFile$, LastOpenProjectFile$
 Global ProjectExplorerPattern, ProjectExplorerPath$
 Global ProjectCloseFiles.l


### PR DESCRIPTION
If you trigger CloseProject(), for example by `Ctrl+Shift+W`, while a project is loading its sources, it crashes the IDE. This is easy to test with a large project that auto-opens many files.

This patch adds an `IsProjectBusy` flag to prevent the crash (and other odd project behaviors) by disallowing `CloseProject()` or `OpenProject()` while the current project is still busy loading (or closing) its files.