### PR TITLE
Add "Show in Folder" to File menu and TabBar popup

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -939,6 +939,7 @@ Enumeration 0
   #MENU_NewlineLinux
   #MENU_NewlineMacOS
   ;#MENU_SortSources
+  #MENU_ShowInFolder
   
   CompilerIf #CompileMac
     #MENU_PreferenceNotUsed

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -402,6 +402,7 @@ DataSection
   Data$ "Reload",           "R&eload"
   Data$ "Close",            "&Close"
   Data$ "CloseAll",         "C&lose All"
+  Data$ "ShowInFolder",     "Show in &Folder"
   Data$ "DiffCurrent",      "View chan&ges"
   Data$ "FileFormat",       "F&ile format"
   Data$ "EncodingPlain",    "Encoding: &Plain Text"

--- a/PureBasicIDE/LinuxExtensions.pb
+++ b/PureBasicIDE/LinuxExtensions.pb
@@ -427,6 +427,11 @@ CompilerIf #CompileLinux
     EndIf
   EndProcedure
   
+  Procedure ShowExplorerFile(File$)
+    ; For now, just launch the containing folder
+    ShowExplorerDirectory(GetPathPart(File$))
+  EndProcedure
+  
   Procedure ModifierKeyPressed(Key)
     Select Key
       Case #PB_Shortcut_Shift:   mod = #GDK_SHIFT_MASK

--- a/PureBasicIDE/MacExtensions.pb
+++ b/PureBasicIDE/MacExtensions.pb
@@ -162,6 +162,10 @@ CompilerIf #CompileMacCocoa
     RunProgram("open", Chr(34)+Directory$+Chr(34), "")
   EndProcedure
   
+  Procedure ShowExplorerFile(File$)
+    RunProgram("open", "-R " + #DQUOTE$ + File$ + #DQUOTE$, "")
+  EndProcedure
+  
   ; Carbon event modifiers
   ;
   #activeFlagBit = 0

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -804,6 +804,7 @@ DataSection
   Data$ "File", "NewlineLinux":  Data.l 0
   Data$ "File", "NewlineMacOS":  Data.l 0
   ;Data$ "File", "SortSources":   Data.l 0
+  Data$ "File", "ShowInFolder":  Data.l 0
   Data$ "File", "Preferences":   Data.l 0
   Data$ "File", "EditHistory":   Data.l 0
   Data$ "File", "Quit":          Data.l 0

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -2656,6 +2656,19 @@ Procedure AutoSave()  ; called before compiling / creating executable to do the 
   
 EndProcedure
 
+Procedure ShowInFolder()
+  If *ActiveSource
+    If *ActiveSource = *ProjectInfo
+      FileToShow$ = ProjectFile$
+    Else
+      FileToShow$ = *ActiveSource\FileName$
+    EndIf
+    If FileToShow$
+      ShowExplorerFile(FileToShow$)
+    EndIf
+  EndIf
+EndProcedure
+
 Procedure ReloadSource()
   If *ActiveSource And *ActiveSource <> *ProjectInfo And *ActiveSource\Filename$
     If GetSourceModified() = #False Or MessageRequester(#ProductName$, Language("FileStuff","ReloadModified"), #PB_MessageRequester_YesNo|#FLAG_Warning) = #PB_MessageRequester_Yes

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -891,22 +891,8 @@ Procedure UpdateMenuStates()
     ;
     If *ActiveSource = *ProjectInfo
       NoRealSource = 1
-      DisableMenuAndToolbarItem(#MENU_ShowInFolder, 0)
-      DisableMenuAndToolbarItem(#MENU_DiffCurrent, 1)
     Else
       NoRealSource = 0
-      
-      If *ActiveSource\FileName$
-        DisableMenuAndToolbarItem(#MENU_ShowInFolder, 0)
-      Else
-        DisableMenuAndToolbarItem(#MENU_ShowInFolder, 1)
-      EndIf
-      If *ActiveSource\FileName$ And GetSourceModified()
-        DisableMenuAndToolbarItem(#MENU_DiffCurrent, 0)
-      Else
-        ; this cannot be done if the current source is not saved yet
-        DisableMenuAndToolbarItem(#MENU_DiffCurrent, 1)
-      EndIf
     EndIf
     
     ; File menu
@@ -922,6 +908,7 @@ Procedure UpdateMenuStates()
     ; File menu special cases
     DisableMenuAndToolbarItem(#MENU_Reload, Bool( (*ActiveSource\FileName$ = "") Or (*ActiveSource = *ProjectInfo) Or (*ActiveSource\IsForm) ))
     DisableMenuAndToolbarItem(#MENU_DiffCurrent, Bool( (*ActiveSource\FileName$ = "") Or (*ActiveSource = *ProjectInfo) Or (*ActiveSource\IsForm) Or (GetSourceModified(*ActiveSource) = 0) ))
+    DisableMenuAndToolbarItem(#MENU_ShowInFolder, Bool( (*ActiveSource <> *ProjectInfo) And (*ActiveSource\FileName$ = "") ))
     
     ; Edit menu (disable all, except FileInFiles)
     ;

--- a/PureBasicIDE/WindowsExtensions.pb
+++ b/PureBasicIDE/WindowsExtensions.pb
@@ -384,6 +384,10 @@ CompilerIf #CompileWindows
     ShellExecute_(#Null, @"explore", @Directory$, #Null, #Null, #SW_SHOWNORMAL)
   EndProcedure
   
+  Procedure ShowExplorerFile(File$)
+    RunProgram("explorer.exe", "/SELECT," + #DQUOTE$ + File$ + #DQUOTE$, "")
+  EndProcedure
+  
   Procedure ModifierKeyPressed(Key)
     Select Key
       Case #PB_Shortcut_Shift:   vKey = #VK_SHIFT


### PR DESCRIPTION
This PR adds a simple "Show in Folder" AKA "Open File Location" action to the File menu and the TabBar popup menu.

It's a quick way to locate a source file (or project PBP file) in your OS's explorer.

![](https://user-images.githubusercontent.com/25482520/158002839-c0e86499-0657-4964-8786-b8b41d13e96f.png)

Notes:

- On Windows and Mac, it should open the Explorer/Finder with the file auto-selected. :warning: On Linux it just opens the folder. Maybe somebody on Linux could implement auto-selecting the file, if possible.
- I called it "Show in Folder", open to other suggestions
- Menu item automatically enabled/disabled when appropriate
- It can be assigned a keyboard shortcut, but defaults to none
