### PR TITLE
Prevent debugger errors and IMA crash on quit

### DIFF
--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -5837,10 +5837,11 @@ Procedure FD_Redraw()
     
     StopDrawing()
     
-    StartDrawing(CanvasOutput(#GADGET_Form_Canvas))
-    DrawingMode(#PB_2DDrawing_Transparent)
-    DrawImage(ImageID(#Drawing_Img),0,0)
-    StopDrawing()
+    If StartDrawing(CanvasOutput(#GADGET_Form_Canvas))
+      DrawingMode(#PB_2DDrawing_Transparent)
+      DrawImage(ImageID(#Drawing_Img),0,0)
+      StopDrawing()
+    EndIf
   EndIf
   duration.q = ElapsedMilliseconds() - starttime
   If duration < 35

--- a/PureBasicIDE/PureBasic.pb
+++ b/PureBasicIDE/PureBasic.pb
@@ -770,7 +770,9 @@ Procedure ShutdownIDE()
   CloseWindow(#WINDOW_Main)
   
   ; Fix IDE crash on macOS Big Sur
-  FlushEvents()
+  CompilerIf #CompileMac
+    FlushEvents()
+  CompilerEndIf
   
   ; end history session. this could take a bit if many files were open (will display a small wait screen if so)
   EndHistorySession()


### PR DESCRIPTION
PR #131 (a bugfix for crash on MacOS Big Sur) introduced new bugs for me (on Windows). That's OK, it's why we have a `devel` branch :slightly_smiling_face: 

**Bug 1 (minor)** Since that PR, at IDE exit `FlushEvents()` is called *after closing all windows*. Since that procedure calls `WindowEvent()`, this causes 1–3 debugger errors, but they're not fatal.

**Bug 2 (major)** With the latest `devel` branch, run the IDE, open a Project, and *also* create a new Form. With both open, quit the IDE... I get an **Invalid Memory Access crash** on Windows. It is caused by the new `FlushEvents()` triggering a Form redraw on a gadget which no longer exists, and the `StartDrawing()` is not checked for success.

My patch for now is to safely check the `StartDrawing()` and also only call the extra `FlushEvents()` on Mac, since it's specifically a fix for Big Sur.

:warning: I have not confirmed the debugger errors or IMA crash on Mac/Linux.