### PR TITLE
Fix crashing on IDE start/close, when a tool is set up to trigger in this case

### DIFF
--- a/PureBasicIDE/AddTools.pb
+++ b/PureBasicIDE/AddTools.pb
@@ -227,7 +227,7 @@ Procedure AddTools_ExecuteCurrent(Trigger, *Target.CompileTarget)
     AddTools_SetEnvVar(EnvVars(), "IDE", ProgramFilename())
     
     Protected *TargetCompiler.Compiler
-    If *Target\CustomCompiler
+    If *Target And *Target\CustomCompiler
       *TargetCompiler = FindCompiler(*Target\CompilerVersion$)
       If *TargetCompiler = 0
         *TargetCompiler = @DefaultCompiler


### PR DESCRIPTION
The bug was introduced by the pull request "Fix the updating of the
`PB_TOOL_Compiler` environment variable (#191)".

PB6.0 GBeta 2 Crash on start
https://www.purebasic.fr/english/viewtopic.php?t=78496

v6 Beta 2 - Invalid memory access
https://www.purebasic.fr/english/viewtopic.php?t=78503