### PR TITLE
Move AsciiDoc Sources to Dedicated Folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -90,4 +90,14 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 
+## AsciiDoc
+###########
+[*.{ad,adoc,asciidoc}]
+indent_size = 2
+indent_style = space
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 # EOF #

--- a/.gitattributes
+++ b/.gitattributes
@@ -110,7 +110,8 @@ LICENSE*   text
 # Exclusion Rules for Zip Download
 # ================================
 # Exclude from the downloadable Zip archive of the repository contents relating
-# to Git or repository maintenance.
+# to Git or repository maintenance, to provide end users with a cut-down version
+# of the project containing the essentials for quick consumption.
 
 /.git            export-ignore
 .editorconfig    export-ignore
@@ -119,6 +120,7 @@ LICENSE*   text
 .gitconfig       export-ignore
 .gitignore       export-ignore
 .gitmodules      export-ignore
+/AsciiDoc        export-ignore
 /validate.sh     export-ignore
 
 # EOF #

--- a/AsciiDoc/DocMaker-Help.asciidoc
+++ b/AsciiDoc/DocMaker-Help.asciidoc
@@ -19,18 +19,7 @@ Fantaisie Software <support@purebasic.com>
 :reproducible:
 :sectanchors:
 
-ifdef::backend-html5[]
-++++
-<!--
-*******************************************************************************
-* DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
-* If you want to contribute changes, submit them to its AsciiDoc source at:   *
-*                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
-*******************************************************************************
--->
-++++
-endif::[]
+include::inc_warn-editing.adoc[]
 
 // IMPORTANT!!!
 // *****************************************************************************

--- a/AsciiDoc/DocMaker-Tags.asciidoc
+++ b/AsciiDoc/DocMaker-Tags.asciidoc
@@ -13,18 +13,7 @@ Fantaisie Software <support@purebasic.com>
 :linkattrs:
 :reproducible:
 
-ifdef::backend-html5[]
-++++
-<!--
-*******************************************************************************
-* DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
-* If you want to contribute changes, submit them to its AsciiDoc source at:   *
-*                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
-*******************************************************************************
--->
-++++
-endif::[]
+include::inc_warn-editing.adoc[]
 
 // IMPORTANT!!!
 // *****************************************************************************

--- a/AsciiDoc/PB-Documentation-Guide.asciidoc
+++ b/AsciiDoc/PB-Documentation-Guide.asciidoc
@@ -22,18 +22,7 @@ Fantaisie Software <support@purebasic.com>
 :reproducible:
 :sectanchors:
 
-ifdef::backend-html5[]
-++++
-<!--
-*******************************************************************************
-* DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
-* If you want to contribute changes, submit them to its AsciiDoc source at:   *
-*                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
-*******************************************************************************
--->
-++++
-endif::[]
+include::inc_warn-editing.adoc[]
 
 // IMPORTANT!!!
 // *****************************************************************************

