### PR TITLE
Enable/disable some menu items appropriately

### DIFF
--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -883,28 +883,23 @@ Procedure UpdateMenuStates()
     ;
     If *ActiveSource = *ProjectInfo
       NoRealSource = 1
-      DisableMenuAndToolbarItem(#MENU_DiffCurrent, 1)
     Else
       NoRealSource = 0
-      
-      If *ActiveSource\FileName$ And GetSourceModified()
-        DisableMenuAndToolbarItem(#MENU_DiffCurrent, 0)
-      Else
-        ; this cannot be done if the current source is not saved yet
-        DisableMenuAndToolbarItem(#MENU_DiffCurrent, 1)
-      EndIf
     EndIf
     
     ; File menu
     DisableMenuAndToolbarItem(#MENU_Save, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_SaveAs, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_Close, NoRealSource)
-    DisableMenuAndToolbarItem(#MENU_Reload, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_EncodingPlain, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_EncodingUtf8, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_NewlineWindows, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_NewlineLinux, NoRealSource)
     DisableMenuAndToolbarItem(#MENU_NewlineMacOS, NoRealSource)
+    
+    ; File menu special cases
+    DisableMenuAndToolbarItem(#MENU_Reload, Bool( (*ActiveSource\FileName$ = "") Or (*ActiveSource = *ProjectInfo) Or (*ActiveSource\IsForm) ))
+    DisableMenuAndToolbarItem(#MENU_DiffCurrent, Bool( (*ActiveSource\FileName$ = "") Or (*ActiveSource = *ProjectInfo) Or (*ActiveSource\IsForm) Or (GetSourceModified(*ActiveSource) = 0) ))
     
     ; Edit menu (disable all, except FileInFiles)
     ;
@@ -1997,8 +1992,12 @@ Procedure MainWindowEvents(EventID)
               EndIf
               DisableMenuItem(#POPUPMENU_TabBar, #MENU_RemoveProjectFile, Disabled)
               
-              ; Disable the save item if the file is not modified
-              DisableMenuItem(#POPUPMENU_TabBar, #MENU_Save, Bool(Not GetSourceModified()))
+              ; Disable the Save items if project info tab
+              DisableMenuItem(#POPUPMENU_TabBar, #MENU_Save, Bool(*ActiveSource = *ProjectInfo))
+              DisableMenuItem(#POPUPMENU_TabBar, #MENU_SaveAs, Bool(*ActiveSource = *ProjectInfo))
+              
+              ; Disable the Reload item if new source, project info tab, or form
+              DisableMenuItem(#POPUPMENU_TabBar, #MENU_Reload, Bool( (*ActiveSource\FileName$ = "") Or (*ActiveSource = *ProjectInfo) Or (*ActiveSource\IsForm) ))
               
               ; Display the TabBar popup menu
               DisplayPopupMenu(#POPUPMENU_TabBar, WindowID(#WINDOW_Main))


### PR DESCRIPTION
This PR takes more time to explain than it did to program!

In preparing for solving #156 I noticed some items in the File menu or tab Popup menu seem to be enabled or disabled inappropriately.

✔ = Enabled (correct)  
➖ = Disabled (correct)  
⚠ = Something seems wrong

| Menu Item | New Source | Normal Source | Project Source | Project Tab | Form |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| File > **Save** | ✔ | ✔ | ✔ | ➖ | ✔ |
| File > **Save As** | ✔ | ✔ | ✔ | ➖ | ✔ |
| File > **Reload** | ⚠ Should be disabled! | ✔ | ✔ | ➖ | ⚠ Should be disabled! |
| File > **View Changes** | ➖ | ✔ Enabled if modified | ✔ Enabled if modified | ➖ | ➖ |
| Popup > **Save** | ⚠ Disabled until modified! | ⚠ Disabled until modified! | ⚠ Disabled until modified! | ➖ | ⚠ Disabled until modified! |
| Popup > **Save As** | ✔ | ✔ | ✔ | ⚠ Should be disabled! | ✔ |
| Popup > **Reload** | ⚠ Should be disabled! | ✔ | ✔ | ⚠ Should be disabled! | ⚠ Should be disabled! |

- **In all cases**: The disabled states of the **Popup Menu should match File menu** (bottom 3 rows should match top 3 rows)
- For a **New** source: Reload has no effect, should be disabled
- **Save** and **Save As** should always be available regardless of Modified flag, as agreed in #146 — Plus if you disable "Monitor for changes on disk" then the IDE doesn't know whether it's different from disk, so definitely let the user `Save`!
- For **Project Info tab**: All of these items should be disabled (in the File menu, they are)
- For **Forms**: Reload and View Changes seem to have no effect, so should be disabled (maybe implement later?)

This patch corrects all the ⚠ cases in the table above. It's also preparation for the `Save As` fixes in #156 and some requested menu features.