### PR TITLE
Multiple "Save As" bugfixes

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -2221,7 +2221,7 @@ Structure ProjectFile Extends ProjectFileConfig
   ; Only if the file is currently loaded
   *Source.SourceFile
   
-  ; Only if the file is corrently NOT loaded
+  ; Only if the file is currently NOT loaded
   Parser.ParserData    ; parsed source data
   
   LastOpen.l     ; valid while saving/closing a project

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -608,6 +608,8 @@ DataSection
   Data$ "FileExists",       "The file you specified already exists!"
   Data$ "OverWrite",        "Do you want to overwrite it?"
   Data$ "CreateError",      "The file cannot be created!"
+  Data$ "FileIsOpen",       "The file you specified is currently open in the IDE!"
+  Data$ "CloseOverWrite",   "Do you want to close that tab and overwrite it?"
   
   Data$ "SaveConfigError",  "Cannot save Compiler options to file"
   Data$ "Modified",         "The file '%filename%'has been modified.%newline%Do you want to save the changes?"


### PR DESCRIPTION
Fixes `Save As` bugs, see issue #156

**1. Prevent duplicate file tabs** — If you perform `Save As` (new file or existing file) *over another file open in the IDE*, it would accept it and you could create 2 or more duplicate tabs of the same file, with unsynchronized content. Now: `SaveSourceAs()` checks the filename against all open tabs. If already open, a requester gives you the option to auto-close the other tab and lose its contents, or cancel and select a different filename.

**2. Keep tab state in sync with project** — If you have a project open, and you `Save As` from a *project file* over a *non-project file* (or the reverse), the tab color and project link were not updated. Now: This fixes that. The logic is in `HandleProjectFileSaveAs()` which resolves the correct links between `ProjectFiles()` list and `*Source`.

**3. (Minor) Suppress overwrite question for case-only change** — On case-insensitive OS (like Windows), if you `Save As` a file like "abc.pb" as "ABC.pb", the IDE asks if you're sure you want to overwrite, even though it's functionally the same file. Now: This suppresses the prompt in that special case. See (new) line 2296.

**4. (Minor) Make case-only name changes possible** — On Windows, if you try to save a file like "abc.pb" as "ABC.pb", the IDE will display the new name, but Windows actually preserves the old case on disk. Easy to verify in Windows Explorer. This is not a functional problem, but deceiving. Now: This PR includes a common workaround, which is to temporarily rename the old file on disk, so the new `Save As` has the user's intended case. See `TempFile$`. (You can also *delete* the existing file before saving, but *rename* gives the ability to undo it, should `SaveSourceFile()` fail for any reason.)

:bulb: **More Info:**

All of this uses the existing `IsEqualFile()` procedure which handles case-sensitive vs case-insensitive filename comparisons. It is the same IDE logic which determines "is this file already open?" when give a filename to load.

Per discussion in #156, `Save As` **still does not change any of your associated Project Files!** You may update them manually.

Feel free to pull this branch locally and test all the cases you can think of! With/without a project open. I have been testing for days, and I am fairly confident in all this.

**My only specific remaining concern:** In the new function `HandleProjectFileSaveAs()`, you see the `*Source` must be linked/unlinked correctly to the `ProjectFiles()` list. But I'm not sure what to do (if anything) with the `Parser.ParserData` member. Should it be cleared? Copied to the new ProjectFile from the old ProjectFile? It took me a few days to study the `ProjectFiles()` and `ParserData`, I fear only Timo and PB devs *fully* understand how it should work and correctly update.

Cheers :coffee: 