### PR TITLE
Prevent the Save Changes prompt if a source is 'New' and also empty

### DIFF
--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -2409,7 +2409,20 @@ Procedure CheckSourceSaved(*Source.SourceFile = 0)
     ProcedureReturn 1
   EndIf
   
+  ; Decide if a save prompt is needed
+  PromptUser = #False
   If GetSourceModified(*Source)
+    If *Source\FileName$ <> ""
+      PromptUser = #True
+    Else
+      ; Only prompt user to save a 'New' source if it's non-empty
+      If ScintillaSendMessage(*Source\EditorGadget, #SCI_GETLENGTH) > 0
+        PromptUser = #True
+      EndIf
+    EndIf
+  EndIf
+  
+  If PromptUser
     
     ; need to make it current for display of the question
     If *Source <> *ActiveSource


### PR DESCRIPTION
**Existing behavior**: When closing a 'New' source, the Modified flag will prompt you to save changes, even if the source is totally empty. (For example, you test a couple lines of code, then delete them.) Prompting you to save an empty file seems unnecessary.

**New behavior**: If a modified source is 'New' *and also empty*, the prompt to save changes will be prevented. (In all other conditions, the behavior remains as-is.) Notepad++ and others do this.

Feature request on the forum: https://www.purebasic.fr/english/viewtopic.php?f=3&t=76834