### PR TITLE
Fix wrong #COLOR comments in DefaultColorSchemes DataSection

### DIFF
--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -5414,10 +5414,10 @@ DataSection
     ; in order if the enumeration.
     
     Data$ "SpiderBasic"
-    Data.l $000000
-    Data.l $FFFFFF
-    Data.l $800000
-    Data.l $FFFFFF ; #COLOR_ASMKeyword
+    Data.l $000000 ;  ToolsPanelFrontColor
+    Data.l $FFFFFF ;  ToolsPanelBackColor
+    Data.l $800000 ; #COLOR_ASMKeyword
+    Data.l $FFFFFF ; #COLOR_GlobalBackground
     Data.l $C37B23 ; #COLOR_BasicKeyword
     Data.l $009001 ; #COLOR_Comment
     Data.l $724B92 ; #COLOR_Constant
@@ -5467,10 +5467,10 @@ DataSection
   ; in order if the enumeration.
   
   Data$ "PureBasic"
-  Data.l 0
-  Data.l $DFFFFF
-  Data.l $724B92
-  Data.l $DFFFFF ; #COLOR_ASMKeyword
+  Data.l 0       ;  ToolsPanelFrontColor
+  Data.l $DFFFFF ;  ToolsPanelBackColor
+  Data.l $724B92 ; #COLOR_ASMKeyword
+  Data.l $DFFFFF ; #COLOR_GlobalBackground
   Data.l $666600 ; #COLOR_BasicKeyword
   Data.l $AAAA00 ; #COLOR_Comment
   Data.l $724B92 ; #COLOR_Constant
@@ -5510,10 +5510,10 @@ DataSection
   
   
   Data$ "Visual Studio"
-  Data.l $000000
-  Data.l $FFFFFF
-  Data.l $800000
-  Data.l $FFFFFF ; #COLOR_ASMKeyword
+  Data.l $000000 ;  ToolsPanelFrontColor
+  Data.l $FFFFFF ;  ToolsPanelBackColor
+  Data.l $800000 ; #COLOR_ASMKeyword
+  Data.l $FFFFFF ; #COLOR_GlobalBackground
   Data.l $FF0000 ; #COLOR_BasicKeyword
   Data.l $008000 ; #COLOR_Comment
   Data.l $000000 ; #COLOR_Constant
@@ -5553,10 +5553,10 @@ DataSection
   
   
   Data$ "PHP extended"
-  Data.l $000000
-  Data.l $F4F4F4
-  Data.l $724B92
-  Data.l $FFFFFF ; #COLOR_ASMKeyword
+  Data.l $000000 ;  ToolsPanelFrontColor
+  Data.l $F4F4F4 ;  ToolsPanelBackColor
+  Data.l $724B92 ; #COLOR_ASMKeyword
+  Data.l $FFFFFF ; #COLOR_GlobalBackground
   Data.l $008000 ; #COLOR_BasicKeyword
   Data.l $0080FF ; #COLOR_Comment
   Data.l $724B92 ; #COLOR_Constant
@@ -5595,10 +5595,10 @@ DataSection
   Data.l $FFFFFF ; #COLOR_PlainBackground
   
   Data$ "Black Style"
-  Data.l $008000
-  Data.l $000000
-  Data.l $FFFFFF
-  Data.l $000000 ; #COLOR_ASMKeyword
+  Data.l $008000 ;  ToolsPanelFrontColor
+  Data.l $000000 ;  ToolsPanelBackColor
+  Data.l $FFFFFF ; #COLOR_ASMKeyword
+  Data.l $000000 ; #COLOR_GlobalBackground
   Data.l $00CCCC ; #COLOR_BasicKeyword
   Data.l $808080 ; #COLOR_Comment
   Data.l $808000 ; #COLOR_Constant
