### PR TITLE
PB Help Quick HTML Preview Build Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@
 *.pbp
 project.cfg
 
+## ==================
+## HTML Help Previews
+## ==================
+Documentation/English/HTML
+Documentation/French/HTML
+Documentation/German/HTML
+
 ## ===============
 ## Misc Work Files
 ## ===============

--- a/Documentation/HTML-BUILD.bat
+++ b/Documentation/HTML-BUILD.bat
@@ -1,0 +1,62 @@
+:: "Documentation\HTML-BUILD.bat"       v1.0.0 | 2020/11/30 | by Tristano Ajmone
+:: -----------------------------------------------------------------------------
+@ECHO OFF
+ECHO.
+ECHO ##############################################################################
+ECHO #                                                                            #
+ECHO #                    PureBasic Help HTML Preview Builder                     #
+ECHO #                                                                            #
+ECHO ##############################################################################
+IF [%1]==[] GOTO :Instructions
+:: Check that DocMaker is available:
+SET DocMaker="%ProgramFiles%\PureBasic\SDK\DocMaker\DocMaker.exe"
+IF NOT EXIST %DocMaker% GOTO :DocMakerNotFound
+:: Track which locales will be converted:
+SET _DE=0
+SET _EN=0
+SET _FR=0
+IF /I %1==de SET _DE=1
+IF /I %1==en SET _EN=1
+IF /I %1==fr SET _FR=1
+IF /I %1==all (
+	SET _DE=1
+	SET _EN=1
+	SET _FR=1
+)
+:: Carry out the actual conversions:
+IF %_DE% EQU 1 CALL :DocMakerBuild German
+IF %_EN% EQU 1 CALL :DocMakerBuild English
+IF %_FR% EQU 1 CALL :DocMakerBuild French
+GOTO :EndScript
+
+:DocMakerBuild
+ECHO Building PureBasic %~1 Help: ".\%~1\HTML\".
+RD /Q /S "%~dp0\%~1\HTML" >nul 2>&1
+%DocMaker% /DOCUMENTATIONPATH "%~dp0" /OUTPUTPATH "%~dp0\%~1\HTML" /LANGUAGE %~1 /FORMAT Html /OS Windows
+EXIT /B
+
+:Instructions
+ECHO Missing parameter! Invoke me with one of (de^|en^|fr^|all):
+ECHO.
+ECHO   de   -- Builds German documentation in:  "German\HTML\"
+ECHO   en   -- Builds English documentation in: "English\HTML\"
+ECHO   fr   -- Builds French documentation in:  "French\HTML\"
+ECHO   all  -- Builds all three locales.
+GOTO :EndScript
+
+:DocMakerNotFound
+ECHO ^*^*^* ERROR^!^!^! ^*^*^* Couldn't find DocMaker at the expected path:
+ECHO.
+ECHO   %DocMaker%
+ECHO.
+ECHO This script needs a standard PureBasic installation to be present on the system,
+ECHO according to the system architecture -- i.e. PureBasic 32-bit on Windows 32-bit,
+ECHO or PureBasic 64-bit edition on Windows 64-bit.
+ECHO.
+ECHO /// Aborting conversion ///
+GOTO :EndScript
+
+:EndScript
+:: Only pause before quitting if the script was launched via File Explorer:
+ECHO "%cmdcmdline%" | FINDSTR /IC:"%~dp0" >nul && PAUSE
+EXIT /B


### PR DESCRIPTION

In order to facilitate quick preview of PB Documentation while editing it, this commits adds the `Documentation\HTML-BUILD.bat` script, which takes parameters (de|en|fr|all) to build a specific locale or all of them at once.

The HTML files are built into the `HTML/` subfolder of each locale and the whole folder is deleted at each rebuild operation:

- `Documentation/English/HTML/`
- `Documentation/French/HTML/`
- `Documentation/German/HTML/`

The above HTML folders are excluded from the repository via newly added `.gitignore` rules.

