### PR TITLE
PB Help EN » Residents: Add Prototypes

### DIFF
--- a/Documentation/English/Reference/residents.txt
+++ b/Documentation/English/Reference/residents.txt
@@ -3,7 +3,7 @@
 @Description
   Residents are precompiled files which are loaded when the compiler starts. They can be found in the 'residents'
   folder of the PureBasic installation path. A resident file must have the extension '.res' and can contain the
-  following items: @ReferenceLink "structures" "structures", @ReferenceLink "interfaces" "interfaces", 
+  following items: @ReferenceLink "structures" "structures", @ReferenceLink "interfaces" "interfaces", @ReferenceLink "prototypes" "prototypes", 
   @ReferenceLink "macros" "macros" and @ReferenceLink "general_rules" "constants". It can not contain
   dynamic code or @ReferenceLink "procedures" "procedures". @LineBreak
   @LineBreak


### PR DESCRIPTION
In PureBasic Help (English), `reference/prototypes`, add Prototypes to the list of allowed items in a resident file — (along with structures, interfaces, macros and constants. 

See #120 for more details.