@@ -5638,10 +5638,10 @@ DataSection
   
   ; Based on the Monokai color scheme, copyright by Wimer Hazenberg (https://monokai.nl)
   Data$ "Monokai"
-  Data.l $C2CFCF
-  Data.l $222827
+  Data.l $C2CFCF ;  ToolsPanelFrontColor
+  Data.l $222827 ;  ToolsPanelBackColor
   Data.l $EFD966 ; #COLOR_ASMKeyword
-  Data.l $222827 ; #COLOR_Background
+  Data.l $222827 ; #COLOR_GlobalBackground
   Data.l $7226F9 ; #COLOR_BasicKeyword
   Data.l $5E7175 ; #COLOR_Comment
   Data.l $FF81AE ; #COLOR_Constant
@@ -5680,10 +5680,10 @@ DataSection
   Data.l $222827 ; #COLOR_PlainBackground
   
   Data$ "Blue Style"
-  Data.l $80FFFF
-  Data.l $804000
-  Data.l $724B92
-  Data.l $FFEAD9 ; #COLOR_ASMKeyword
+  Data.l $80FFFF ;  ToolsPanelFrontColor
+  Data.l $804000 ;  ToolsPanelBackColor
+  Data.l $724B92 ; #COLOR_ASMKeyword
+  Data.l $FFEAD9 ; #COLOR_GlobalBackground
   Data.l $800000 ; #COLOR_BasicKeyword
   Data.l $006400 ; #COLOR_Comment
   Data.l $000080 ; #COLOR_Constant
@@ -5722,10 +5722,10 @@ DataSection
   Data.l $FFEAD9 ; #COLOR_PlainBackground
   
   Data$ "White Style"
-  Data.l $000000
-  Data.l $FFFFFF
-  Data.l $0000FF
-  Data.l $FFFFFF ; #COLOR_ASMKeyword
+  Data.l $000000 ;  ToolsPanelFrontColor
+  Data.l $FFFFFF ;  ToolsPanelBackColor
+  Data.l $0000FF ; #COLOR_ASMKeyword
+  Data.l $FFFFFF ; #COLOR_GlobalBackground
   Data.l $800000 ; #COLOR_BasicKeyword
   Data.l $008000 ; #COLOR_Comment
   Data.l $000080 ; #COLOR_Constant
@@ -5765,10 +5765,10 @@ DataSection
   
   
   Data$ "Grey Style"
-  Data.l $6F3F00
-  Data.l $8F8F8F
-  Data.l $FF0000
-  Data.l $AFAFAF ; #COLOR_ASMKeyword
+  Data.l $6F3F00 ;  ToolsPanelFrontColor
+  Data.l $8F8F8F ;  ToolsPanelBackColor
+  Data.l $FF0000 ; #COLOR_ASMKeyword
+  Data.l $AFAFAF ; #COLOR_GlobalBackground
   Data.l $000000 ; #COLOR_BasicKeyword
   Data.l $FFFFFF ; #COLOR_Comment
   Data.l $7F007F ; #COLOR_Constant
@@ -5807,10 +5807,10 @@ DataSection
   Data.l $FFFFFF ; #COLOR_PlainBackground
   
   Data$ "Accessibility"
-  Data.l 0
-  Data.l $FFFFFF
-  Data.l $000000
-  Data.l $FFFFFF  ; #COLOR_ASMKeyword
+  Data.l 0        ;  ToolsPanelFrontColor
+  Data.l $FFFFFF  ;  ToolsPanelBackColor
+  Data.l $000000  ; #COLOR_ASMKeyword
+  Data.l $FFFFFF  ; #COLOR_GlobalBackground
   Data.l $FF0000  ; #COLOR_BasicKeyword
   Data.l $0000FF  ; #COLOR_Comment
   Data.l 0        ; #COLOR_Constant


### PR DESCRIPTION
Fixes #101 reported by @SicroAtGit .

In the default color schemes DataSection, `#COLOR_GlobalBackground` values are incorrectly labeled as `#COLOR_ASMKeyword` in their comments.
(And `#COLOR_GlobalBackground` was not mentioned anywhere!)

This also labels the `ToolsPanel` values for extra clarity.