### PR TITLE
Fix Broken Links in DocMaker Help

### DIFF
--- a/AsciiDoc/DocMaker-Help.asciidoc
+++ b/AsciiDoc/DocMaker-Help.asciidoc
@@ -1,6 +1,6 @@
 = PureBasic DocMaker Help
 Fantaisie Software <support@purebasic.com>
-:revdate: 2020-11-26
+:revdate: 2021-03-06
 :DocMakerVer: 5.00
 :revremark: DocMaker v{DocMakerVer}
 :revnumber!:
@@ -117,9 +117,15 @@ files are perfect because they are compact (compressed) and support indexing and
 Nevertheless creating these files is a long and rather boring process.
 Don't worry, DocMaker will handle all the work for you (almost :-).
 
-First, download and install the *HTML Help Workshop* from Microsoft website (free tool):
+First, you'll need to download and install the *HTML Help Workshop*, a free tool by Microsoft.
+The application is no longer available from Microsoft's website, but fortunately it's still possible to download its archived copy via the Wayback Machine (aka "`The Web Archive`", a free service by the
+https://archive.org/[Internet Archive^]):
 
-- https://www.microsoft.com/en-us/download/details.aspx?id=21138
+// Old Microsoft download page:
+//    https://www.microsoft.com/en-us/download/details.aspx?id=21138
+
+* link:https://web.archive.org/web/20160301123255/https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe[`htmlhelp.exe`^,title="Donwload 'htmlhelp.exe' from the Web Archive"]
+-- *HTML Help Workshop* (3.3 MB, English Installer)
 
 Then launch DocMaker.
 A `PureBasic Help.hhp` file will be created.

--- a/Documentation/DocMaker-Help.html
+++ b/Documentation/DocMaker-Help.html
@@ -447,7 +447,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="details">
 <span id="author" class="author">Fantaisie Software</span><br>
 <span id="email" class="email"><a href="mailto:support@purebasic.com">support@purebasic.com</a></span><br>
-<span id="revdate">2020-11-26</span>
+<span id="revdate">2021-03-06</span>
 <br><span id="revremark">DocMaker v5.00</span>
 </div>
 <div id="toc" class="toc2">
@@ -703,12 +703,14 @@ Nevertheless creating these files is a long and rather boring process.
 Don&#8217;t worry, DocMaker will handle all the work for you (almost :-).</p>
 </div>
 <div class="paragraph">
-<p>First, download and install the <strong>HTML Help Workshop</strong> from Microsoft website (free tool):</p>
+<p>First, you&#8217;ll need to download and install the <strong>HTML Help Workshop</strong>, a free tool by Microsoft.
+The application is no longer available from Microsoft&#8217;s website, but fortunately it&#8217;s still possible to download its archived copy via the Wayback Machine (aka &#8220;The Web Archive&#8221;, a free service by the
+<a href="https://archive.org/" target="_blank" rel="noopener">Internet Archive</a>):</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://www.microsoft.com/en-us/download/details.aspx?id=21138" class="bare">https://www.microsoft.com/en-us/download/details.aspx?id=21138</a></p>
+<p><a href="https://web.archive.org/web/20160301123255/https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe" title="Donwload 'htmlhelp.exe' from the Web Archive" target="_blank" rel="noopener"><code>htmlhelp.exe</code></a>&#8201;&#8212;&#8201;<strong>HTML Help Workshop</strong> (3.3 MB, English Installer)</p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
Fix Broken Links in DocMaker Help

In `DocMaker-Help.asciidoc`, update the download link for the "HTML Help Workshop" installer (fixes #149).

The "HTML Help Workshop" download page was removed from microsoft.com:

    https://www.microsoft.com/en-us/download/details.aspx?id=21138

@Naheulf found that an archived copy of the installer can be downloaded via the Wayback Machine (Internet Archive); we now provide this link in the download instructions.

-------------------------------------------------------------------------------

For a live preview of the amended document:

- [`Documentation/DocMaker-Help.html`][DocMaker-Help.html]

<!----------------------------- REFERENCE LINKS ------------------------------>

[DocMaker-Help.html]: https://htmlpreview.github.io/?https://github.com/fantaisie-software/purebasic/blob/DocMaker-Help/Documentation/DocMaker-Help.html#_windows_chm_help "Live HTML Preview from PR branch"
