### PR TITLE
Prevent crash when opening new project

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -2594,6 +2594,13 @@ Procedure OpenProjectOptions(NewProject)
       SetGadgetState(#GADGET_Project_OpenLoadLast, 1)
       
       ProjectExplorerPattern = 0 ; default pattern is "PB files"
+      CompilerIf #CompileLinux
+        ; On Linux we have to check if SourcePath$ is an accessible folder - otherwise a crash will occur!
+        ; If SourcePath$ is no folder then change it to home folder
+        If FileSize(SourcePath$) <> -2
+          SourcePath$ = "~"
+        EndIf
+      CompilerEndIf
       ProjectExplorerPath$   = SourcePath$
       
       ClearList(ProjectConfig()) ; no files in the list yet


### PR DESCRIPTION
This patch prevents a crash on Linux when opening a new project and when SourcePath$ contains a folder path which is currently not available (for example an USB-Stick plugged out). On MacOS and Windows no crash occurs in this situation.

This problem was posted in this bug report (https://www.purebasic.fr/english/viewtopic.php?f=23&t=75479) and a workaround was described.

My added solution tests for the availability of the folder path in SourcePath$ and if not simply sets SourcePath$ to the home folder.