### PR TITLE
Allow Enter key to open selected Project File in list

### DIFF
--- a/PureBasicIDE/Macro.pb
+++ b/PureBasicIDE/Macro.pb
@@ -121,3 +121,9 @@ EndMacro
 Macro DebugPointer(Ptr)
   RSet(Hex(Ptr, #PB_Integer), SizeOf(INTEGER)*2, "0")
 EndMacro
+
+Macro EnsureListIconSelection(Gadget)
+  If GetGadgetState(Gadget) = -1
+    SetGadgetState(Gadget, 0)
+  EndIf
+EndMacro

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -166,7 +166,9 @@ Procedure ChangeActiveSourcecode(*OldSource.SourceFile = 0)
   ResizeMainWindow()  ; make sure the EditorGadget is correctly sized
   
   If *ActiveSource = *ProjectInfo
+    EnsureListIconSelection(#GADGET_ProjectInfo_Files)
     HideGadget(#GADGET_ProjectInfo, 0)
+    SetActiveGadget(#GADGET_ProjectInfo_Files)
     
   Else
     If *ProjectInfo

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1717,6 +1717,12 @@ Procedure MainMenuEvent(MenuItemID)
             SendEditorMessage(#SCI_NEWLINE, 0, 0)
           EndIf
           
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          index = GetGadgetState(#GADGET_ProjectInfo_Files)
+          If index <> -1 And SelectElement(ProjectFiles(), index)
+            LoadSourceFile(ProjectFiles()\Filename$) ; will just switch if open
+          EndIf
+          
         Else
           CompilerIf #CompileWindows
             SendMessage_(GetFocus_(), #WM_KEYDOWN, #VK_RETURN, 0) ; for the label editing in Templates for example

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1718,10 +1718,10 @@ Procedure MainMenuEvent(MenuItemID)
           EndIf
           
         ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
-          index = GetGadgetState(#GADGET_ProjectInfo_Files)
-          If index <> -1 And SelectElement(ProjectFiles(), index)
-            LoadSourceFile(ProjectFiles()\Filename$) ; will just switch if open
-          EndIf
+          PostEvent(#PB_Event_Gadget, #WINDOW_Main, #GADGET_ProjectInfo_Files, #PB_EventType_LeftDoubleClick)
+          
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Targets))
+          PostEvent(#PB_Event_Gadget, #WINDOW_Main, #GADGET_ProjectInfo_Targets, #PB_EventType_LeftDoubleClick)
           
         Else
           CompilerIf #CompileWindows
@@ -1746,6 +1746,14 @@ Procedure MainMenuEvent(MenuItemID)
               InsertTab()
             EndIf
           EndIf
+        
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          EnsureListIconSelection(#GADGET_ProjectInfo_Targets)
+          SetActiveGadget(#GADGET_ProjectInfo_Targets)
+        ElseIf IsProject And (*ActiveSource = *ProjectInfo)
+          EnsureListIconSelection(#GADGET_ProjectInfo_Files)
+          SetActiveGadget(#GADGET_ProjectInfo_Files)
+
           
         EndIf
         
@@ -1757,6 +1765,14 @@ Procedure MainMenuEvent(MenuItemID)
           Else
             RemoveTab()
           EndIf
+        
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          EnsureListIconSelection(#GADGET_ProjectInfo_Targets)
+          SetActiveGadget(#GADGET_ProjectInfo_Targets)
+        ElseIf IsProject And (*ActiveSource = *ProjectInfo)
+          EnsureListIconSelection(#GADGET_ProjectInfo_Files)
+          SetActiveGadget(#GADGET_ProjectInfo_Files)
+        
         EndIf
         
       CompilerEndIf


### PR DESCRIPTION
In the `Project` tab > `Project Files` list, you can double-click a project file to open it (or switch to it).

This PR adds the same action if you press the Enter key, useful when navigating the list by keyboard.

In fact the action is directly copied from the `#PB_EventType_LeftDoubleClick` handler in `MainWindowEvents()`.