### PR TITLE
Bug fix: Wrong tab can be labeled "Project"

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -579,7 +579,12 @@ EndProcedure
 ; Apply preferences changes
 Procedure UpdateProjectInfoPreferences()
   If *ProjectInfo
-    SetTabBarGadgetItemText(#GADGET_FilesPanel, 0, "> " + Language("Project","TabTitle"))
+    
+    ; Find Project tab (position may have changed!) and update its text
+    PushListPosition(FileList())
+    ChangeCurrentElement(FileList(), *ProjectInfo)
+    SetTabBarGadgetItemText(#GADGET_FilesPanel, ListIndex(FileList()), Language("Project","TabTitle"))
+    PopListPosition(FileList())
     
     SetGadgetText(#GADGET_ProjectInfo_FrameProject, Language("Project","ProjectInfo"))
     SetGadgetText(#GADGET_ProjectInfo_FrameFiles, Language("Project","FileTab"))


### PR DESCRIPTION
A minor text bug fix. To demonstrate:

1. Open the IDE
2. Open any PB Project and one or more files
3. **Drag the "Project" tab in the TabBar to any other position besides 0**
4. Open preferences
5. Change any preference (eg. toggle Splash Screen)
6. Hit OK or Apply preferences - **Whatever file tab is in the first position is renamed "> Project"** :warning: 

This happens because `UpdateProjectInfoPreferences()` assumes the "Project" tab is in position 0. It should locate it using `*ProjectInfo`.

Also, this PR removes the `> ` prefix, so it remains `Project` instead of suddenly changing to `> Project`. The prefix seems to be leftover from older versions, and it didn't get removed in this function.