### PR TITLE
Change format for all build targets from 'console' to default

### DIFF
--- a/PureBasicIDE/PureBasicIDE.pbp
+++ b/PureBasicIDE/PureBasicIDE.pbp
@@ -356,7 +356,6 @@
       <executable value=""/>
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x86\ide\" enable="1"/>
@@ -373,7 +372,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\PBLogoBig.ico</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x86\ide\" enable="1"/>
@@ -392,7 +390,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\PBLogoBig.ico</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x64\ide\" enable="1"/>
@@ -411,7 +408,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\logo\PBLogoLinux.png</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x86\ide\" enable="1"/>
@@ -430,7 +426,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\logo\PBLogoLinux.png</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x64\ide\" enable="1"/>
@@ -449,7 +444,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\logo\PB3D_MacIcon.icns</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x86\ide\" enable="1"/>
@@ -468,7 +462,6 @@
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1"/>
       <icon enable="1">data\logo\PB3D_MacIcon.icns</icon>
-      <format exe="console" cpu="0"/>
       <debugger custom="1" type="ide"/>
       <constants>
         <constant value="#BUILD_DIRECTORY=..\Build\x64\ide\" enable="1"/>


### PR DESCRIPTION
Change the "Executable format" for all 7 build targets from `console` to the default (GUI program).

When the format is default, and `cpu=0`, the IDE simply doesn't write the `<format>` XML node. That's why this PR is 7 line deletions.

Fixes issue #153 