### PR TITLE
Prevent crash when opening new project

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -2594,22 +2594,13 @@ Procedure OpenProjectOptions(NewProject)
       SetGadgetState(#GADGET_Project_OpenLoadLast, 1)
       
       ProjectExplorerPattern = 0 ; default pattern is "PB files"
-      CompilerIf #CompileLinux
-        ; On Linux we have to check if SourcePath$ is an accessible folder - otherwise a crash will occur!
-        ; If SourcePath$ is no folder then change it to home folder
-        If FileSize(SourcePath$) <> -2
-          SourcePath$ = "~"
-        EndIf
-      CompilerEndIf
       ProjectExplorerPath$   = SourcePath$
-      
       ClearList(ProjectConfig()) ; no files in the list yet
-      
       ProjectOptionsDialog\GuiUpdate() ; to resize from the new strings
       
       DisableWindow(#WINDOW_Main, 1)
       SetActiveGadget(#GADGET_Project_File)
-      
+
     Else
       IsProjectCreation = 0
       
@@ -2645,9 +2636,19 @@ Procedure OpenProjectOptions(NewProject)
     
     ; This also fills the explorer pattern in the project options and sets the correct state
     UpdateExplorerPatterns()
+
+    CompilerIf #CompileLinux
+      ; On Linux we have to check if ProjectExplorerPath$ is an accessible folder - otherwise a crash
+      ; will occur because of a bug in the following SetGadgetText()!
+      ; If ProjectExplorerPath$ is no folder then change it to home folder
+      If FileSize(ProjectExplorerPath$) <> -2
+        ProjectExplorerPath$ = GetHomeDirectory()
+      EndIf
+    CompilerEndIf
+
     SetGadgetText(#GADGET_Project_Explorer, ProjectExplorerPath$+StringField(ExplorerPatternStrings$, ProjectExplorerPattern+1, "|"))
     SetGadgetText(#GADGET_Project_ExplorerCombo, ProjectExplorerPath$)
-    
+
     UpdateProjectOptionStates() ; disable some buttons as needed
   EndIf
   

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -2594,6 +2594,13 @@ Procedure OpenProjectOptions(NewProject)
       SetGadgetState(#GADGET_Project_OpenLoadLast, 1)
       
       ProjectExplorerPattern = 0 ; default pattern is "PB files"
+      CompilerIf #CompileLinux
+        ; On Linux we have to check if SourcePath$ is an accessible folder - otherwise a crash will occur!
+        ; If SourcePath$ is no folder then change it to home folder
+        If FileSize(SourcePath$) <> -2
+          SourcePath$ = "~"
+        EndIf
+      CompilerEndIf
       ProjectExplorerPath$   = SourcePath$
       
       ClearList(ProjectConfig()) ; no files in the list yet


### PR DESCRIPTION
> @t-harter Thinking more of it, maybe this should rather be a bugreport/bugfix done in the actual PB command that crashes with the invalid path. If this happens on only one OS then maybe making the actual PB command more resilient is the better solution also for all other PB programs. If you can reproduce this easily then maybe adding a bugreport for that command would help too.

I have found out that SetGadgetText() produces the bug (only on Linux) and have posted a bug report: [https://www.purebasic.fr/english/viewtopic.php?f=23&t=77930](url)

Nevertheless I think that the bug in the IDE should be fixed at least until the bug in SetGadgetText() is fixed. Therefore I propose a new patch.

> @t-harter I don't think automatically changing the SourcePath$ setting is a good idea. This is a global user setting in the preferences and should not be changed without knowledge of the user (we had bug reports about such behavior in the past). I think it would be better to check for this situation and only use a different path for the actual operation that fails and not change the global setting. From a quick look it seems like doing the automatic change for the ProjectExplorerPath$ might be the more "local" solution to this problem (if that fixes the crash).

I have used the variable ProjectExplorerPath$ in my new patch.

> @t-harter Finally, I am not sure using "~" for the home folder will work correctly everywhere in the IDE. I am not sure all code can handle this path shortcut. Using GetHomeDirectory() may be the more safe alternative.

I have used GetHomeDirectory() instead of "~" in my new patch.