### PR TITLE
Fix wrong "x64" reference, and some misspellings

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -1764,7 +1764,7 @@ Structure SourceItem
   EndStructureUnion
 EndStructure
 
-; spechial scope value (in addition to the debugger ones)
+; special scope value (in addition to the debugger ones)
 #SCOPE_UNKNOWN = -1
 
 #PARSER_VTSize = 27   ; number of indexed entries per sorted array

--- a/PureBasicIDE/ProjectPanel.pb
+++ b/PureBasicIDE/ProjectPanel.pb
@@ -10,7 +10,7 @@
 ; selection, scroll position and open nodes stay consistent
 ;
 ; For this, we store the ProjectFiles() pointer in the GadgetItemData
-; Spechal values for the GadgetItemData:
+; Special values for the GadgetItemData:
 ;
 #ProjectPanel_Directory    = 0
 #ProjectPanel_InternalBase = -1

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -2593,7 +2593,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
             If *OriginalItem And *OriginalItem\Type = #ITEM_Keyword
               *Item.SourceItem = 0
               
-              ; spechial treatment is needed for some keywords
+              ; special treatment is needed for some keywords
               Select *OriginalItem\Keyword
                   
                 Case #KEYWORD_For, #KEYWORD_ForEach, #KEYWORD_Repeat, #KEYWORD_While, #KEYWORD_Procedure, #KEYWORD_ProcedureC, #KEYWORD_ProcedureDLL, #KEYWORD_ProcedureCDLL
@@ -3214,7 +3214,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
       ProcedureReturn 0
     EndProcedure
     
-    ; Spechial handler for the double-click on linux, as the Scintilla event does
+    ; Special handler for the double-click on linux, as the Scintilla event does
     ; not provide the modifier keys, so we do not know if Ctrl+Double-click was done.
     ;
     ProcedureC ScintillaDoubleclickHandler(*Widget, *Event.GdkEventButton, user_data)

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -499,7 +499,7 @@ EndProcedure
 ;  So to avoid any confustion from a disappearing character we handle this conversion
 ;  as well when doing the Source encoding change.
 ;
-;  Lets hope there are no more such spechial characters.
+;  Let's hope there are no more such special characters.
 ;
 ; Some notes:
 ;  - unrepresentable chars become '?'

--- a/PureBasicIDE/SourceParser.pb
+++ b/PureBasicIDE/SourceParser.pb
@@ -2570,7 +2570,7 @@ Procedure MatchKeywordBackward(*Parser.ParserData, *pLine.INTEGER, *pItem.INTEGE
     ;
     If *Item\Type = #ITEM_Keyword
       
-      ; Spechial check: Inside Compiler statements we ignore the keywords, as the compiler
+      ; Special check: Inside Compiler statements we ignore the keywords, as the compiler
       ; statements do not need to respect the nesting of normal commands
       ;
       ; Note: The #KEYWORD_ constants are sorted by alphabetic keyword name, so this check works
@@ -2654,7 +2654,7 @@ Procedure MatchKeywordForward(*Parser.ParserData, *pLine.INTEGER, *pItem.INTEGER
     ;
     If *Item\Type = #ITEM_Keyword
       
-      ; Spechial check: Inside Compiler statements we ignore the keywords, as the compiler
+      ; Special check: Inside Compiler statements we ignore the keywords, as the compiler
       ; statements do not need to respect the nesting of normal commands
       ;
       ; Note: The #KEYWORD_ constants are sorted by alphabetic keyword name, so this check works
@@ -3856,7 +3856,7 @@ DataSection
   ;   are multiple pairs.
   ;   (Example: Case must be followed by either Case, Default Or EndSelect)
   ;
-  ; Note: Compiler Keywords are treated spechially, as they can be used
+  ; Note: Compiler Keywords are treated specially, as they can be used
   ;   outside of the normal nesting rules.
   ;
   KeywordMatches:

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1703,7 +1703,7 @@ Procedure MainMenuEvent(MenuItemID)
       CompilerIf #CompileWindows | #CompileMac
         
       Case #MENU_Scintilla_Enter
-        If AutoCompleteWindowOpen And KeyboardShortcuts(#MENU_AutoComplete_OK) = #PB_Shortcut_Return    ; spechial handling when enter is used here
+        If AutoCompleteWindowOpen And KeyboardShortcuts(#MENU_AutoComplete_OK) = #PB_Shortcut_Return    ; special handling when enter is used here
           AutoComplete_Insert()
           
         ElseIf GetFocusGadgetID(#WINDOW_Main) = GadgetID(*ActiveSource\EditorGadget)
@@ -1722,7 +1722,7 @@ Procedure MainMenuEvent(MenuItemID)
         EndIf
         
       Case #MENU_Scintilla_Tab
-        If AutoCompleteWindowOpen And KeyboardShortcuts(#MENU_AutoComplete_OK) = #PB_Shortcut_Tab ; spechial handling when tab is used
+        If AutoCompleteWindowOpen And KeyboardShortcuts(#MENU_AutoComplete_OK) = #PB_Shortcut_Tab ; special handling when tab is used
           AutoComplete_Insert()
           
         ElseIf GetFocusGadgetID(#WINDOW_Main) = GadgetID(*ActiveSource\EditorGadget)
@@ -2561,7 +2561,7 @@ Procedure DispatchEvent(EventID)
                   ResizeTools()
                   
                 ElseIf EventID = #PB_Event_GadgetDrop
-                  ; spechial case for the Templates D+D
+                  ; special case for the Templates D+D
                   If EventGadget() = #GADGET_Template_Tree
                     Template_DropEvent()
                   EndIf

--- a/Window-x86.cmd
+++ b/Window-x86.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-:: Set the PureBasic home directory to a real x64 PureBasic installation (warning:
+:: Set the PureBasic home directory to a real x86 PureBasic installation (warning:
 :: when compiling, the IDE will be overwritten with the new one.
 set PUREBASIC_HOME=C:\PureBasic\Svn\v5.70\Build\PureBasic_x86
 


### PR DESCRIPTION
In `Windows-x86.cmd` a comment tells you to specify the path of an `x64` installation - I think this is supposed to be `x86`.

While submitting this tiny correction, I'm also fixing misspellings of `special` :grin: 