### PR TITLE
Small fix macOS darkmode and auto complete

### DIFF
--- a/PureBasicIDE/ConstantsData.pbi
+++ b/PureBasicIDE/ConstantsData.pbi
@@ -563,7 +563,7 @@ DataSection
   Data$ "ReceiveHTTPMemory,2,#PB_HTTP_Asynchronous,#PB_HTTP_NoRedirect"
   Data$ "ReleaseMouse,1,#True,#False"
   Data$ "ReloadMaterial,3,#True,#False"
-  Data$ "RemoveKeyboardShortcut,2,#PB_Key_*"
+  Data$ "RemoveKeyboardShortcut,2,#PB_Shortcut_*"
   Data$ "RemoveMailRecipient,3,#PB_Mail_To,#PB_Mail_Cc,#PB_Mail_Bcc"
   Data$ "RemoveString,3,#PB_String_CaseSensitive,#PB_String_NoCase"
   Data$ "RemoveSysTrayIcon,1,#PB_All"

--- a/PureBasicIDE/MacExtensions.pb
+++ b/PureBasicIDE/MacExtensions.pb
@@ -255,7 +255,7 @@ CompilerIf #CompileMacCocoa
       
       If Update
         With TabBarGadgetInclude
-          OldFaceColor = \FaceColor
+          OldFaceColor = \FaceColor & $FFFFFF
           ; Save current appearance
           NSAppearanceSave = CocoaMessage(0, 0, "NSAppearance currentAppearance")
           NSEffectiveAppearance = CocoaMessage(0, NSApp, "effectiveAppearance")
@@ -289,7 +289,7 @@ CompilerIf #CompileMacCocoa
         Case "effectiveAppearance"
           If DisplayDarkMode
             With TabBarGadgetInclude
-              OldFaceColor = \FaceColor
+              OldFaceColor = \FaceColor & $FFFFFF
               ; Save current appearance
               NSAppearanceSave = CocoaMessage(0, 0, "NSAppearance currentAppearance")
               NSEffectiveAppearance = CocoaMessage(0, NSApp, "effectiveAppearance")


### PR DESCRIPTION
Under macOS, the TabBarPanel no longer functions to switch between DarkMode and Aqua.
This is because the function 'GetTabBarGadgetItemColor' no longer returns the previously set color values (with alphachannel and signed).

The auto-completion for 'RemoveKeyboardShortcut' constants is not correct.