### PR TITLE
PB Help FR: Fix Broken HTML Table in "Règles de syntaxe générales"

### DIFF
--- a/Documentation/French/Reference/general_rules.txt
+++ b/Documentation/French/Reference/general_rules.txt
@@ -22,6 +22,7 @@
   <tr>  
     <td align="center" vAlign="center" nowrap><a href="#Texte multiligne"><u>Texte multiligne</u></a></td>
     <td align="center" vAlign="center" nowrap><a href="#Glossaire"><u>Glossaire</u></a></td>
+    <td></td>
   </tr>
     </table>
   </center>


### PR DESCRIPTION
At the beginning of the French PB documentation page _Règles de syntaxe générales_ there's an HTML table providing a sort of Table of Contents to the page topics. The last row of the table omitted a table cell  (which is empty), which caused the table borders to display oddly.

This commit adds the missing cell (`<td></td>`) to fix the problem an make all table borders look good.