--- a/AsciiDoc/README.md
+++ b/AsciiDoc/README.md
@@ -1,0 +1,102 @@
+# AsciiDoc Sources
+
+This directory contains the [AsciiDoc] sources and assets of various HTML documents found in the repository (currently, only in the [`../Documentation/`][Documentation/] folder).
+
+
+-----
+
+**Table of Contents**
+
+<!-- MarkdownTOC autolink="true" bracket="round" autoanchor="false" lowercase="only_ascii" uri_encoding="true" levels="1,2,3" -->
+
+- [Directory Contents](#directory-contents)
+- [Documents List](#documents-list)
+- [About](#about)
+- [System Requirements](#system-requirements)
+
+<!-- /MarkdownTOC -->
+
+-----
+
+# Directory Contents
+
+- [`DocMaker-Help.asciidoc`][DocMaker-Help.asciidoc] — _[PureBasic DocMaker Help]_.
+- [`DocMaker-Tags.asciidoc`][DocMaker-Tags.asciidoc] — _[PureBasic DocMaker Tags Guide]_.
+- [`PB-Documentation-Guide.asciidoc`][PB-Documentation-Guide.asciidoc] — _[PureBasic Documentation Guidelines]_.
+- [`inc_warn-editing.adoc`][inc_warn-editing.adoc] — shared include file with HTML commented warning about editing.
+- [`asciidoc2html.sh`][asciidoc2html.sh] — converter script.
+
+
+# Documents List
+
+The following table maps the AsciiDoc sources of this folder to their generated HTML documents elsewhere in the repository.
+
+|                         AsciiDoc Source File                         |                              Generated HTML File                              |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| [`DocMaker-Help.asciidoc`][DocMaker-Help.asciidoc]                   | [`../Documentation/DocMaker-Help.html`][DocMaker-Help.html]                   |
+| [`DocMaker-Tags.asciidoc`][DocMaker-Tags.asciidoc]                   | [`../Documentation/DocMaker-Tags.html`][DocMaker-Tags.html]                   |
+| [`PB-Documentation-Guide.asciidoc`][PB-Documentation-Guide.asciidoc] | [`../Documentation/PB-Documentation-Guide.html`][PB-Documentation-Guide.html] |
+
+
+# About
+
+The purpose of this directory is to gather various PureBasic and SpiderBasic documents, which were originally distributed as plain text files, and convert them to AsciiDoc sources in order to allow creating rich formated HTML versions.
+
+Keeping all the AsciiDoc sources and their assets in this folder prevents cluttering the repository with unnecessary files, by keeping just the HTML documents in the destination folders.
+The generated HTML documents are fully self-contained, they don't rely on external CSS stylesheets or image files (images are included in the generated document via [Data URIs]).
+
+[AsciiDoc] is an optimal documentation format for collaborative editing since it relies on UTF-8 text sources, which are ideal for version controlled projects (unlike binary document formats like Word, or other formats which are zipped files).
+Furthermore, the AsciiDoc syntax offers powerful formatting features (much richer than Markdown), yet remaining human-readable and easy to work with, using any text editor.
+
+Although for the purpose of this repository we only convert the documents to HTML, the AsciiDoc sources can be converted to a wide variety of output formats, making these sources highly reusable in other projects (including websites created with CMSs supporting AsciiDoc).
+
+HTML is an ideal format for distributing documents, since every end user has a web browser, whereas formats like Markdown require a previewer tool which might not be present natively on every OS.
+
+Currently, there are only the sources for the HTML documents found in the [`../Documentation/`][Documentation/] folder, so the [`asciidoc2html.sh`][asciidoc2html.sh] conversion script simply targets that single output folder.
+In the future we might be adding new documents targeting other folders; when this happens the converter script will be adapted to support multiple target folders.
+
+# System Requirements
+
+The documents, assets and scripts in this folder were designed to work with the [Asciidoctor Ruby gem].
+
+Although AsciiDoc is an implementation-independent specification, due to slight differences between the various AsciiDoc implementations, using other AsciiDoc tools might produce slightly different output documents.
+
+Furthermore, in order to use other AsciiDoc implementations, you'll need to adapt the converter script.
+
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[AsciiDoc]: https://asciidoc.org/ "Visit AsciiDoc website"
+[Asciidoctor]: https://asciidoctor.org/ "Visit Asciidoctor website"
+[Asciidoctor Ruby gem]: https://rubygems.org/gems/asciidoctor "Asciidoctor page at RubyGems"
+
+[Data URIs]: https://en.wikipedia.org/wiki/Data_URI_scheme "Wikipedia page on data URI scheme"
+
+<!-- project folders -->
+
+[Documentation/]: ../Documentation/ "Navigate to folder"
+
+<!-- project files -->
+
+[DocMaker-Help.asciidoc]: ./DocMaker-Help.asciidoc "View source document"
+[DocMaker-Tags.asciidoc]: ./DocMaker-Tags.asciidoc "View source document"
+[PB-Documentation-Guide.asciidoc]: ./PB-Documentation-Guide.asciidoc "View source document"
+[asciidoc2html.sh]: ./asciidoc2html.sh "View source script"
+[inc_warn-editing.adoc]: ./inc_warn-editing.adoc "View source document"
+
+<!-- html output files -->
+
+[DocMaker-Help.html]: ../Documentation/DocMaker-Help.html "View generated HTML document"
+[DocMaker-Tags.html]: ../Documentation/DocMaker-Tags.html "View generated HTML document"
+[PB-Documentation-Guide.html]: ../Documentation/PB-Documentation-Guide.html "View generated HTML document"
+
+<!-- html outpt docs by title -->
+
+[PureBasic DocMaker Help]: ../Documentation/DocMaker-Help.html "View generated HTML file"
+[PureBasic DocMaker Tags Guide]: ../Documentation/DocMaker-Tags.html "View generated HTML file"
+[PureBasic Documentation Guidelines]: ../Documentation/PB-Documentation-Guide.html "View generated HTML file"
+
+
+<!-- EOF -->

--- a/AsciiDoc/asciidoc2html.sh
+++ b/AsciiDoc/asciidoc2html.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# "asciidoc2html.sh"  by Tristano Ajmone                     v1.0.0 | 2020/11/25
+# "asciidoc2html.sh"  by Tristano Ajmone                     v2.0.0 | 2020/12/07
 #-------------------------------------------------------------------------------
 # Convert to HTML all AsciiDoc files with extension "*.asciidoc" inside current
 # folder. Requires Asciidoctor (Ruby) to be installed:
@@ -26,7 +26,8 @@ fi
 # ===============
 # Convert to HTML
 # ===============
-# Every document in current folder with extension "*.asciidoc":
+# Every document in current folder with extension "*.asciidoc".
+# Currently, all HTML docs will be generated in the "../Documentation" folder.
 
 for doc in *.asciidoc ; do
 	asciidoctor \
@@ -40,5 +41,6 @@ for doc in *.asciidoc ; do
 		-a sectanchors \
 		-a toc=left \
 		-a reproducible \
+		-D ../Documentation \
 			$doc
 done

--- a/AsciiDoc/inc_warn-editing.adoc
+++ b/AsciiDoc/inc_warn-editing.adoc
@@ -1,0 +1,12 @@
+ifdef::backend-html5[]
+++++
+<!--
+*******************************************************************************
+* DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
+* If you want to contribute changes, submit them to its AsciiDoc source at:   *
+*                                                                             *
+* https://github.com/fantaisie-software/purebasic/tree/master/AsciiDoc/       *
+*******************************************************************************
+-->
+++++
+endif::[]

--- a/Documentation/DocMaker-Help.html
+++ b/Documentation/DocMaker-Help.html
@@ -468,7 +468,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 * DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
 * If you want to contribute changes, submit them to its AsciiDoc source at:   *
 *                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
+* https://github.com/fantaisie-software/purebasic/tree/master/AsciiDoc/       *
 *******************************************************************************
 -->
 <div class="paragraph">

--- a/Documentation/DocMaker-Tags.html
+++ b/Documentation/DocMaker-Tags.html
@@ -455,7 +455,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 * DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
 * If you want to contribute changes, submit them to its AsciiDoc source at:   *
 *                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
+* https://github.com/fantaisie-software/purebasic/tree/master/AsciiDoc/       *
 *******************************************************************************
 -->
 <div class="paragraph">

--- a/Documentation/PB-Documentation-Guide.html
+++ b/Documentation/PB-Documentation-Guide.html
@@ -465,7 +465,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 * DON'T EDIT THIS DOCUMENT!!! This HTML document was generated from AsciiDoc. *
 * If you want to contribute changes, submit them to its AsciiDoc source at:   *
 *                                                                             *
-* https://github.com/fantaisie-software/purebasic/tree/master/Documentation/  *
+* https://github.com/fantaisie-software/purebasic/tree/master/AsciiDoc/       *
 *******************************************************************************
 -->
 <div class="paragraph">


### PR DESCRIPTION
Move all the AsciiDoc source files, and their build script, to the newly added `/AsciiDoc/` (root) folder to prevent cluttering the repository with unnecessary sources.

The `AsciiDoc/` folder will allow to store documents images and other assets (e.g. for syntax highlighting PureBasic/SpiderBasic source code excerpts) separately from the output HTML docs (which are self-contained) without introducing extra files in the target folders of these documents.

- Create new `AsciiDoc/` folder and move therein all the `.asciidoc` sources and the converter script from `Documentation/`.
- Adapt the `asciidoc2html.sh` script to build the HTML docs in the `Documentation/` folder.
- Externalize the "DON'T EDIT THIS DOCUMENT!!!" HTML comments warning to `inc_warn-editing.adoc` and replace its occurrence in the ADoc sources with an `include::` directive. Also, update the provided link to point to the new `AsciiDoc/` folder (instead of `Documentation/`).
- Add `AsciiDoc/README.md`.
- Exclude the `AsciiDoc/` folder from exported Zip archives.
- Add to `.editorconfig` code-styles rules for AsciiDoc files.
