### PR TITLE
Allow Enter key to open selected Project File in list (all platforms)

### DIFF
--- a/PureBasicIDE/Macro.pb
+++ b/PureBasicIDE/Macro.pb
@@ -121,3 +121,9 @@ EndMacro
 Macro DebugPointer(Ptr)
   RSet(Hex(Ptr, #PB_Integer), SizeOf(INTEGER)*2, "0")
 EndMacro
+
+Macro EnsureListIconSelection(Gadget)
+  If GetGadgetState(Gadget) = -1
+    SetGadgetState(Gadget, 0)
+  EndIf
+EndMacro

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -619,6 +619,16 @@ Procedure UpdateProjectInfoPreferences()
   EndIf
 EndProcedure
 
+; Enter key handling for project file & target list
+; For Windows this is done when handling the #MENU_Scintilla_Enter shortcut in UserInterface.pb
+CompilerIf #CompileLinux
+  ProcedureC ProjectInfo_EnterKeyHandler(*Widget, *Event.GdkEventKey, Gadget)
+    Debug "Key event: " + *Event\keyval
+    If *Event\keyval = #GDK_Return
+      PostEvent(#PB_Event_Gadget, #WINDOW_Main, Gadget, #PB_EventType_LeftDoubleClick)
+    EndIf
+  EndProcedure
+CompilerEndIf
 
 
 Procedure AddProjectInfo()
@@ -671,6 +681,11 @@ Procedure AddProjectInfo()
       AddGadgetColumn(#GADGET_ProjectInfo_Targets, 6, Language("Project","BuildCountShort"), 60)
       AddGadgetColumn(#GADGET_ProjectInfo_Targets, 7, Language("Project","FormatShort"), 60)
       AddGadgetColumn(#GADGET_ProjectInfo_Targets, 8, Language("Project","InputFile"), 200)
+      
+      CompilerIf #CompileLinux
+        GTKSignalConnect(GadgetID(#GADGET_ProjectInfo_Files), "key-press-event", @ProjectInfo_EnterKeyHandler(), #GADGET_ProjectInfo_Files)
+        GTKSignalConnect(GadgetID(#GADGET_ProjectInfo_Targets), "key-press-event", @ProjectInfo_EnterKeyHandler(), #GADGET_ProjectInfo_Targets)
+      CompilerEndIf
       
       CompilerIf #CompileWindows
         ; Make the settings columns centered for a better look

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -3123,6 +3123,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
   CompilerIf #CompileLinux
     
     ; Workaround for the Scintilla shortcut *eating* on Linux.
+    ; Enter key handling for the other OS is done via #MENU_Scintilla_Enter shortcut
     ;
     ProcedureCDLL ScintillaShortcutHandler(*Widget, *Event._GdkEventKey, user_data)
       

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -177,7 +177,9 @@ Procedure ChangeActiveSourcecode(*OldSource.SourceFile = 0)
   ResizeMainWindow()  ; make sure the EditorGadget is correctly sized
   
   If *ActiveSource = *ProjectInfo
+    EnsureListIconSelection(#GADGET_ProjectInfo_Files)
     HideGadget(#GADGET_ProjectInfo, 0)
+    SetActiveGadget(#GADGET_ProjectInfo_Files)
     
   Else
     If *ProjectInfo

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1725,10 +1725,10 @@ Procedure MainMenuEvent(MenuItemID)
           EndIf
           
         ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
-          index = GetGadgetState(#GADGET_ProjectInfo_Files)
-          If index <> -1 And SelectElement(ProjectFiles(), index)
-            LoadSourceFile(ProjectFiles()\Filename$) ; will just switch if open
-          EndIf
+          PostEvent(#PB_Event_Gadget, #WINDOW_Main, #GADGET_ProjectInfo_Files, #PB_EventType_LeftDoubleClick)
+          
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Targets))
+          PostEvent(#PB_Event_Gadget, #WINDOW_Main, #GADGET_ProjectInfo_Targets, #PB_EventType_LeftDoubleClick)
           
         Else
           CompilerIf #CompileWindows
@@ -1753,6 +1753,14 @@ Procedure MainMenuEvent(MenuItemID)
               InsertTab()
             EndIf
           EndIf
+        
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          EnsureListIconSelection(#GADGET_ProjectInfo_Targets)
+          SetActiveGadget(#GADGET_ProjectInfo_Targets)
+        ElseIf IsProject And (*ActiveSource = *ProjectInfo)
+          EnsureListIconSelection(#GADGET_ProjectInfo_Files)
+          SetActiveGadget(#GADGET_ProjectInfo_Files)
+
           
         EndIf
         
@@ -1764,6 +1772,14 @@ Procedure MainMenuEvent(MenuItemID)
           Else
             RemoveTab()
           EndIf
+        
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          EnsureListIconSelection(#GADGET_ProjectInfo_Targets)
+          SetActiveGadget(#GADGET_ProjectInfo_Targets)
+        ElseIf IsProject And (*ActiveSource = *ProjectInfo)
+          EnsureListIconSelection(#GADGET_ProjectInfo_Files)
+          SetActiveGadget(#GADGET_ProjectInfo_Files)
+        
         EndIf
         
       CompilerEndIf

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1724,6 +1724,12 @@ Procedure MainMenuEvent(MenuItemID)
             SendEditorMessage(#SCI_NEWLINE, 0, 0)
           EndIf
           
+        ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
+          index = GetGadgetState(#GADGET_ProjectInfo_Files)
+          If index <> -1 And SelectElement(ProjectFiles(), index)
+            LoadSourceFile(ProjectFiles()\Filename$) ; will just switch if open
+          EndIf
+          
         Else
           CompilerIf #CompileWindows
             SendMessage_(GetFocus_(), #WM_KEYDOWN, #VK_RETURN, 0) ; for the label editing in Templates for example

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -1711,6 +1711,8 @@ Procedure MainMenuEvent(MenuItemID)
         SetGadgetItemImage(#GADGET_ProjectInfo_Targets, index, ProjectTargetImage(@ProjectTargets()))
       EndIf
       
+      ; Enter handling in Scintilla (and other places) via global shortcut
+      ; For linux this is done via ScintillaShortcutHandler()
       CompilerIf #CompileWindows | #CompileMac
         
       Case #MENU_Scintilla_Enter
@@ -1724,6 +1726,7 @@ Procedure MainMenuEvent(MenuItemID)
             SendEditorMessage(#SCI_NEWLINE, 0, 0)
           EndIf
           
+        ; See ProjectInfo_EnterKeyHandler() in ProjectManagement.pb for Linux specific handling of this
         ElseIf IsProject And (GetFocusGadgetID(#WINDOW_Main) = GadgetID(#GADGET_ProjectInfo_Files))
           PostEvent(#PB_Event_Gadget, #WINDOW_Main, #GADGET_ProjectInfo_Files, #PB_EventType_LeftDoubleClick)
           


### PR DESCRIPTION
Continuation of PR #167 to implement the functionality also for Linux. Thanks @kenmo-pb for the initial work.

I also added comments in an attempt to make it more clear where the enter key handling takes place on each OS.