### PR TITLE
Fixed a number of typos (mostly misspelled 'separate/separately')

### DIFF
--- a/Documentation/English/Clipboard.txt
+++ b/Documentation/English/Clipboard.txt
@@ -9,7 +9,7 @@
 @Overview
 
   The clipboard is the standard way to share information and data between applications,
-  which are currently running on the OS. It also gives the user a temporary location,
+  which are currently running on the OS. It also gives the user a temporary location
   where information and data may be stored and accessed quickly and easily. For instance,
   when text is cut within an editor, that text goes to the clipboard, where it may be
   retrieved later, by pasting it into another application. PureBasic gives the programmer
@@ -28,7 +28,7 @@
 
 @Description
 
-  Clears the clipboard. This means that any data contained within the clipboard, is totally flushed and is no
+  Clears the clipboard. This means that any data contained within the clipboard, is flushed and no
   longer available from the clipboard.
 
 @NoParameters
@@ -44,7 +44,7 @@
 @Function Result = GetClipboardImage(#Image [, Depth])
 
 @Description
-  Creates a new image from the clipboard image data (if any). 
+  Creates a new image from the clipboard image data (if any).
 
 @Parameter "#Image"
   The number for the new image.
@@ -55,7 +55,7 @@
 
 @ReturnValue
   Returns nonzero on success and zero on failure.
-  If @#PB_Any was used as the #Image parameter then the new image number is returned.
+  If @#PB_Any was used as the #Image parameter, then the new image number is returned.
 
 @Remarks
   The image may be freed by using the @@FreeImage function.
@@ -91,7 +91,7 @@
 
 @Description
   Places a copy of the given image into the clipboard. If the clipboard currently
-  contains an image then it will be overwritten.
+  contains an image, then it will be overwritten.
 
 @Parameter "#Image"
   The image to put into the clipboard.
@@ -127,7 +127,7 @@
 @Parameter "Text$"
   The string you want to store in the clipboard.
 
-@NoReturnValue 
+@NoReturnValue
 
 @SeeAlso
   @@SetClipboardImage, @@ClearClipboard

--- a/Documentation/English/File.txt
+++ b/Documentation/English/File.txt
@@ -7,8 +7,8 @@
 @Library File
 
 @Overview
-  Files are the main method for storage on computers. PureBasic allows the programmer to create applications
-  in such a manner that the methods used to manage these files, are simple to use, and yet still optimized.
+  Files are the main method for storing data on computers. PureBasic allows the programmer to create applications
+  in such a manner that the methods used to manage these files are simple to use, and yet still optimized.
   Any number of files may be handled at the same time. This library uses buffered functions to increase the
   reading/writing speed. All the file functions can handle huge files, all the way up to: 2^64 bytes,
   (i.e. if the file-system supports it).
@@ -36,7 +36,7 @@
 @Function CloseFile(#File)
 
 @Description
-  Close the specified file. 
+  Close the specified file.
 
 @Parameter "#File"
   The file to close. If @#PB_All is specified, all the remaining files are closed.
@@ -64,7 +64,7 @@
 
 @Description
 
-  Create an empty file. 
+  Create an empty file.
 
 @Parameter "#File"
   The number to identify the new file. @ReferenceLink "purebasic_objects" "#PB_Any" can be used to
@@ -79,10 +79,10 @@
 @FixedFont
   @#PB_File_SharedRead : the opened file can be read by another process (Windows only).
   @#PB_File_SharedWrite: the opened file can be write by another process (Windows only).
-  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file. 
+  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file.
                         @@FileBuffersSize can not be used on this file.
 @EndFixedFont
-  combined with one of the following values (the following flags affect the @@WriteString(), @@WriteStringN, 
+  combined with one of the following values (the following flags affect the @@WriteString(), @@WriteStringN,
   @@ReadString, @@ReadCharacter and @@WriteCharacter behaviour):
 @FixedFont
   @#PB_Ascii  : all read/write string operation will use ascii if not specified otherwise.
@@ -95,7 +95,7 @@
   If @#PB_Any was used as the #File parameter then the new generated number is returned on success.
 
 @Remarks
-  If the file already exists, it will be overwritten by the new empty file. 
+  If the file already exists, it will be overwritten by the new empty file.
   The @@FileSize function can be used to determine whether a file exists so the
   user can be prompted before overwriting a file.
 @LineBreak
@@ -154,8 +154,8 @@
   Changes the size of the memory buffer used for file operations.
 
 @Parameter "#File"
-  The file to change. If @#PB_Default is used as this parameter then the
-  new buffer size will apply to all newly opened files with @@OpenFile, 
+  The file to change. If @#PB_Default is used as this parameter, then the
+  new buffer size will apply to all newly opened files with @@OpenFile,
   @@CreateFile or @@ReadFile.
 
 @Parameter "Size"
@@ -167,7 +167,7 @@
   For performance reasons, the buffer size should be kept large enough (1028 seems
   to be ok as a minimum). When buffers are used, the information is really written to the disk once the
   cache buffer is full or when the file is closed. The @@FlushFileBuffers function
-  forces the cache buffer to be written at the time the function is called. 
+  forces the cache buffer to be written at the time the function is called.
   The default buffer size is 4096 bytes per file.
 
 @SeeAlso
@@ -180,7 +180,7 @@
 @Function Result = FileID(#File)
 
 @Description
-  Returns the Operating system handle of the file.
+  Returns the operating system handle of the file.
 
 @Parameter "#File"
   The file to use.
@@ -198,7 +198,7 @@
 @Function FileSeek(#File, NewPosition.q [, Mode])
 
 @Description
-  Change the read/write pointer position in the file. 
+  Change the read/write pointer position in the file.
 
 @Parameter "#File"
   The file to use.
@@ -226,7 +226,7 @@
       Debug "Position: " + Str(Loc(0))      ; show actual file pointer position
       *MemoryID = AllocateMemory(10)        ; allocate the needed memory for 10 bytes
       If *MemoryID
-        bytes = ReadData(0, *MemoryID, 10)  ; read this last 10 chars in the file
+        bytes = ReadData(0, *MemoryID, 10)  ; read the last 10 chars in the file
         Debug PeekS(*MemoryID)
       EndIf
       CloseFile(0)
@@ -245,7 +245,7 @@
 @Function Result = FlushFileBuffers(#File)
 
 @Description
-  Ensures that all buffered operations are written to disk. 
+  Ensures that all buffered operations are written to disk.
 
 @Parameter "#File"
   The file to use.
@@ -267,7 +267,7 @@
 @Function Result = IsFile(#File)
 
 @Description
-  Tests if the given #File number is a valid and correctly initialized file. 
+  Tests if the given #File number is a valid and correctly initialized file.
 
 @Parameter "#File"
   The file to use.
@@ -345,7 +345,7 @@
 @Function Result = OpenFile(#File, Filename$ [, Flags])
 
 @Description
-  Opens a file for reading/writing or creates a new file if it does not exist. 
+  Opens a file for reading/writing or creates a new file if it does not exist.
 
 @Parameter "#File"
   The number to identify the file. @ReferenceLink "purebasic_objects" "#PB_Any" can be used to
@@ -361,10 +361,10 @@
   @#PB_File_SharedRead : the opened file can be read by another process (Windows only).
   @#PB_File_SharedWrite: the opened file can be write by another process (Windows only).
   @#PB_File_Append     : the file pointer position will be set at the end of file.
-  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file. 
+  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file.
                         @@FileBuffersSize can not be used on this file.
 @EndFixedFont
-  combined with one of the following values (the following flags affect the @@WriteString, @@WriteStringN, 
+  combined with one of the following values (the following flags affect the @@WriteString, @@WriteStringN,
   @@ReadString, @@ReadCharacter and @@WriteCharacter behaviour):
 @FixedFont
   @#PB_Ascii  : all read/write string operation will use ascii if not specified otherwise.
@@ -484,7 +484,7 @@
   @#PB_Ascii  : 1 byte character.
   @#PB_Unicode: 2 bytes character (default in @ReferenceLink "unicode" "unicode" mode).
   @#PB_UTF8   : multi-bytes character (from 1 to 4 bytes).
-@EndFixedFont  
+@EndFixedFont
 
 @ReturnValue
   Returns the read character or zero if there was an error.
@@ -542,7 +542,7 @@
                         this flag is needed to access it (Windows only).
   @#PB_File_SharedWrite: if the file has been already opened by another process for write operation,
                         this flag is needed to access it (Windows only).
-  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file. 
+  @#PB_File_NoBuffering: the internal PureBasic file buffering system will be disabled for this file.
                         @@FileBuffersSize can not be used on this file.
 @EndFixedFont
   combined with one of the following values (the following flags affect the @@ReadString and @@ReadCharacter behaviour):
@@ -744,7 +744,7 @@
 
 @Description
   Checks if the current file position contains a BOM (Byte Order Mark) and tries to identify the
-  String encoding used in the file. 
+  String encoding used in the file.
 
 @Parameter "#File"
   The file to use.
@@ -842,7 +842,7 @@
 @Function Result = WriteAsciiCharacter(#File, Number.a)
 
 @Description
-  Write an ascii character (1 byte) to a file. 
+  Write an ascii character (1 byte) to a file.
 
 @Parameter "#File"
   The file to write to.
@@ -855,7 +855,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 @LineBreak
 @LineBreak
@@ -884,7 +884,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -915,14 +915,14 @@
   @#PB_Ascii  : 1 byte character.
   @#PB_Unicode: 2 bytes character (default, see @ReferenceLink "unicode" "unicode" mode).
   @#PB_UTF8   : multi-bytes character (from 1 to 4 bytes).
-@EndFixedFont  
+@EndFixedFont
 
 @ReturnValue
   Returns nonzero if the operation was successful or zero if it failed.
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -952,7 +952,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -982,7 +982,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1012,7 +1012,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1042,7 +1042,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1076,7 +1076,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @Example
@@ -1105,7 +1105,7 @@
 @Function Result = WriteQuad(#File, Number.q)
 
 @Description
-  Write a quad number (8 bytes) to a file. 
+  Write a quad number (8 bytes) to a file.
 
 @Parameter "#File"
   The file to write to.
@@ -1118,7 +1118,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1135,7 +1135,7 @@
 @Function Result = WriteString(#File, Text$ [, Format])
 
 @Description
-  Write a string to a file. 
+  Write a string to a file.
 
 @Parameter "#File"
   The file to write to.
@@ -1156,7 +1156,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
   The null ending string character is not written to the file.
 @LineBreak
@@ -1178,7 +1178,7 @@
 @Function Result = WriteStringFormat(#File, Format)
 
 @Description
-  Writes a BOM (Byte Order Mark) at the current position in the file. 
+  Writes a BOM (Byte Order Mark) at the current position in the file.
 
 @Parameter "#File"
   The file to write to.
@@ -1204,7 +1204,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1232,7 +1232,7 @@
 @Function Result = WriteStringN(#File, Text$ [, Format])
 
 @Description
-  Write a string to a file and add an 'end of line' character. 
+  Write a string to a file and add an 'end of line' character.
 
 @Parameter "#File"
   The file to write to.
@@ -1253,7 +1253,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 @LineBreak
 @LineBreak
@@ -1287,7 +1287,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak
@@ -1304,7 +1304,7 @@
 @Function Result = WriteWord(#File, Number)
 
 @Description
-  Write a word number (2 bytes) to a file. 
+  Write a word number (2 bytes) to a file.
 
 @Parameter "#File"
   The file to write to.
@@ -1317,7 +1317,7 @@
 
 @Remarks
   Because of @Link "FileBuffersSize" "file buffering", this function may return successful even if there is not enough
-  space left on the output device for the write operation. 
+  space left on the output device for the write operation.
   The file must be opened using a write-capable function (i.e. not with @@ReadFile).
 
 @LineBreak

--- a/Documentation/English/FileSystem.txt
+++ b/Documentation/English/FileSystem.txt
@@ -8,7 +8,7 @@
 
 @Overview
 
-FileSystem is a generic term which deal with all advanced file related manipulations. For example, it's
+FileSystem is a generic term which deals with all advanced file related manipulations. For example, it's
 possible to read a directory content, create a new directory and more...
 @LineBreak
 @LineBreak
@@ -20,11 +20,11 @@ possible to read a directory content, create a new directory and more...
   can be used to modify the current directory.
 @LineBreak
 @LineBreak
-  Specific OS path seperator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
+  Specific OS path separator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
 @LineBreak
 @LineBreak
-  In addition to the functions in this library you will also functions for manipulating file contents in the @LibraryLink "file" "File"
-  library. To get the name of a running program use the function @@ProgramFilename from the 
+  In addition to the functions in this library you will also find functions for manipulating file contents in the @LibraryLink "file" "File"
+  library. To get the name of a running program use the function @@ProgramFilename from the
   @LibraryLink "process" "Process" library.
 
 @CommandList
@@ -38,7 +38,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = CopyDirectory(SourceDirectory$, DestinationDirectory$, Pattern$ [, Mode])
 
 @Description
-  Copy the contents of the source directory to the destination. 
+  Copy the contents of the source directory to the destination.
 
 @Parameter "SourceDirectory$"
   The directory to copy.
@@ -93,10 +93,10 @@ possible to read a directory content, create a new directory and more...
 @Remarks
   If the destination file already exists, it will be overwritten. The @@FileSize function
   can be used to determine if the target exists or not. If source file and destination file
-  are the same, a copy will not occurs and zero will be returned.
+  are the same, a copy will not occur and zero will be returned.
 
 @SeeAlso
-  @@RenameFile, @@DeleteFile, @@FileSize, 
+  @@RenameFile, @@DeleteFile, @@FileSize,
   @@CreateFile, @@OpenFile
 
 @SupportedOS
@@ -107,7 +107,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
 
-  Creates a new directory. 
+  Creates a new directory.
 
 @Parameter "DirectoryName$"
   The name of the new directory.
@@ -131,7 +131,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = DeleteDirectory(Directory$, Pattern$ [, Mode])
 
 @Description
-  Deletes the specified Directory$. 
+  Deletes the specified Directory$.
 
 @Parameter "Directory$"
   The directory to delete.
@@ -161,7 +161,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = DeleteFile(Filename$ [, Mode])
 
 @Description
-  Deletes the specified file. 
+  Deletes the specified file.
 
 @Parameter "Filename$"
   The file to delete.
@@ -169,15 +169,15 @@ possible to read a directory content, create a new directory and more...
 @OptionalParameter "Mode"
   Options for the delete operation. It can be one of the following values:
 @FixedFont
-  @#PB_FileSystem_Force: Also deletes the file which are protected (read-only).
+  @#PB_FileSystem_Force: Also deletes the files which are protected (read-only).
 @EndFixedFont
 
 @ReturnValue
   Returns nonzero if the operation was successful or zero if it failed.
 
 @SeeAlso
-  @@CopyFile, @@RenameFile, @@FileSize, 
-  @@CreateFile, @@OpenFile  
+  @@CopyFile, @@RenameFile, @@FileSize,
+  @@CreateFile, @@OpenFile
 
 @SupportedOS
 
@@ -187,7 +187,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   Returns the attributes of the current entry in the directory being listed with @@ExamineDirectory and
-  @@NextDirectoryEntry functions. 
+  @@NextDirectoryEntry functions.
 
 @Parameter "#Directory"
   The directory examined with @@ExamineDirectory.
@@ -218,7 +218,7 @@ possible to read a directory content, create a new directory and more...
   @#PB_FileSystem_ReadAll   : Access flags for all other users
   @#PB_FileSystem_WriteAll
   @#PB_FileSystem_ExecAll
-@EndFixedFont  
+@EndFixedFont
 
 
 @Remarks
@@ -226,12 +226,12 @@ possible to read a directory content, create a new directory and more...
 
 @Code
   [...]
-  
+
   FileAttributes = DirectoryEntryAttributes(#Directory)
   If FileAttributes & #PB_FileSystem_Hidden
     Debug "This file is hidden !"
   EndIf
-@EndCode  
+@EndCode
 
 @SeeAlso
   @@ExamineDirectory,
@@ -249,7 +249,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   Returns the date of the current entry in the directory being listed with @@ExamineDirectory and
-  @@NextDirectoryEntry functions. 
+  @@NextDirectoryEntry functions.
 
 @Parameter "#Directory"
   The directory examined with @@ExamineDirectory.
@@ -294,7 +294,7 @@ possible to read a directory content, create a new directory and more...
   Returns the name of the current directory entry.
 
 @Remarks
-  The pseudo-directories "." and ".." can be returned in a directory enumeration, so they have to be filtered if they should not 
+  The pseudo-directories "." and ".." can be returned in a directory enumeration, so they have to be filtered if they should not
   be included in the program output.
 
 @SeeAlso
@@ -303,7 +303,7 @@ possible to read a directory content, create a new directory and more...
   @@DirectoryEntryType,
   @@DirectoryEntrySize,
   @@DirectoryEntryAttributes,
-  @@DirectoryEntryDate  
+  @@DirectoryEntryDate
 
 @SupportedOS
 
@@ -313,7 +313,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   Returns the type of the current entry in the directory being listed with @@ExamineDirectory and
-  @@NextDirectoryEntry functions. 
+  @@NextDirectoryEntry functions.
 
 @Parameter "#Directory"
   The directory examined with @@ExamineDirectory.
@@ -355,7 +355,7 @@ possible to read a directory content, create a new directory and more...
   @@DirectoryEntryType,
   @@DirectoryEntryName,
   @@DirectoryEntryAttributes,
-  @@DirectoryEntryDate  
+  @@DirectoryEntryDate
 
 @SupportedOS
 
@@ -365,7 +365,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   Start to examine a directory for listing with the functions @@NextDirectoryEntry,
-  @@DirectoryEntryName and @@DirectoryEntryType. 
+  @@DirectoryEntryName and @@DirectoryEntryType.
 
 @Parameter "#Directory"
   A number to identify the new directory listing. @ReferenceLink "purebasic_objects" "#PB_Any" can be used as
@@ -376,7 +376,7 @@ possible to read a directory content, create a new directory and more...
 
 @Parameter "Pattern$"
   A pattern to filter the returned entries by.
-  For example: A 'Pattern$' like "*.*" or "" will list all the files (and sub-directories) in the directory. 
+  For example: A 'Pattern$' like "*.*" or "" will list all the files (and sub-directories) in the directory.
   A 'Pattern$' like "*.exe" will list only .exe files (and sub-directories ending with .exe if any).
 @LineBreak
 @LineBreak
@@ -391,13 +391,13 @@ possible to read a directory content, create a new directory and more...
   Once the enumeration is done, @@FinishDirectory must
   be called to free the resources associated to the listing.
 @LineBreak
-@LineBreak 
-  Specific OS path seperator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
+@LineBreak
+  Specific OS path separator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
 
 @Example
 @Code
   Directory$ = GetHomeDirectory() ; Lists all files and folder in the home directory
-  If ExamineDirectory(0, Directory$, "*.*")  
+  If ExamineDirectory(0, Directory$, "*.*")
     While NextDirectoryEntry(0)
       If DirectoryEntryType(0) = #PB_DirectoryEntry_File
         Type$ = "[File] "
@@ -406,7 +406,7 @@ possible to read a directory content, create a new directory and more...
         Type$ = "[Directory] "
         Size$ = "" ; A directory doesn't have a size
       EndIf
-      
+
       Debug Type$ + DirectoryEntryName(0) + Size$
     Wend
     FinishDirectory(0)
@@ -421,7 +421,7 @@ possible to read a directory content, create a new directory and more...
   @@DirectoryEntrySize,
   @@DirectoryEntryAttributes,
   @@DirectoryEntryDate
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -439,7 +439,7 @@ possible to read a directory content, create a new directory and more...
 
 @SeeAlso
   @@ExamineDirectory
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -447,7 +447,7 @@ possible to read a directory content, create a new directory and more...
 @Function Extension$ = GetExtensionPart(FullPathName$)
 
 @Description
-  Retrieves the file extension part of a full path. 
+  Retrieves the file extension part of a full path.
 
 @Parameter "FullPathName$"
   The full path to get the extension from.
@@ -472,7 +472,7 @@ possible to read a directory content, create a new directory and more...
 @Function Filename$ = GetFilePart(FullPathName$ [, Mode])
 
 @Description
-  Retrieves the file part of a full path. 
+  Retrieves the file part of a full path.
 
 @Parameter "FullPathName$"
   The full path to get the filename from.
@@ -512,13 +512,13 @@ possible to read a directory content, create a new directory and more...
 
 @Remarks
   To retrieve the extension or the file part from a full path, look at the
-  @@GetExtensionPart and @@GetFilePart 
+  @@GetExtensionPart and @@GetFilePart
   functions.
 
 @SeeAlso
   @@GetExtensionPart,
-  @@GetFilePart 
- 
+  @@GetFilePart
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -526,7 +526,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = IsDirectory(#Directory)
 
 @Description
-  Tests if the given directory number is a valid and correctly initialized directory enumeration. 
+  Tests if the given directory number is a valid and correctly initialized directory enumeration.
 
 @Parameter "#Directory"
   The directory enumeration to test.
@@ -538,7 +538,7 @@ possible to read a directory content, create a new directory and more...
   This function is bulletproof and can be used with any value. This is the correct way to ensure a directory is ready to use.
 
 @SeeAlso
-  @@ExamineDirectory  
+  @@ExamineDirectory
 
 @SupportedOS
 
@@ -548,21 +548,21 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   Checks if the specified Filename$ doesn't contain invalid characters for the file-system. For example, on Windows
-  '/' and '\' characters are not allowed in the filename. 
+  '/' and '\' characters are not allowed in the filename.
 
 @Parameter "Filename$"
   The filename to check without a path.
 
 @ReturnValue
   Returns nonzero if the filename does not contain invalid characters and zero if it does.
-  
+
 @Remarks
   Even if the syntax-check of this function doesn't complain, there are different 'forbidden' filenames on
   different OS. For example on Windows filenames containing "COM1" till "COM9", "LPT1" till "LPT9" or "aux"
   are not allowed. For more informations see @InternetLink "https://en.wikipedia.org/wiki/Filename" "here".
 
 @SupportedOS
-  
+
 ;--------------------------------------------------------------------------------------------------------
 
 @Function Result.q = FileSize(Filename$)
@@ -571,7 +571,7 @@ possible to read a directory content, create a new directory and more...
   Returns the size of the specified file. This function can also be used to check if a file or directory
   exists or not.
 
-@Parameter "Filename$" 
+@Parameter "Filename$"
   The filename to get the size from.
 
 @ReturnValue
@@ -583,7 +583,7 @@ possible to read a directory content, create a new directory and more...
 
 @SeeAlso
   @@DirectoryEntrySize
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -596,7 +596,7 @@ possible to read a directory content, create a new directory and more...
 @NoParameters
 
 @ReturnValue
-  Returns the full path of the current directory. 
+  Returns the full path of the current directory.
   It will end with a directory separator ('\', @#PS, @ConstantColor "#PS$" for Windows or '/', @#NPS, @ConstantColor "#NPS$" otherwise).
 @LineBreak
 @LineBreak
@@ -611,7 +611,7 @@ possible to read a directory content, create a new directory and more...
   @@GetHomeDirectory,
   @@GetUserDirectory,
   @@GetTemporaryDirectory
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -619,12 +619,12 @@ possible to read a directory content, create a new directory and more...
 @Function Result$ = GetHomeDirectory()
 
 @Description
-  Returns the home directory path of the currently logged user. 
+  Returns the home directory path of the currently logged user.
 
 @NoParameters
 
 @ReturnValue
-  Returns the full path of the home directory. 
+  Returns the full path of the home directory.
   It will end with a directory separator ('\', @#PS, @ConstantColor "#PS$" for Windows or '/', @#NPS, @ConstantColor "#NPS$" otherwise).
 @LineBreak
 @LineBreak
@@ -646,7 +646,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result$ = GetUserDirectory(Type)
 
 @Description
-  Returns the directory path of the specified directory type. 
+  Returns the directory path of the specified directory type.
 
 @Parameter "Type"
   The type of directory to get the path. It can be one of the following value:
@@ -658,7 +658,7 @@ possible to read a directory content, create a new directory and more...
   @#PB_Directory_Musics     : musics directory path of the current logged user
   @#PB_Directory_Pictures   : pictures directory path of the current logged user
   @#PB_Directory_Public     : public directory of the current logged user
-  @#PB_Directory_ProgramData: program data directory of the current logged user. 
+  @#PB_Directory_ProgramData: program data directory of the current logged user.
                              On Linux and OSX, it is the home directory followed by '/.' to be able to create
                              hidden config directory in the home user.
   @#PB_Directory_AllUserData: common program data directory (accessible to all users)
@@ -666,7 +666,7 @@ possible to read a directory content, create a new directory and more...
 @EndFixedFont
 
 @ReturnValue
-  Returns the full path of the specified directory. It will end with a directory separator 
+  Returns the full path of the specified directory. It will end with a directory separator
   ('\', @#PS, @ConstantColor "#PS$" for Windows or '/', @#NPS, @ConstantColor "#NPS$" otherwise).
   If the type is not found it will return an empty string.
 
@@ -682,19 +682,19 @@ possible to read a directory content, create a new directory and more...
 @Function Result$ = GetTemporaryDirectory()
 
 @Description
-  Returns the temporary directory name. 
+  Returns the temporary directory name.
 
 @NoParameters
 
 @ReturnValue
-  Returns the full path to the temporary directory. It will end with a directory separator 
+  Returns the full path to the temporary directory. It will end with a directory separator
   ('\', @#PS, @ConstantColor "#PS$" for Windows or '/', @#NPS, @ConstantColor "#NPS$" otherwise).
 @LineBreak
 @LineBreak
   It's very unlikely, but if this function fails, it will return an empty string.
 
 @Remarks
-  This directory provides read and write access and should be used to store temporary files. Depending on the operating system 
+  This directory provides read and write access and should be used to store temporary files. Depending on the operating system
   and settings, the contents of this directory may be deleted on a regular basis. It is however better to delete temporary files
   when they are no longer needed and not rely on such automatic cleanup.
 
@@ -709,7 +709,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = GetFileDate(Filename$, DateType)
 
 @Description
-  Returns the date of the specified file. 
+  Returns the date of the specified file.
 
 @Parameter "Filename$"
   The file to get the date from.
@@ -739,7 +739,7 @@ possible to read a directory content, create a new directory and more...
 @Function Attributes = GetFileAttributes(Filename$)
 
 @Description
-  Returns the attributes of the given file. 
+  Returns the attributes of the given file.
 
 @Parameter "Filename$"
   The file to read the attributes from. This can also specify the name of a directory.
@@ -771,7 +771,7 @@ possible to read a directory content, create a new directory and more...
   @#PB_FileSystem_ReadAll   : Access flags for all other users
   @#PB_FileSystem_WriteAll
   @#PB_FileSystem_ExecAll
-@EndFixedFont  
+@EndFixedFont
 
 @Remarks
   To check if one attribute is actually set, just use the '&' (binary AND) and the attribute constant value:
@@ -780,22 +780,22 @@ possible to read a directory content, create a new directory and more...
   If FileAttributes & #PB_FileSystem_Hidden
     Debug "This file is hidden !"
   EndIf
-@EndCode  
+@EndCode
 
 @Example
 @Code
-  Value = GetFileAttributes("c:\autoexec.bat") 
-  
-  If Value = -1 
+  Value = GetFileAttributes("c:\autoexec.bat")
+
+  If Value = -1
     Debug "Error reading file attributes!"
-  Else 
-    If Value & #PB_FileSystem_Hidden     : txt$ + "H" : Else : txt$+"-" : EndIf 
-    If Value & #PB_FileSystem_Archive    : txt$ + "A" : Else : txt$+"-" : EndIf 
-    If Value & #PB_FileSystem_Compressed : txt$ + "C" : Else : txt$+"-" : EndIf 
-    If Value & #PB_FileSystem_Normal     : txt$ + "N" : Else : txt$+"-" : EndIf 
-    If Value & #PB_FileSystem_ReadOnly   : txt$ + "R" : Else : txt$+"-" : EndIf 
-    If Value & #PB_FileSystem_System     : txt$ + "S" : Else : txt$+"-" : EndIf 
-    Debug txt$ 
+  Else
+    If Value & #PB_FileSystem_Hidden     : txt$ + "H" : Else : txt$+"-" : EndIf
+    If Value & #PB_FileSystem_Archive    : txt$ + "A" : Else : txt$+"-" : EndIf
+    If Value & #PB_FileSystem_Compressed : txt$ + "C" : Else : txt$+"-" : EndIf
+    If Value & #PB_FileSystem_Normal     : txt$ + "N" : Else : txt$+"-" : EndIf
+    If Value & #PB_FileSystem_ReadOnly   : txt$ + "R" : Else : txt$+"-" : EndIf
+    If Value & #PB_FileSystem_System     : txt$ + "S" : Else : txt$+"-" : EndIf
+    Debug txt$
   EndIf
 @EndCode
 
@@ -810,7 +810,7 @@ possible to read a directory content, create a new directory and more...
 
 @Description
   This function must be called after an @@ExamineDirectory. It will go step-by-step into
-  the directory and list its contents. 
+  the directory and list its contents.
 
 @Parameter "#Directory"
   The directory examined with @@ExamineDirectory
@@ -829,7 +829,7 @@ possible to read a directory content, create a new directory and more...
   @@DirectoryEntryName,
   @@DirectoryEntrySize,
   @@DirectoryEntryAttributes,
-  @@DirectoryEntryDate 
+  @@DirectoryEntryDate
 
 @SupportedOS
 
@@ -838,7 +838,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = RenameFile(OldFilename$, NewFilename$)
 
 @Description
-  Rename the old file to the new file. 
+  Rename the old file to the new file.
 
 @Parameter "OldFilename$"
   The old name of the file.
@@ -855,9 +855,9 @@ possible to read a directory content, create a new directory and more...
 
 @Example
 @Code
-  If RenameFile("C:\test.txt", "D:\temp\test_backup.txt")   
+  If RenameFile("C:\test.txt", "D:\temp\test_backup.txt")
     Debug "Moving and renaming successful."    ; Moving and renaming of the file was successful
-  Else 
+  Else
     Debug "Moving and renaming failed."        ; Moving and renaming failed, e.g. because of a not found source file
   EndIf
 @EndCode
@@ -872,7 +872,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = SetFileDate(Filename$, DateType, Date)
 
 @Description
-  Changes the date of the specified file. 
+  Changes the date of the specified file.
 
 @Parameter "Filename$"
   The name of the file to modify.
@@ -905,7 +905,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = SetFileAttributes(Filename$, Attributes)
 
 @Description
-  Set the attributes of the given Filename$. 
+  Set the attributes of the given Filename$.
 
 @Parameter "Filename$"
   The name of the file to modify. This can also specify the name of a directory.
@@ -913,7 +913,7 @@ possible to read a directory content, create a new directory and more...
 @Parameter "Attributes"
   The new attributes.
 @LineBreak
-@LineBreak 
+@LineBreak
   On Windows, 'Attributes' is a combination of the following values:
 @FixedFont
   @#PB_FileSystem_Hidden    : File is hidden
@@ -934,12 +934,12 @@ possible to read a directory content, create a new directory and more...
   @#PB_FileSystem_ReadAll   : Access flags for all other users
   @#PB_FileSystem_WriteAll
   @#PB_FileSystem_ExecAll
-@EndFixedFont  
-  
-  To combine several attributes, just use the '|' (binary OR) operand:  
+@EndFixedFont
+
+  To combine several attributes, just use the '|' (binary OR) operand:
 @Code
   SetFileAttributes("C:\Text.txt", #PB_FileSystem_Hidden | #PB_FileSystem_ReadOnly)
-@EndCode  
+@EndCode
 
 @ReturnValue
   Returns nonzero if the operation was successful and zero otherwise.
@@ -954,7 +954,7 @@ possible to read a directory content, create a new directory and more...
 @Function Result = SetCurrentDirectory(Directory$)
 
 @Description
-  Changes the current directory for the program. 
+  Changes the current directory for the program.
 
 @Parameter "Directory$"
   The full path to the new current directory, or a path relative to the existing current directory.
@@ -967,9 +967,9 @@ possible to read a directory content, create a new directory and more...
   no absolute path is specified. To get the current directory, use @@GetCurrentDirectory.
 @LineBreak
 @LineBreak
-  Specific OS path seperator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
+  Specific OS path separator characters are available @#PS, @#NPS, @ConstantColor "#PS$" ('\') and @ConstantColor "#NPS$" ('/').
 
 @SeeAlso
   @@GetCurrentDirectory
-  
+
 @SupportedOS

--- a/Documentation/English/Image.txt
+++ b/Documentation/English/Image.txt
@@ -12,8 +12,8 @@
   which are supported by the @LibraryLink "ImagePlugin" "ImagePlugin Library".
 @LineBreak
 @LineBreak
-  Transparent PNG images can be used to enable transparency in the @LibraryLink "Gadget" "gadgets", 
-  @LibraryLink "menu" "menu" and @LibraryLink "Toolbar" "toolbars" images. On Windows, transparent 
+  Transparent PNG images can be used to enable transparency in the @LibraryLink "Gadget" "gadgets",
+  @LibraryLink "menu" "menu" and @LibraryLink "Toolbar" "toolbars" images. On Windows, transparent
   ICON images can be used as well but PNG should be preferred as it works on all platforms.
   Transparency of BMP images is not supported.
 
@@ -57,7 +57,7 @@
   The image to remove a frame.
 
 @Parameter "Index"
-  The index (starting from 0) of the frame to remove. 
+  The index (starting from 0) of the frame to remove.
 
 @ReturnValue
   Returns nonzero if the frame has been successfully removed, zero otherwise.
@@ -98,7 +98,7 @@
   The image to use.
 
 @Parameter "Index"
-  The index (starting from 0) of the frame to set as current. 
+  The index (starting from 0) of the frame to set as current.
 
 @NoReturnValue
 
@@ -112,7 +112,7 @@
 @Function Result = ImageFrameCount(#Image)
 
 @Description
-  Returns the number of frames of the image. 
+  Returns the number of frames of the image.
 
 @Parameter "#Image"
   The image to get the frame count.
@@ -120,7 +120,7 @@
 @ReturnValue
   Returns the frame count of the image.
   If the image is not multi-frame, it will always return 1.
-  
+
 @SeeAlso
   @@CreateImage, @@AddImageFrame, @@RemoveImageFrame, @@SetImageFrame, @@GetImageFrame
 
@@ -131,15 +131,15 @@
 @Function Result = GetImageFrameDelay(#Image)
 
 @Description
-  Returns the display delay (in millisecond) for the current image frame. Each frame can have its own
+  Returns the display delay (in milliseconds) for the current image frame. Each frame can have its own
   delay.
 
 @Parameter "#Image"
   The image to get the frame delay.
 
 @ReturnValue
-  Returns the display delay (in millisecond) for the current image frame.
-  
+  Returns the display delay (in milliseconds) for the current image frame.
+
 @SeeAlso
   @@CreateImage, @@AddImageFrame, @@RemoveImageFrame, @@SetImageFrame, @@GetImageFrame, @@SetImageFrameDelay
 
@@ -150,15 +150,15 @@
 @Function Result = SetImageFrameDelay(#Image, Delay)
 
 @Description
-  Sets the display delay (in millisecond) for the current image frame. Each frame can have its own
+  Sets the display delay (in milliseconds) for the current image frame. Each frame can have its own
   delay.
 
 @Parameter "#Image"
   The image to set the frame delay.
 
 @ReturnValue
-  Sets the display delay (in millisecond) for the current image frame.
-  
+  Sets the display delay (in milliseconds) for the current image frame.
+
 @SeeAlso
   @@CreateImage, @@AddImageFrame, @@RemoveImageFrame, @@SetImageFrame, @@GetImageFrame, @@GetImageFrameDelay
 
@@ -169,7 +169,7 @@
 @Function Result = CatchImage(#Image, *MemoryAddress [, Size])
 
 @Description
-  Load the specified image from the given memory area. 
+  Load the specified image from the given memory area.
 
 @Parameter "#Image"
   A number to identify the loaded image. @ReferenceLink "purebasic_objects" "#PB_Any" can
@@ -179,7 +179,7 @@
   The memory address from which to load the image.
 
 @OptionalParameter "Size"
-  The size of the image in bytes. The size is optional as the loader can determine from the image when to 
+  The size of the image in bytes. The size is optional as the loader can determine from the image when to
   stop reading. It is however advisable to provide a size when loading unknown images, as the loader can then handle
   corrupted images correctly (without specifying the image size, a corrupt image can crash the program).
 
@@ -189,7 +189,7 @@
 
 @Remarks
   The limit for the image size that can be handled depends on the operating system and the available amount of memory.
-  If enough memory is available, then images up to at least 8192x8192 pixel can be handled by all operating systems supported by PureBasic.
+  If enough memory is available, then images up to at least 8192x8192 pixels can be handled by all operating systems supported by PureBasic.
 @LineBreak
 @LineBreak
   When an image is loaded, it is converted either in 24-bit (if the image depth
@@ -205,7 +205,7 @@
 @LineBreak
   The image can be in BMP, icon (.ico, only on Windows) or any other format supported by the ImagePlugin library.
   Transparency of BMP images is not supported.
-  The following functions can be used to enable automatically more image formats:
+  The following functions can be used to enable additional image formats:
 @LineBreak
 @LineBreak
   @@UseJPEGImageDecoder @LineBreak
@@ -214,19 +214,19 @@
   @@UseTIFFImageDecoder @LineBreak
   @@UseTGAImageDecoder @LineBreak
   @@UseGIFImageDecoder @LineBreak
-  
+
 @Example
 @Code
   CatchImage(0, ?Logo)
   End
 
   DataSection
-    Logo: 
+    Logo:
       IncludeBinary "Logo.bmp"
   EndDataSection
 @EndCode
   Note: The "?" is a pointer to a label. More information about pointers and memory access can be found
-  in the relating chapter @ReferenceLink "memory" "here". 
+  in the relating chapter @ReferenceLink "memory" "here".
 
 @SeeAlso
   @@CreateImage, @@LoadImage, @@FreeImage,
@@ -281,7 +281,7 @@
   Valid values can be: 24 and 32. The default is 24-bit if no depth is specified.
 
 @OptionalParameter "BackColor"
-  The back @@RGB color used when the image is created. This color can be set to @#PB_Image_Transparent to create an image with the 
+  The back @@RGB color used when the image is created. This color can be set to @#PB_Image_Transparent to create an image with the
   alpha channel set to full transparent. This only has an effect on 32-bit images. The default
   backcolor is black if not specified.
 
@@ -291,7 +291,7 @@
 
 @Remarks
   The limit for the image size that can be handled depends on the operating system and the available amount of memory.
-  If enough memory is available, then images up to at least 8192x8192 are can be handled by all operating systems supported by PureBasic.
+  If enough memory is available, then images up to at least 8192x8192 pixels can be handled by all operating systems supported by PureBasic.
 @LineBreak
 @LineBreak
   You can use the several other functions for acting with the created image:
@@ -320,7 +320,7 @@
 @Function *Buffer = EncodeImage(#Image [, ImagePlugin [, Flags [, Depth]]])
 
 @Description
-  Encode the specified image into a memory buffer. 
+  Encode the specified image into a memory buffer.
 
 @Parameter "#Image"
   The image to encode.
@@ -348,7 +348,7 @@
 
 @OptionalParameter "Depth"
   The depth in which to save the image. Valid values are 1, 4, 8, 24 and 32.
-  The default value is the original image depth. 
+  The default value is the original image depth.
   For now, only PNG encoder support palletized image format (1, 4 or 8-bit).
 
 @ReturnValue
@@ -356,7 +356,7 @@
   @@MemorySize can be used to get the size of the encoded image. @@FreeMemory has to be used to free the buffer
   after use.
 
-@SeeAlso 
+@SeeAlso
   @@LoadImage,
   @LibraryLink "ImagePlugin" "ImagePlugin library"
 
@@ -376,7 +376,7 @@
 
 @Remarks
   All remaining images are automatically freed when the program ends.
-  
+
 @SeeAlso
   @@CreateImage, @@LoadImage, @@CatchImage, @@CopyImage, @@GrabImage
 
@@ -403,7 +403,7 @@
 
 @Parameter "x, y, Width, Height"
   The location and size of the area to copy into the new image.
-  
+
 @ReturnValue
   Returns nonzero if the image was created successfully and zero if the image could not be created.
   If @#PB_Any was specified as the #Image2 parameter then the auto-generated number is returned on success.
@@ -443,12 +443,12 @@
 
 @Remarks
   When loading an image, PureBasic converts it either in 24-bit or in 32-bit, depending
-  if the source image got an alpha-channel or not. Every image which has a 
+  if the source image has an alpha-channel or not. Every image which has a
   depth less than 24-bit will be internally converted to 24-bit.
 
 @SeeAlso
   @@ImageWidth, @@ImageHeight
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -456,14 +456,14 @@
 @Function Result = ImageFormat(#Image)
 
 @Description
-  Return the original image format. 
+  Return the original image format.
 
 @Parameter "#Image"
   The image to use.
 
 @ReturnValue
   Returns the image original format. It can be one of the following value:
-@FixedFont  
+@FixedFont
   @#PB_ImagePlugin_JPEG
   @#PB_ImagePlugin_JPEG2000
   @#PB_ImagePlugin_PNG
@@ -473,10 +473,10 @@
   @#PB_ImagePlugin_ICON
   @#PB_ImagePlugin_GIF
 @EndFixedFont
-  If the image was not loaded from one of this format, it will return zero. This is the case for images created with
+  If the image was not loaded from one of these formats, it will return zero. This is the case for images created with
   @@CreateImage or @@GrabImage.
 
-@SeeAlso  
+@SeeAlso
   @@LoadImage, @@CreateImage, @@CatchImage, @@GrabImage,
   @LibraryLink "ImagePlugin" "ImagePlugin library"
 
@@ -484,7 +484,7 @@
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function Result = ImageHeight(#Image) 
+@Function Result = ImageHeight(#Image)
 
 @Description
   Returns the height of the given image.
@@ -496,7 +496,7 @@
   Returns the height of the image in pixels.
 
 @SeeAlso
-  @@ImageWidth, @@ImageDepth  
+  @@ImageWidth, @@ImageDepth
 
 @SupportedOS
 
@@ -518,7 +518,7 @@
   @@ImageGadget,
   @@ButtonImageGadget,
   @@CanvasGadget
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -559,14 +559,14 @@
 @Function VectorOutputID = ImageVectorOutput(#Image [, Unit])
 
 @Description
-  Returns the OutputID of the image to perform @LibraryLink "vectordrawing" "2D vector drawing operations" on it. 
+  Returns the OutputID of the image to perform @LibraryLink "vectordrawing" "2D vector drawing operations" on it.
   If the image is multi-frame, the current frame will be used.
 
 @Parameter "#Image"
   The image to draw on.
-  
+
 @OptionalParameter "Unit"
-  Specifies the unit used for measuring distances on the drawing output. 
+  Specifies the unit used for measuring distances on the drawing output.
   The default unit for images is @#PB_Unit_Pixel.
 @FixedFont
   @#PB_Unit_Pixel     : Values are measured in pixels (or dots in case of a printer)
@@ -610,7 +610,7 @@
 
 @SeeAlso
   @@ImageHeight, @@ImageDepth
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -618,7 +618,7 @@
 @Function Result = IsImage(#Image)
 
 @Description
-  Tests if the given image number is a valid and correctly initialized image. 
+  Tests if the given image number is a valid and correctly initialized image.
 
 @Parameter "#Image"
   The image to test.
@@ -627,11 +627,11 @@
   Returns nonzero if #Image is a valid image and zero if not.
 
 @Remarks
-  This function is bulletproof and can be used with any value. 
+  This function is bulletproof and can be used with any value.
   This is the correct way to ensure an image is ready to use.
 
 @SeeAlso
-  @@CreateImage, @@LoadImage, @@CatchImage, @@CopyImage, @@GrabImage  
+  @@CreateImage, @@LoadImage, @@CatchImage, @@CopyImage, @@GrabImage
 
 @SupportedOS
 
@@ -640,7 +640,7 @@
 @Function Result = LoadImage(#Image, Filename$ [, Flags])
 
 @Description
-  Load the specified image from a file. 
+  Load the specified image from a file.
 
 @Parameter "#Image"
   A number to identify the loaded image. @ReferenceLink "purebasic_objects" "#PB_Any" can
@@ -659,7 +659,7 @@
 
 @Remarks
   The limit for the image size that can be handled depends on the operating system and the available amount of memory.
-  If enough memory is available, then images up to at least 8192x8192 are can be handled by all operating systems supported by PureBasic.
+  If enough memory is available, then images up to at least 8192x8192 pixels are can be handled by all operating systems supported by PureBasic.
 @LineBreak
 @LineBreak
   When an image is loaded, it is converted either in 24-bit (if the image depth
@@ -707,7 +707,7 @@
 
 @Function Result = ResizeImage(#Image, Width, Height [, Mode])
 
-@Description  
+@Description
   Resize the #Image to the given dimension.
 
 @Parameter "#Image"
@@ -737,7 +737,7 @@
 @LineBreak
 @LineBreak
   The limit for the image size that can be handled depends on the operating system and the available amount of memory.
-  If enough memory is available, then images up to at least 8192x8192 are can be handled by all operating systems supported by PureBasic.
+  If enough memory is available, then images up to at least 8192x8192 pixels can be handled by all operating systems supported by PureBasic.
 
 @SeeAlso
   @@ImageWidth, @@ImageHeight
@@ -749,7 +749,7 @@
 @Function Result = SaveImage(#Image, Filename$ [, ImagePlugin [, Flags [, Depth]]])
 
 @Description
-  Saves the specified image to disk. 
+  Saves the specified image to disk.
 
 @Parameter "#Image"
   The image to save.
@@ -773,7 +773,7 @@
   quality is set to '7' if no flags are specified).
 @LineBreak
 @LineBreak
-  When an image is saved using palletized depth (1, 4 or 8), the following
+  When an image is saved using palettized depth (1, 4 or 8), the following
   flag is available for combination:
 @FixedFont
   @#PB_Image_FloydSteinberg: Apply a Floyd-Steinberg dithering.
@@ -781,13 +781,13 @@
 
 @OptionalParameter "Depth"
   The depth in which to save the image. Valid values are 1, 4, 8, 24 and 32.
-  The default value is the original image depth. 
+  The default value is the original image depth.
   For now, only BMP and PNG encoders support palletized image format (1, 4 or 8-bit).
 
 @ReturnValue
   Returns nonzero if the operation succeeded and zero if it failed.
 
-@SeeAlso 
+@SeeAlso
   @@ImageDepth,
   @LibraryLink "ImagePlugin" "ImagePlugin library"
 

--- a/Documentation/English/MainGuide/history.txt
+++ b/Documentation/English/MainGuide/history.txt
@@ -57,13 +57,13 @@
 - @Green "Added": HTTPRequest(), HTTPRequestMemory() (sponsored by c-wayne) @LineBreak
 - @Green "Added": UseMySQLDatabase() (sponsored by Paul) @LineBreak
 - @Green "Added": DPI aware support for Windows app @LineBreak
-- @Green "Added": #PS, #NPS, #PS$ and #NPS$ constants (Path seperator character depending of the OS) @LineBreak
+- @Green "Added": #PS, #NPS, #PS$ and #NPS$ constants (Path separator character depending of the OS) @LineBreak
 - @Green "Added": #PB_JSON_NoClear support to ExtractJSONStructure @LineBreak
 - @Green "Added": #PB_Path_Winding filling mode for VectorDrawing @LineBreak
 - @Green "Added": DesktopResolutionX(), DesktopResolutionY(), DesktopScaledX(), DesktopScaledY(), DesktopUnscaledX(), DesktopUnscaledY() @LineBreak
 - @Green "Added": an optional 'Mode' parameter for OpenConsole() @LineBreak
 - @Green "Added": MaterialTextureAliases()  @LineBreak
-- @Green "Added": #PB_Vehicle_IsInContact, #PB_Vehicle_ContactPointX/Y/Z for GetVehicleAttribute() @LineBreak 
+- @Green "Added": #PB_Vehicle_IsInContact, #PB_Vehicle_ContactPointX/Y/Z for GetVehicleAttribute() @LineBreak
 - @Green "Added": #PB_Vehicle_ContactPointNormalX/Y/Z for GetVehicleAttribute() @LineBreak
 - @Green "Added": #PB_Vehicle_CurrentSpeedKmHour, #PB_Vehicle_ForwardVectorX/Y/Z for GetVehicleAttribute() @LineBreak
 - @Green "Added": #PB_Material_ProjectiveTexturing for SetMaterialAttribute() @LineBreak
@@ -86,7 +86,7 @@
 
 @Section  12th September 2017 : Version 5.61
 - @Blue "Fixed": The touchbar issue on new MacBook Air and the DebugOutput problem on Windows. @LineBreak
-- @Blue "Fixed": Fix a lot of bugs. Notable bug fixes are prototype and quad return were 
+- @Blue "Fixed": Fix a lot of bugs. Notable bug fixes are prototype and quad return were
                  broken, MacBook Pro crash, and optionGadget on Windows now support keyboard. @LineBreak
 - @Green "Updated": MacOS X package is now self contained to be OSX Sierra compliant @LineBreak
 @LineBreak
@@ -96,7 +96,7 @@
 @Section  10th August 2017 : Version 5.45 LTS
 
 - @Blue "Fixed": The touchbar issue on new MacBook Air and the DebugOutput problem on Windows. @LineBreak
-- @Blue "Fixed": Fix a lot of bugs. Notable bug fixes are prototype and quad return were 
+- @Blue "Fixed": Fix a lot of bugs. Notable bug fixes are prototype and quad return were
                  broken, MacBook Pro crash, and optionGadget on Windows now support keyboard. @LineBreak
 - @Green "Updated": MacOS X package is now self contained to be OSX Sierra compliant @LineBreak
 @LineBreak
@@ -144,12 +144,12 @@
 @Section 19th November 2016 : Version 5.44 LTS
 
 - @Green  "Updated": A bug fix version of the current LTS branch. @LineBreak
-  It fix important Linux issues and brings a new way to install the app on OS X to comply 
-  with OSX Sierra. Now the whole purebasic directory is embedded in the PureBasic.app, 
-  so if you need to use the commandline, you will have to add the path 
+  It fix important Linux issues and brings a new way to install the app on OS X to comply
+  with OSX Sierra. Now the whole purebasic directory is embedded in the PureBasic.app,
+  so if you need to use the commandline, you will have to add the path
   PureBasic.app/MacOS/Content/Resources/compiler to the $PATH. @LineBreak
 
-@Section 25th July 2016 : Version Version 5.43 LTS 
+@Section 25th July 2016 : Version Version 5.43 LTS
 
 - @Green  "Updated": The new version of the long term support branch of PureBasic. @LineBreak
   All the fixes done on the 5.50 should be also in this version.@LineBreak
@@ -280,8 +280,8 @@ created using the '/IMPORT' switch of the pbcompiler. @LineBreak
 
 @Section 25th July 2014 : Version 5.23 LTS
 
-- @Blue "Fixed": The new LTS version which should include most of the latest fixes 
-  (excluding new IDE one, solved by the new Unicode mode). Some other fixes available 
+- @Blue "Fixed": The new LTS version which should include most of the latest fixes
+  (excluding new IDE one, solved by the new Unicode mode). Some other fixes available
   to 5.30 could be missing, as if we changed too many the internals of a lib, we don't
   want to push it in the old branches. So no fancy new stuff, just a stabilisation release.
 
@@ -2284,4 +2284,3 @@ created using the '/IMPORT' switch of the pbcompiler. @LineBreak
   - Built-in OS X API support (only for a few functions for now) @LineBreak
   - The IDE and debuggers are fully written in PureBasic, which prove the portability concept between OS X, Windows and Linux @LineBreak
   - Most of the PureBasic commandset is supported @LineBreak
-    

--- a/Documentation/English/Reference/module.txt
+++ b/Documentation/English/Reference/module.txt
@@ -9,13 +9,13 @@
   @Keyword Module <name>
     ...
   @Keyword EndModule
-  
+
   @Keyword UseModule <name>
   @Keyword UnuseModule <name>
 
 @Description
 
-  Modules are an easy way to isolate code part from the main code, allowing code reuse and sharing
+  Modules are an easy way to isolate code parts from the main code, allowing code reuse and sharing
   without risk of name conflict. In some other programming languages, modules are known as 'namespaces'.
   A module must have a @Keyword DeclareModule section (which is the public interface) and an associated
   @Keyword Module section (which is the implementation).
@@ -26,23 +26,23 @@
   to write specific code, as simple names can be reused within each module without risk of conflict.
 @LineBreak
 @LineBreak
-  Items allowed in the @Keyword DeclareModule section can be the following: procedure (only procedure declaration allowed), structure, macro, variable, 
+  Items allowed in the @Keyword DeclareModule section can be the following: procedure (only procedure declaration allowed), structure, macro, variable,
   constant, enumeration, array, list, map and label.
 @LineBreak
 @LineBreak
   To access a module item from outside the module, the module name has to be specified followed by the '::' separator. When explicitly specifying
   the module name, the module item is available everywhere in the code source, even in another module.
-  All items in the @Keyword DeclareModule section can be automatically imported into another module or in the main code using @Keyword UseModule. 
-  In this case, if a module name conflict, the module items won't be imported and a compiler error will be raised.
-  @Keyword UnuseModule remove the module items. @Keyword UseModule is not mandatory to access a module item, but the module name needs to be specified.
+  All items in the @Keyword DeclareModule section can be automatically imported into another module or in the main code using @Keyword UseModule.
+  In the case of a module name conflict, the module items won't be imported and a compiler error will be raised.
+  @Keyword UnuseModule removes the module items. @Keyword UseModule is not mandatory to access a module item, but the module name needs to be specified.
 @LineBreak
 @LineBreak
-  To share information between modules, a common module can be created and then used in every modules which needs it. It's the common way
+  To share information between modules, a common module can be created and then used in every module which needs it. It's the common way
   have global data available for all modules.
 @LineBreak
 @LineBreak
   Default items available in modules are all PureBasic commands, structure and constants. Therefore module items can not be named like
-  internal PureBasic commands, structure or constants.
+  internal PureBasic commands, structures or constants.
 @LineBreak
 @LineBreak
   All code put inside @Keyword DeclareModule and @Keyword Module sections is executed like any other code when the program flow reaches the module.
@@ -56,51 +56,51 @@
   for use when reusing and sharing it.
 
 @Example
-    
+
 @Code
-  
+
   ; Every items in this sections will be available from outside
   ;
   DeclareModule Ferrari
     #FerrariName$ = "458 Italia"
-    
+
     Declare CreateFerrari()
   EndDeclareModule
-  
+
   ; Every items in this sections will be private. Every names can be used without conflict
   ;
   Module Ferrari
-    
+
     Global Initialized = #False
-    
+
     Procedure Init() ; Private init procedure
       If Initialized = #False
         Initialized = #True
         Debug "InitFerrari()"
       EndIf
-    EndProcedure  
-      
+    EndProcedure
+
     Procedure CreateFerrari()
       Init()
       Debug "CreateFerrari()"
     EndProcedure
-    
+
   EndModule
-  
-  
+
+
   Procedure Init() ; Main init procedure, doesn't conflict with the Ferrari Init() procedure
     Debug "Main init()"
   EndProcedure
-  
+
   Init()
-  
+
   Ferrari::CreateFerrari()
   Debug Ferrari::#FerrariName$
-  
+
   Debug "------------------------------"
-  
+
   UseModule Ferrari ; Now import all public item directly in the main program scope
-  
+
   CreateFerrari()
   Debug #FerrariName$
 
@@ -109,38 +109,38 @@
 @Example With a common module
 
 @Code
-  
+
   ; The common module, which will be used by others to share data
   ;
   DeclareModule Cars
     Global NbCars = 0
   EndDeclareModule
-  
-  Module Cars 
+
+  Module Cars
   EndModule
-  
+
   ; First car module
   ;
   DeclareModule Ferrari
   EndDeclareModule
-  
+
   Module Ferrari
     UseModule Cars
-    
+
     NbCars+1
   EndModule
-  
+
   ; Second car module
   ;
   DeclareModule Porsche
   EndDeclareModule
-  
+
   Module Porsche
     UseModule Cars
-    
+
     NbCars+1
   EndModule
-  
+
   Debug Cars::NbCars
 
 @EndCode

--- a/Documentation/English/Reference/procedures.txt
+++ b/Documentation/English/Reference/procedures.txt
@@ -2,22 +2,22 @@
 
 @Syntax
 
-  @Keyword Procedure[.<type>] name(<parameter1[.<type>]> [, <parameter2[.<type>] [= DefaultValue]>, ...]) 
+  @Keyword Procedure[.<type>] name(<parameter1[.<type>]> [, <parameter2[.<type>] [= DefaultValue]>, ...])
     ...
     [@Keyword ProcedureReturn value]
-  @Keyword EndProcedure 
-  
+  @Keyword EndProcedure
+
 @Description
 
-  A @Keyword Procedure is a part of code independent from the main code which can have any parameters 
-  and it's own @ReferenceLink "variables" "variables". In PureBasic, a recurrence is fully supported for the procedures 
-  and any procedure can call it itself. At each call of the procedure the variables inside 
-  will start with a value of 0 (null). To access main code variables, they have to be shared 
-  them by using @ReferenceLink "Shared" Shared or @ReferenceLink "Global" Global keywords
-  (see also the @ReferenceLink "Protected" Protected and @ReferenceLink "Static" Static keywords). 
+  A @Keyword Procedure is a part of code independent from the main code which can have any parameters
+  and its own @ReferenceLink "variables" "variables". In PureBasic, a recurrence is fully supported for the procedures
+  and any procedure can call it itself. At each call of the procedure the variables inside
+  will start with a value of 0 (null). To access main code variables, they have to be shared
+  by using @ReferenceLink "Shared" Shared or @ReferenceLink "Global" Global keywords
+  (see also the @ReferenceLink "Protected" Protected and @ReferenceLink "Static" Static keywords).
   @LineBreak
   @LineBreak
-  The last parameters can have a default value (need to be a constant
+  The last parameters can have a default value (needs to be a constant
   expression), so if these parameters are omitted when the procedure is called, the default value will be used.
   @LineBreak
   @LineBreak
@@ -26,8 +26,8 @@
   @LineBreak
   @LineBreak
   A procedure can return a value or a string if necessary. You have to set the type after @Keyword Procedure
-  and use the @Keyword ProcedureReturn keyword at any moment inside the procedure. 
-  A call of @Keyword ProcedureReturn exits immediately the procedure, even when its called inside a loop. 
+  and use the @Keyword ProcedureReturn keyword at any moment inside the procedure.
+  A call of @Keyword ProcedureReturn exits immediately the procedure, even when its called inside a loop.
   @LineBreak
   @Keyword ProcedureReturn can't be used to return an @ReferenceLink "dim" "array", @ReferenceLink "newlist" "list" or a @ReferenceLink "newmap" "map".
   For this purpose pass the array, the list or the map as parameter to the procedure.
@@ -42,7 +42,7 @@
   @LineBreak
   @LineBreak
   Selected procedures can be executed asynchronously to the main program by using of @LibraryLink "thread" "threads".
-  
+
 
   @Example Procedure with a numeric variable as return-value
 
@@ -53,10 +53,10 @@
     Else
       Result = nb2
     Endif
-  
+
     ProcedureReturn Result
-  EndProcedure 
-  
+  EndProcedure
+
   Result = Maximum(15, 30)
   Debug Result
 @EndCode
@@ -67,7 +67,7 @@
 @Code
   Procedure.s Attach(String1$, String2$)
     ProcedureReturn String1$+" "+String2$
-  EndProcedure 
+  EndProcedure
 
   Result$ = Attach("PureBasic", "Coder")
   Debug Result$
@@ -82,7 +82,7 @@
   EndProcedure
 
   a(10, 12)      ; 2 will be used as default value for 3rd parameter
-  a(10, 12, 15) 
+  a(10, 12, 15)
 @EndCode
 
  @Example List as parameter
@@ -103,7 +103,7 @@
     ForEach ParameterList()
       MessageRequester("List", Str(ParameterList()\x))
     Next
- 
+
   EndProcedure
 
   DebugList(10, Test())
@@ -121,7 +121,7 @@
 
     ParameterTable(1, 2)\x = 3
     ParameterTable(2, 2)\x = 4
- 
+
   EndProcedure
 
   TestIt(10, Table())
@@ -155,8 +155,8 @@
 
 
 @Example Call a function by its name
-  
-@Code  
+
+@Code
    Prototype Function()
 
   Runtime Procedure Function1()
@@ -169,48 +169,48 @@
   EndProcedure
 
   LaunchProcedure("Function1") ; Display "I call Function1 by its name"
-@EndCode  
+@EndCode
 
 @LineBreak
-@LineBreak 
- 
+@LineBreak
+
 ; -------------------------------------------------------------------------------------------------
 @FormatIf HTML
 <br><hr><br>
 @FormatEndIf
 
-@Syntax 
+@Syntax
 
   @Keyword Declare[.<type>] name(<parameter1[.<type>]> [, <parameter2[.<type>] [= DefaultValue]>, ...])
 
-@Description 
+@Description
 
-  Sometimes a procedure need to call another procedure which isn't declared before its definition. 
-  This is annoying because the compiler will complain 'Procedure <name> not found'. @Keyword Declare can help 
-  in this particular case by declaring only the header of the procedure. Nevertheless, the @Keyword Declare 
+  Sometimes a procedure need to call another procedure which isn't declared before its definition.
+  This is annoying because the compiler will complain 'Procedure <name> not found'. @Keyword Declare can help
+  in this particular case by declaring only the header of the procedure. Nevertheless, the @Keyword Declare
   and real @Keyword Procedure declaration must be identical (including the correct type and optional parameters, if any).
   @LineBreak
   @LineBreak
-  For advanced programmers @Keyword DeclareC is available and will declare the procedure using 'CDecl' 
+  For advanced programmers @Keyword DeclareC is available and will declare the procedure using 'CDecl'
   instead of 'StandardCall' calling convention.
-  
+
   @Example
 
 @Code
   Declare Maximum(Value1, Value2)
-  
+
   Procedure Operate(Value)
     Maximum(10, 2)      ; At this time, Maximum() is unknown.
   EndProcedure
-  
+
   Procedure Maximum(Value1, Value2)
     ProcedureReturn 0
   EndProcedure
 @EndCode
 
 @LineBreak
-@LineBreak 
- 
+@LineBreak
+
 ; -------------------------------------------------------------------------------------------------
 @FormatIf HTML
 <br><hr><br>

--- a/Documentation/English/Sort.txt
+++ b/Documentation/English/Sort.txt
@@ -8,22 +8,22 @@
 
 @Overview
 
-  Sometimes, elements has to be sorted to be usable or more convenient. PureBasic offers
+  Sometimes, elements have to be sorted to be usable or more convenient. PureBasic offers
   highly optimized functions in order to sort @ReferenceLink "dim" "arrays" and @LibraryLink "List" "lists",
   either in ascending or descending order.
   @LineBreak
   @LineBreak
-  SortStructuredList and SortList use Mergesort which is a stable sort, so if you first sort 
-  all the list by titles and then again by album you will get a list which is sorted by album 
+  SortStructuredList and SortList use Mergesort which is a stable sort, so if you first sort
+  all the list by titles and then again by album you will get a list which is sorted by album
   and each album is sorted by title.
   @LineBreak
-  Note that this does not work with Arrays, as SortArray uses Quicksort which is unstable. 
-  (ie the sorting of the secondary key would be lost)
+  Note that this does not work with Arrays, as SortArray uses Quicksort which is unstable.
+  (ie. the sorting of the secondary key would be lost)
   @LineBreak
   @LineBreak
   Furthermore there are functions to reorder the elements of an array or a list in a random order.
 
-  
+
 @CommandList
 
   @ExampleFile All Sort_(Numeric).pb
@@ -39,7 +39,7 @@
 
   Sorts the specified @ReferenceLink "dim" "array", according to the given options. The array may be of one of
   @ReferenceLink "variables" "basic type": byte, word, long, integer, string or float. For structured
-  array, use @@SortStructuredArray. Multi-dimensioned arrays are not supported.
+  arrays, use @@SortStructuredArray. Multi-dimensioned arrays are not supported.
 
 @Parameter "ArrayName()"
   The array to sort.
@@ -49,7 +49,7 @@
 @FixedFont
   @#PB_Sort_Ascending : Sort the array in ascending order (lower values first)
   @#PB_Sort_Descending: Sort the array in descending order (higher values first)
-  @#PB_Sort_NoCase    : Sort the string array without case sensitive (a=A, b=B etc..)
+  @#PB_Sort_NoCase    : Sort the string array without case sensitivity (a=A, b=B etc..)
 @EndFixedFont
 
 @OptionalParameter "Start, End"
@@ -59,14 +59,14 @@
 @NoReturnValue
 
 @Remarks
-  If an array is not fully filled then null elements will be sorted first in ascending order and
+  If an array is not fully filled, then null elements will be sorted first in ascending order and
   last in descending order.
   @LineBreak
   @Link "Math/IsNaN" "NaN numbers" are not accepted when sorting as it produces random results.
-  
+
 @SeeAlso
   @@SortStructuredArray, @@RandomizeArray
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
@@ -78,7 +78,7 @@
   Sorts the specified @LibraryLink "List" "list", according to the given options. The list may be of one of
   @ReferenceLink "variables" "basic type": byte, word, long, integer, string or float.
   For structured list, use @@SortStructuredList.
-  
+
 @Parameter "ListName()"
   The list to sort.
 
@@ -87,7 +87,7 @@
 @FixedFont
   @#PB_Sort_Ascending : Sort the list in ascending order (lower values first)
   @#PB_Sort_Descending: Sort the list in descending order (higher values first)
-  @#PB_Sort_NoCase    : Sort the string list without case sensitive (a=A, b=B etc..)
+  @#PB_Sort_NoCase    : Sort the string list without case sensitivity (a=A, b=B etc..)
 @EndFixedFont
 
 @OptionalParameter "Start, End"
@@ -109,7 +109,7 @@
 
 @Description
 
-  Sorts the specified structured @ReferenceLink "dim" "array", according to the given options. 
+  Sorts the specified structured @ReferenceLink "dim" "array", according to the given options.
   The array must have an associated @ReferenceLink "Structures" "structure".
 
 @Parameter "ArrayName()"
@@ -120,16 +120,16 @@
 @FixedFont
   @#PB_Sort_Ascending : Sort the array in ascending order (lower values first)
   @#PB_Sort_Descending: Sort the array in descending order (higher values first)
-  @#PB_Sort_NoCase    : Sort the string array without case sensitive (a=A, b=B etc..)
+  @#PB_Sort_NoCase    : Sort the string array without case sensitivity (a=A, b=B etc..)
 @EndFixedFont
 
 @Parameter "OffsetOf(Structure\Field)"
   Offset of the field in the structure.
   @ReferenceLink "compilerfunctions" "OffsetOf()" may be used to retrieve the field offset in the structure associated to the array.
-  
+
 @Parameter "TypeOf(Structure\Field)"
-  The field type of the field in the structure. It has to match the real structure field type. 
-  @ReferenceLink "compilerfunctions" "TypeOf()" may be used to automatically retrieve the field type. 
+  The field type of the field in the structure. It has to match the real structure field type.
+  @ReferenceLink "compilerfunctions" "TypeOf()" may be used to automatically retrieve the field type.
   Available types are:
 @FixedFont
   @#PB_Byte     : The structure field to sort is a byte (.b)
@@ -151,7 +151,7 @@
 
 @Remarks
   @ReferenceLink "variables" "Fixed strings" are not supported by the sort routine.
-  If an array is not fully filled then null elements will be sorted first in ascending order and last in descending order. 
+  If an array is not fully filled, then null elements will be sorted first in ascending order and last in descending order.
   @LineBreak
   @Link "Math/IsNaN" "NaN numbers" are not accepted when sorting as it produces random results.
 
@@ -203,7 +203,7 @@
 
 @Description
 
-  Sorts the specified structured @LibraryLink "List" "list", according to the given options. 
+  Sorts the specified structured @LibraryLink "List" "list", according to the given options.
   The list must have an associated @ReferenceLink "Structures" "structure".
 
 @Parameter "ListName()"
@@ -214,16 +214,16 @@
 @FixedFont
   @#PB_Sort_Ascending : Sort the list in ascending order (lower values first)
   @#PB_Sort_Descending: Sort the list in descending order (higher values first)
-  @#PB_Sort_NoCase    : Sort the string list without case sensitive (a=A, b=B etc..)
+  @#PB_Sort_NoCase    : Sort the string list without case sensitivity (a=A, b=B etc..)
 @EndFixedFont
 
 @Parameter "OffsetOf(Structure\Field)"
   Offset of the field in the structure.
   @ReferenceLink "compilerfunctions" "OffsetOf()" may be used to retrieve the field offset in the structure associated to the list.
-  
+
 @Parameter "TypeOf(Structure\Field)"
-  The field type of the field in the structure. It has to match the real structure field type. 
-  @ReferenceLink "compilerfunctions" "TypeOf()" may be used to automatically retrieve the field type. 
+  The field type of the field in the structure. It has to match the real structure field type.
+  @ReferenceLink "compilerfunctions" "TypeOf()" may be used to automatically retrieve the field type.
   Available types are:
 @FixedFont
   @#PB_Byte     : The structure field to sort is a byte (.b)
@@ -244,7 +244,7 @@
   are not specified, then the whole list is sorted.
   @LineBreak
   The first list element is at position 0, the next at 1 and so on.
-  
+
 @Remarks
   @ReferenceLink "variables" "Fixed strings" are not supported by the sort routine.
 
@@ -310,7 +310,7 @@
 @NoReturnValue
 
 @Remarks
-  This function uses the pseudorandom number generator of the @@Random function to determine the new order of the array elements. 
+  This function uses the pseudorandom number generator of the @@Random function to determine the new order of the array elements.
   It is therefore dependent on the current @@RandomSeed.
 
 @SeeAlso
@@ -337,7 +337,7 @@
 @NoReturnValue
 
 @Remarks
-  This function uses the pseudorandom number generator of the @@Random function to determine the new order of the list elements. 
+  This function uses the pseudorandom number generator of the @@Random function to determine the new order of the list elements.
   It is therefore dependent on the current @@RandomSeed.
 
 @SeeAlso

--- a/Documentation/English/String.txt
+++ b/Documentation/English/String.txt
@@ -8,7 +8,7 @@
 
 @Overview
   Strings are the method used in order to store a list of characters. With the functions supplied in
-  this library, many essential actions may be performed upon strings. By default, Strings are seen 
+  this library, many essential actions may be performed upon strings. By default, Strings are seen
   as unicode strings.
 
 @CommandList
@@ -28,7 +28,7 @@
   The string to get the first character value.
 
 @ReturnValue
-  The string first character value. 
+  The string first character value.
 
 @Example
 @Code
@@ -95,7 +95,7 @@
   Debug RSet(Bin(32), 16, "0") ; Will display "0000000000100000"
 @EndCode
 
-@SeeAlso 
+@SeeAlso
   @@Str, @@Val, @@Hex
 
 @SupportedOS
@@ -167,7 +167,7 @@
 @Function Result$ = EscapeString(String$ [, Mode])
 
 @Description
-  Returns the escaped version of the string. @@UnescapeString can be used to 
+  Returns the escaped version of the string. @@UnescapeString can be used to
   do the reverse operation.
 
 @Parameter "String$"
@@ -192,7 +192,7 @@
   Debug EscapeString("<item>Hello</item>", #PB_String_EscapeXML) ; Will display "&lt;item&gt;Hello&lt;/item&gt;"
 @EndCode
 
-@SeeAlso 
+@SeeAlso
   @@UnescapeString
 
 @SupportedOS
@@ -203,17 +203,17 @@
 
 @Description
   Find the 'StringToFind$' within the given 'String$'.
-  
+
 @Parameter "String$"
   The string to use.
-  
+
 @Parameter "StringToFind$"
   The string to find.
-  
+
 @OptionalParameter "StartPosition"
-  The start position to begin the search. The first valid character index is 1. 
+  The start position to begin the search. The first valid character index is 1.
   If this parameter isn't specified, the whole string is searched.
-  
+
 @OptionalParameter "Mode"
   It can be one of the following values:
 @FixedFont
@@ -236,7 +236,7 @@
 
 @Description
   Converts a quad numeric number into a string, in hexadecimal format.
-    
+
 @Parameter "Value.q"
   The number to convert.
 
@@ -276,7 +276,7 @@
   Debug Hex(-1, #PB_Quad)    ; quad value is the default
 @EndCode
 
-@SeeAlso 
+@SeeAlso
   @@Str, @@Val, @@Bin
 
 @SupportedOS
@@ -290,10 +290,10 @@
 
 @Parameter "String$"
   The string to use.
-  
+
 @Parameter "StringToInsert$"
   The string to insert.
-  
+
 @Parameter "Position"
   The position in the string to insert the new string. The first position index is 1.
 
@@ -306,7 +306,7 @@
   Debug InsertString("Hello !", "World", 1)  ; Will display "WorldHello !"
 @EndCode
 
-@SeeAlso 
+@SeeAlso
   @@RemoveString
 
 @SupportedOS
@@ -320,7 +320,7 @@
 
 @Parameter "String$"
   The string to convert into lowercase.
-  
+
 @ReturnValue
   The string converted into lowercase.
 
@@ -350,7 +350,7 @@
 @Parameter "Length"
   The number of characters to return. If this value exceeds the number of characters
   of the string, it will be returns the whole string.
-  
+
 @ReturnValue
   A string holding the specified number of characters from the left side of the string.
 
@@ -398,7 +398,7 @@
   The total length (in characters) of the new string.
 
 @OptionalParameter "Character$"
-  The character used to pad extra space in the new string. The default character is 'space'. 
+  The character used to pad extra space in the new string. The default character is 'space'.
   'Character$' has to be a one character length string.
 
 @ReturnValue
@@ -406,7 +406,7 @@
   length.
 
 @Remarks
-  If the string is longer than the specified length, it will be truncated starting from 
+  If the string is longer than the specified length, it will be truncated starting from
   the right side of the string.
 
 @Example
@@ -426,7 +426,7 @@
 @Function Result$ = LTrim(String$ [, Character$])
 
 @Description
-  Removes all the specified characters located in the front of a string. 
+  Removes all the specified characters located in the front of a string.
 
 @Parameter "String$"
   The string to trim.
@@ -455,7 +455,7 @@
 
 @Description
   Extracts a string of specified length from the given string.
-  
+
 @Parameter "String$"
   The string to use.
 
@@ -468,7 +468,7 @@
 
 @ReturnValue
   A new string holding the extracted characters.
-  
+
 @Example
 @Code
   Debug Mid("Hello", 2) ; Will display "ello"
@@ -535,7 +535,7 @@
 
 @Parameter "ReplacementString$"
   The string to use as replacement.
-  
+
 @OptionalParameter "Mode"
   It can be a combination of the following values:
 @FixedFont
@@ -544,7 +544,7 @@
   @#PB_String_InPlace: In-place replacing. This means that the string is replaced directly in the memory.
                       The 'StringToFind$' and 'ReplacementString$' parameter must have the same length. This is
                       a dangerous option, for advanced users only. The advantage is the very high speed of the
-                      replacement. When using this option, the result of ReplaceString() has to be ignored. 
+                      replacement. When using this option, the result of ReplaceString() has to be ignored.
                       Only the string passed in parameter 'String$' is changed and it's the result.
 @EndFixedFont
 
@@ -566,7 +566,7 @@
   test$ = "Hello again, hello again"
   Result$ = ReplaceString(test$, "HELLO", "oh no...", 1, 10) ; Will display "Hello again, oh no... again"
   Debug Result$
-  
+
   test$ = "Bundy, Barbie, Buddy"
   ReplaceString(test$, "B", "Z", 2, 1)  ; all B gets changed to Z  (directly in memory, no valid return-value here)
   Debug test$   ; Output of the changed string and will display "Zundy, Zarbie, Zuddy"
@@ -590,7 +590,7 @@
 @Parameter "Length"
   The number of characters to return. If this value exceeds the number of characters
   of the string, it will be returns the whole string.
-  
+
 @ReturnValue
   A string holding the specified number of characters from the right side of the string.
 
@@ -626,7 +626,7 @@
   length.
 
 @Remarks
-  If the string is longer than the specified length, it will be truncated starting from 
+  If the string is longer than the specified length, it will be truncated starting from
   the right side of the string.
 
 @Example
@@ -646,7 +646,7 @@
 @Function Result$ = RTrim(String$ [, Character$])
 
 @Description
-  Removes all the specified characters located at the end of a string. 
+  Removes all the specified characters located at the end of a string.
 
 @Parameter "String$"
   The string to trim.
@@ -674,8 +674,8 @@
 @Function Result = StringByteLength(String$ [, Format])
 
 @Description
-  Returns the number of bytes required to store the string in memory in a given format. 
-  
+  Returns the number of bytes required to store the string in memory in a given format.
+
 @Parameter "String$"
   The string to use.
 
@@ -689,7 +689,7 @@
   If omitted, the mode of the executable (@ReferenceLink "unicode" "unicode" or ascii) is used.
 
 @ReturnValue
-  The number of bytes required to store the string in memory in a given format. 
+  The number of bytes required to store the string in memory in a given format.
 
 @Remarks
   The number of bytes returned does not include the terminating Null-Character of the string.
@@ -745,7 +745,7 @@
   A string holding the converted value.
 
 @Remarks
-  Signed integer numbers have to be converted with @@Str and unsigned numbers with @@StrU. 
+  Signed integer numbers have to be converted with @@Str and unsigned numbers with @@StrU.
   It is possible to omit this command when concatenating string and float, it will then use the default behaviour of @@StrF.
 
 @Example
@@ -780,7 +780,7 @@
   A string holding the converted value.
 
 @Remarks
-  Signed integer numbers have to be converted with @@Str and unsigned numbers with @@StrU. 
+  Signed integer numbers have to be converted with @@Str and unsigned numbers with @@StrU.
   It is possible to omit this command when concatenating string and double, it will then use the default behaviour of @@StrD.
 
 @Example
@@ -811,7 +811,7 @@
   A string holding the converted value.
 
 @Remarks
-  Floats must be converted with @@StrF, doubles with @@StrD and unsigned numbers with @@StrU. 
+  Floats must be converted with @@StrF, doubles with @@StrD and unsigned numbers with @@StrU.
   It is possible to omit this command when concatenating string and integer, it will then use the default behaviour of @@Str.
 
 @Example
@@ -947,7 +947,7 @@
 
 @Parameter "String$"
   The string to convert into uppercase.
-  
+
 @ReturnValue
   The string converted into uppercase.
 
@@ -969,7 +969,7 @@
 @Function Result$ = UnescapeString(String$ [, Mode])
 
 @Description
-  Returns the unescaped version of the string. @@EscapeString can be used to 
+  Returns the unescaped version of the string. @@EscapeString can be used to
   do the reverse operation.
 
 @Parameter "String$"
@@ -994,7 +994,7 @@
   Debug UnescapeString("&lt;item&gt;Hello&lt;/item&gt;", #PB_String_EscapeXML) ; Will display "<item>Hello</item>"
 @EndCode
 
-@SeeAlso 
+@SeeAlso
   @@EscapeString
 
 @SupportedOS
@@ -1100,13 +1100,13 @@
   The Ascii representation of the string.
 
 @Remarks
-  This function is mainly useful when interacting with third-party libraries which requiers Ascii as input. 
+  This function is mainly useful when interacting with third-party libraries which requiers Ascii as input.
   @ReferenceLink "pseudotypes" "Pseudotype" 'p-ascii' can also be used to automated the converting process when importing external
   functions.
 @LineBreak
 @LineBreak
   The buffer includes a null-terminated character.
-  
+
 @Example
 @Code
   *Ascii = Ascii("Hélé")
@@ -1133,7 +1133,7 @@
   The UTF8 representation of the string.
 
 @Remarks
-  This function is mainly useful when interacting with third-party libraries which requiers UTF8 as input. 
+  This function is mainly useful when interacting with third-party libraries which requiers UTF8 as input.
   @ReferenceLink "pseudotypes" "Pseudotype" 'p-utf8' can also be used to automated the converting process when importing external
   functions.
 @LineBreak
@@ -1144,7 +1144,7 @@
 @Code
   *UTF8 = UTF8("Hélé")
   ShowMemoryViewer(*UTF8, MemorySize(*UTF8))
-  
+
   Debug PeekS(*UTF8, -1, #PB_UTF8) ; Displays "Hélé"
 @EndCode
 
@@ -1158,10 +1158,10 @@
   *Mem2 = UTF8("Test - éàîöÊÜ")
 
   Text.s = Unicode(*Mem1)
-  Debug Text 
+  Debug Text
 
   Text2.s = Unicode(*Mem2, #PB_UTF8)
-  Debug Text2 
+  Debug Text2
 @EndCode
 
 @SeeAlso
@@ -1171,7 +1171,7 @@
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function Result$ = FormatNumber(Number.d [, NbDecimals [, DecimalPoint$ [, ThousandSeperator$]]])
+@Function Result$ = FormatNumber(Number.d [, NbDecimals [, DecimalPoint$ [, ThousandSeparator$]]])
 
 @Description
   Format a number into money-like format.
@@ -1185,7 +1185,7 @@
 @OptionalParameter "DecimalPoint$"
   The string to use to split the decimal and integer parts. It can be a multiple character string. Default value is ".".
 
-@OptionalParameter "ThousandSeperator$"
+@OptionalParameter "ThousandSeparator$"
   The string to use to separate thousands. It can be a multiple character string. Default value is ",".
 
 @ReturnValue

--- a/Documentation/German/Reference/data.txt
+++ b/Documentation/German/Reference/data.txt
@@ -158,7 +158,7 @@
 
   Dieses Schlüsselwort ist nützlich, um die Startposition für ein nachfolgendes @Keyword "Read" auf eine angegebene 
   Sprungmarke (Label) zu setzen. Alle für diesen Zweck verwendeten Sprungmarken sollten sich innerhalb einer
-  @Keyword "DataSection" (des Datenabschnitts) befinden, da die Daten beim Kompilieren als ein vom Programmcode seperater Block 
+  @Keyword "DataSection" (des Datenabschnitts) befinden, da die Daten beim Kompilieren als ein vom Programmcode separater Block 
   behandelt werden und möglicherweise von einer Sprungmarke getrennt werden, wenn die Sprungmarke außerhalb
   der @Keyword "DataSection" platziert wurde.
      

--- a/Documentation/German/Toolbar.txt
+++ b/Documentation/German/Toolbar.txt
@@ -11,7 +11,7 @@
   Icons schnellen Zugriff auf einige Funktionen der Applikation zu erhalten.
   Die Icons sind oftmals 'Shortcuts' (Kürzel) von Menüpunkten. PureBasic ermöglicht die
   Erstellung einer beliebigen Zahl von Toolbars und deren Handhabung als wären
-  es Menüs. 
+  es Menüs.
 
 @CommandList
 
@@ -43,12 +43,12 @@
   - @#PB_ToolBar_Text      : Text wird unterhalb des Schalters dargestellt
   - @#PB_ToolBar_InlineText: Text wird rechts vom Schalter dargestelt (nur auf Windows)
 @EndFixedFont
-  
+
 @ReturnValue
   Gibt einen Wert ungleich Null zurück, wenn die Werkzeugleiste erfolgreich erstellt
   wurde, und Null wenn nicht. Wenn @#PB_Any als #ToolBar Parameter verwendet wurde,
   dann wird im Erfolgsfall die generierte Nummer zurückgegeben.
-  
+
 @Remarks
   Diese Toolbar wird die aktuelle Toolbar für die Erstellung, zu der mittels
   @@ToolBarStandardButton, @@ToolBarImageButton und @@ToolBarSeparator einige
@@ -56,7 +56,7 @@
 @LineBreak
 @LineBreak
   Die Ereignisse werden genauso wie Menü-Ereignisse behandelt, mittels der Funktion
-  @@EventMenu. Werkzeugleisten werden oft als Kürzel für Menü-Einträge verwendet - 
+  @@EventMenu. Werkzeugleisten werden oft als Kürzel für Menü-Einträge verwendet -
   wenn daher die gleiche Menü-Eintrag-Nummer zu einem Werkzeugleisten-Schalter
   zugewiesen wird, werden beide Ereignisse durch den gleichen Code behandelt.
 
@@ -73,12 +73,12 @@
       If Event = #PB_Event_Menu
         Debug "ToolBar ID: "+Str(EventMenu())
       EndIf
-    Until Event = #PB_Event_CloseWindow 
+    Until Event = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
 @Image createtoolbar.png
-  
+
 @SeeAlso
   @@ToolBarStandardButton, @@ToolBarImageButton, @@ToolBarSeparator, @@FreeToolBar
 
@@ -94,10 +94,10 @@
 @Parameter "#ToolBar"
   Die freizugebende Werkzeugleiste. Wenn @#PB_All angegeben wird, dann werden alle verbliebenen
   Werkzeugleisten freigegeben.
-  
+
 @NoReturnValue
 
-@Remarks  
+@Remarks
   Alle verbleibenden Werkzeugleisten werden automatisch freigegeben, wenn das Programm endet.
 
 @SeeAlso
@@ -111,7 +111,7 @@
 
 @Description
   Deaktiviert (oder aktiviert) einen Werkzeugleisten-Schalter auf der angegebenen Werkzeugleiste.
-  
+
 @Parameter "#ToolBar"
   Die zu verwendende Werkzeugleiste.
 
@@ -151,7 +151,7 @@
           EndIf
         EndIf
       EndIf
-    Until Event = #PB_Event_CloseWindow 
+    Until Event = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
@@ -169,7 +169,7 @@
 @Description
   Ermittelt den Status des angegebenen Werkzeugleisten-Schalters.
   Der Schalter muss mittels des @#PB_ToolBar_Toggle Modus erstellt worden sein.
-  
+
 @Parameter "#ToolBar"
   Die zu verwendende Werkzeugleiste.
 
@@ -202,7 +202,7 @@
 @ReturnValue
   Gibt einen Wert ungleich Null zurück, wenn #ToolBar eine gültige Werkzeugleiste ist,
   andernfalls Null.
-  
+
 @Remarks
   Diese Funktion ist "kugelsicher" und kann mit jedem Wert benutzt werden. Ist das 'Ergebnis'
   ungleich Null, dann ist das Objekt gültig und initialisiert, andernfalls wird Null zurückgegeben.
@@ -220,7 +220,7 @@
 @Description
   Setzt den Status des angegebenen Werkzeugleisten-Schalters.
   Der Schalter muss mittels des @#PB_ToolBar_Toggle Modus erstellt worden sein.
-  
+
 @Parameter "#ToolBar"
   Die zu verwendende Werkzeugleiste.
 
@@ -240,12 +240,12 @@
 
 @SeeAlso
   @@GetToolBarButtonState
-  
+
 @SupportedOS
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function Höhe = ToolBarHeight(#ToolBar) 
+@Function Höhe = ToolBarHeight(#ToolBar)
 
 @Description
   Gibt die Höhe (in Pixel) der Werkzeugleiste zurück. Dies ist nützlich für eine korrekte
@@ -256,7 +256,7 @@
 
 @ReturnValue
   Gibt die Höhe (in Pixel) der Werkzeugleiste zurück.
-  
+
 @Remarks
   Auf OS X gibt dieser Befehl 0 zurück, da die Werkzeugleiste kein Bestandteil der inneren
   Fensterhöhe ist, weshalb hier keine Berechnung nötig ist.
@@ -271,7 +271,7 @@
 @Function ToolBarImageButton(#Button, ImageID [, Modus [, Text$]])
 
 @Description
-  Fügt einen Image-Schalter (Bild-Schalter) zur konstruierten Werkzeugleiste hinzu. 
+  Fügt einen Image-Schalter (Bild-Schalter) zur konstruierten Werkzeugleiste hinzu.
   @@CreateToolBar muss vor Benutzung dieses Befehls aufgerufen werden.
 
 @Parameter "#Button"
@@ -317,7 +317,7 @@
       ToolBarImageButton(1,ImageID(1))
     EndIf
     Repeat
-    Until WaitWindowEvent() = #PB_Event_CloseWindow 
+    Until WaitWindowEvent() = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
@@ -333,7 +333,7 @@
 @Function ToolBarSeparator()
 
 @Description
-  Fügt der zu konstruierenden Toolbar einen vertikalen Balken (Seperator) hinzu.
+  Fügt der zu konstruierenden Toolbar einen vertikalen Balken (Separator) hinzu.
   Vor diesem Befehl muss @@CreateToolBar aufgerufen worden sein.
 
 @NoParameters
@@ -356,7 +356,7 @@
       If Event = #PB_Event_Menu
         Debug "ToolBar ID: "+Str(EventMenu())
       EndIf
-    Until Event = #PB_Event_CloseWindow 
+    Until Event = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
@@ -373,16 +373,16 @@
 
 @Description
   Fügt der zu konstruierenden Werkzeugleiste einen Standard-Schalter hinzu. Vor diesem
-  Befehl muss @@CreateToolBar aufgerufen worden sein. 
+  Befehl muss @@CreateToolBar aufgerufen worden sein.
 @LineBreak
 @LineBreak
-  Ein Standard-Schalter ist ein Icon, welches direkt im OS verfügbar ist. 
-  
+  Ein Standard-Schalter ist ein Icon, welches direkt im OS verfügbar ist.
+
 @Parameter "#Button"
   Der Bezeichner des neuen Werkzeugleisten-Schalters.
 
 @Parameter "#ButtonIcon"
-  Dies kann eine der folgenden Konstanten sein: 
+  Dies kann eine der folgenden Konstanten sein:
 @FixedFont
   Konstante                     Dargestelltes Symbol
   ---------------------------------------------------
@@ -419,7 +419,7 @@
   @#PB_ToolBar_Text Flag erstellt werden, oder der Text wird nicht angezeigt.
 
 @NoReturnValue
-  
+
 @Example
 @Code
   If OpenWindow(0, 0, 0, 150, 25, "ToolBar", #PB_Window_SystemMenu | #PB_Window_ScreenCentered)
@@ -433,7 +433,7 @@
       If Event = #PB_Event_Menu
         Debug "ToolBar ID: "+Str(EventMenu())
       EndIf
-    Until Event = #PB_Event_CloseWindow 
+    Until Event = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
@@ -446,7 +446,7 @@
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function ToolBarButtonText(#ToolBar, Schalter, Text$) 
+@Function ToolBarButtonText(#ToolBar, Schalter, Text$)
 
 @Description
   Ändert den Text für den angegebenen #ToolBar Schalter. Die Werkzeugleiste muss mit dem
@@ -460,7 +460,7 @@
 
 @Parameter "Text$"
   Der neu anzuzeigende Text.
-  
+
 @NoReturnValue
 
 @Example
@@ -473,7 +473,7 @@
       ToolBarButtonText(0, 0, "Old")
     EndIf
     Repeat
-    Until WaitWindowEvent() = #PB_Event_CloseWindow 
+    Until WaitWindowEvent() = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak
@@ -485,7 +485,7 @@
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function ToolBarToolTip(#ToolBar, Button, Text$) 
+@Function ToolBarToolTip(#ToolBar, Button, Text$)
 
 @Description
   Verknüpft den angegebenen Text mit dem Werkzeugleisten-Schalter.
@@ -501,7 +501,7 @@
 @Parameter "Text$"
   Der neue Text, welcher mit dem Werkzeugleisten-Schalter verknüpft werden soll.
   Ist der Text leer, dann wird der Tooltip entfernt.
-  
+
 @NoReturnValue
 
 @Example
@@ -516,7 +516,7 @@
       ToolBarToolTip(0, 2, "Save file")
     EndIf
     Repeat
-    Until WaitWindowEvent() = #PB_Event_CloseWindow 
+    Until WaitWindowEvent() = #PB_Event_CloseWindow
   EndIf
 @EndCode
 @LineBreak

--- a/Residents/Linux/gtk2/gtk/gtkaccellabel.pb
+++ b/Residents/Linux/gtk2/gtk/gtkaccellabel.pb
@@ -18,7 +18,7 @@ Structure GtkAccelLabelClass
  *mod_name_control
  *mod_name_alt
  *mod_separator
- *accel_seperator
+ *accel_separator
   packed_flags.l
   ; latin1_to_char:1
   PB_Align(0, 4)

--- a/Residents/Linux/gtk2/gtk/gtkaccellabel.pb
+++ b/Residents/Linux/gtk2/gtk/gtkaccellabel.pb
@@ -18,7 +18,7 @@ Structure GtkAccelLabelClass
  *mod_name_control
  *mod_name_alt
  *mod_separator
- *accel_separator
+ *accel_seperator
   packed_flags.l
   ; latin1_to_char:1
   PB_Align(0, 4)

--- a/Residents/MacOS/Makefile
+++ b/Residents/MacOS/Makefile
@@ -1,9 +1,9 @@
 # Small makefile to build the residents easily
 
 all: residents
-	
 
-# We need to seperate imports and constants for the build server
+
+# We need to separate imports and constants for the build server
 residents:
 	rm -f $(PUREBASIC_HOME)/$(SUBSYSTEM)residents/purebasic.res
 	pbcompiler PureBasic.pb -q -r $(PUREBASIC_HOME)/residents/purebasic.res -ir purebasic.res


### PR DESCRIPTION
In many cases **separate** & **separately** were spelled incorrectly - fixed. Also fixed a few typos/grammar in the vicinity of the main fixes.