### PR TITLE
PB Help FR » Residents: Add Prototypes

### DIFF
--- a/Documentation/French/Reference/residents.txt
+++ b/Documentation/French/Reference/residents.txt
@@ -5,7 +5,7 @@
   compilateur. Ils se trouvent dans le dossier des 'residents' dans le chemin 
   d'installation de PureBasic. Un fichier résident doit avoir l'extension '.res' et peut 
   contenir les éléments suivants:  @ReferenceLink "structures" "Structures", 
-  @ReferenceLink "interfaces" "interfaces",  @ReferenceLink "macros" "macros" et 
+  @ReferenceLink "interfaces" "interfaces", @ReferenceLink "prototypes" "prototypes", @ReferenceLink "macros" "macros" et 
   @ReferenceLink "general_rules" "constantes". Il ne peut pas contenir un code dynamique 
   ni des @ReferenceLink "procedures" "procédures".
   @LineBreak


### PR DESCRIPTION
In PureBasic Help (French), reference/prototypes, add Prototypes to the list of allowed items in a resident file — (along with structures, interfaces, macros and constants.

See #120 for more details.

Note: This is the French version of #121 