### PR TITLE
Fix the updating of the `PB_TOOL_Compiler` environment variable

### DIFF
--- a/PureBasicIDE/AddTools.pb
+++ b/PureBasicIDE/AddTools.pb
@@ -225,7 +225,17 @@ Procedure AddTools_ExecuteCurrent(Trigger, *Target.CompileTarget)
     Protected NewList EnvVars.s()
     
     AddTools_SetEnvVar(EnvVars(), "IDE", ProgramFilename())
-    AddTools_SetEnvVar(EnvVars(), "Compiler", *CurrentCompiler\Executable$) ; use *CurrentCompiler to have the real compiler path if multiple compiler are available
+    
+    Protected *TargetCompiler.Compiler
+    If *Target\CustomCompiler
+      *TargetCompiler = FindCompiler(*Target\CompilerVersion$)
+      If *TargetCompiler = 0
+        *TargetCompiler = @DefaultCompiler
+      EndIf
+    Else
+      *TargetCompiler = @DefaultCompiler
+    EndIf
+    AddTools_SetEnvVar(EnvVars(), "Compiler", *TargetCompiler\Executable$)
     
     AddTools_SetEnvVar(EnvVars(), "Preferences", PreferencesFile$)
     AddTools_SetEnvVar(EnvVars(), "MainWindow", Str(WindowID(#WINDOW_Main)))


### PR DESCRIPTION
The environment variable was updated only when the compiler compiled the
source code. Therefore, only the following tool trigger events resulted
in an update of the environment variable:

- `After Compile/Run`
- `After Create Executable`

PB_TOOL_Compiler update delayed
https://www.purebasic.fr/english/viewtopic.php?t=72110