### PR TITLE
Keep order of project files

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -2231,6 +2231,7 @@ Structure ProjectFileConfig
   AutoScan.l       ; Should the file be scanned for autocomplete ?
   ShowPanel.l      ; show in panel
   ShowWarning.l    ; show warning if file changes
+  SortIndex.l      ; for sorting
   
   PanelState$      ; string of "0"/"1" for every parent directory of the file to indicate whether it is expanded in panel (empty if ShowPanel=0)
 EndStructure

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -583,7 +583,7 @@ Procedure UpdateProjectInfoPreferences()
     ; Find Project tab (position may have changed!) and update its text
     PushListPosition(FileList())
     ChangeCurrentElement(FileList(), *ProjectInfo)
-    SetTabBarGadgetItemText(#GADGET_FilesPanel, ListIndex(FileList()), Language("Project","TabTitle"))
+    SetTabBarGadgetItemText(#GADGET_FilesPanel, ListIndex(FileList()), Language("Project","TabTitle") + " [" + ProjectName$ + "]")
     PopListPosition(FileList())
     
     SetGadgetText(#GADGET_ProjectInfo_FrameProject, Language("Project","ProjectInfo"))
@@ -2180,13 +2180,12 @@ Procedure ProjectOptionsEvents(EventID)
             ChangeActiveSourceCode()
           ElseIf OldProjectName$ <> ProjectName$
             ;change name of Tab, if user changed the project name
-            ;Tab can be moved by customer, therefore going through all open Tabs to find it. Maybe there is a better solution, but it works
-            For i = 0 To CountTabBarGadgetItems(#GADGET_FilesPanel) - 1
-              If GetTabBarGadgetItemText(#GADGET_FilesPanel, i) = Language("Project", "TabTitle") + " [" + OldProjectName$ + "]"
-                SetTabBarGadgetItemText(#GADGET_FilesPanel, i, Language("Project", "TabTitle") + " [" + ProjectName$ + "]")
-                Break
-              EndIf
-            Next i
+            If *ProjectInfo
+              PushListPosition(FileList())
+              ChangeCurrentElement(FileList(), *ProjectInfo)
+              SetTabBarGadgetItemText(#GADGET_FilesPanel, ListIndex(FileList()), Language("Project","TabTitle") + " [" + ProjectName$ + "]")
+              PopListPosition(FileList())
+            EndIf
           EndIf
           
           ; Update the options


### PR DESCRIPTION
Project files keep their tab positions in the IDE.
Additionally I've added the project name to the Project tab (shown as: Project [Name], instead of just Project)

More or less that whole feature request from here:
https://www.purebasic.fr/english/viewtopic.php?t=66119