### PR TITLE
Add PageUp/Dn shortcuts to step through Preferences screens

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -205,6 +205,8 @@ Runtime Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_Ok
   #GADGET_Preferences_Cancel
   #GADGET_Preferences_Apply
+  #GADGET_Preferences_PageUp    ; Not actually a gadget, for now, just a shortcut
+  #GADGET_Preferences_PageDown  ; Not actually a gadget, for now, just a shortcut
   #GADGET_Preferences_MonitorFileChanges
   #GADGET_Preferences_SystemMessages
   #GADGET_Preferences_DebugToLog

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -4382,6 +4382,26 @@ Procedure PreferencesWindowEvents(EventID)
         DisableGadget(#GADGET_Preferences_Ok, 0)
         DisableGadget(#GADGET_Preferences_Cancel, 0)
         
+      Case #GADGET_Preferences_PageUp
+        index = GetGadgetState(#GADGET_Preferences_Tree)
+        If index > 0
+          SetGadgetState(#GADGET_Preferences_Tree, index - 1)
+        ElseIf index = -1
+          SetGadgetState(#GADGET_Preferences_Tree, 0)
+        EndIf
+        SetActiveGadget(#GADGET_Preferences_Tree)
+        PostEvent(#PB_Event_Gadget, #WINDOW_Preferences, #GADGET_Preferences_Tree, #PB_EventType_Change)
+        
+      Case #GADGET_Preferences_PageDown
+        index = GetGadgetState(#GADGET_Preferences_Tree)
+        If index < CountGadgetItems(#GADGET_Preferences_Tree) - 1
+          SetGadgetState(#GADGET_Preferences_Tree, index + 1)
+        ElseIf index = -1
+          SetGadgetState(#GADGET_Preferences_Tree, 0)
+        EndIf
+        SetActiveGadget(#GADGET_Preferences_Tree)
+        PostEvent(#PB_Event_Gadget, #WINDOW_Preferences, #GADGET_Preferences_Tree, #PB_EventType_Change)
+        
       Case #GADGET_Preferences_EnableHistory
         Enabled = GetGadgetState(#GADGET_Preferences_EnableHistory)
         For i = #GADGET_Preferences_HistoryTimer To #GADGET_Preferences_HistoryCount

--- a/PureBasicIDE/dialogs/Preferences.xml
+++ b/PureBasicIDE/dialogs/Preferences.xml
@@ -5,7 +5,7 @@
 <window label="Dialog_Preferences" id="#WINDOW_Preferences" lang="Preferences:Title" invisible="yes" height="510">
   <vbox spacing="10" expand="item:1">
     <hbox spacing="10">
-      <tree id="#GADGET_Preferences_Tree" width="#DEFAULT_PreferencesTreeWidth">
+      <tree id="#GADGET_Preferences_Tree" width="#DEFAULT_PreferencesTreeWidth" flags="#PB_Tree_AlwaysShowSelection">
         <item sublevel="0" lang="Preferences:General" />
         <item sublevel="1" lang="Preferences:Language" />
         <item sublevel="1" lang="Shortcuts:Shortcuts" />
@@ -1079,5 +1079,7 @@
 
   <shortcut key="#PB_Shortcut_Return" id="#GADGET_Preferences_Ok" />
   <shortcut key="#PB_Shortcut_Escape" id="#GADGET_Preferences_Cancel" />
+  <shortcut key="#PB_Shortcut_PageUp" id="#GADGET_Preferences_PageUp" />
+  <shortcut key="#PB_Shortcut_PageDown" id="#GADGET_Preferences_PageDown" />
 </window>
   


### PR DESCRIPTION
A small feature I've wanted: Add PageUp / PageDown hotkeys to flip through the Preferences screens, regardless of where the focus is.

Only tested on Windows, but it's very basic and should work on others.

It edits `Preferences.xml` so a fresh `make` is required to regenerate `ide/Preferences.pb`!