### PR TITLE
Fixes for reloading of settings from temp files

### DIFF
--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -1235,6 +1235,12 @@ Procedure AnalyzeSettings_Common(*Source.SourceFile, NbLines)  ; analyze the Con
   
   *Source\Watchlist$ = ""
   
+  *Source\NbConstants = 0
+  For i = 0 To #MAX_Constants-1
+    *Source\Constant$[i] = ""
+    *Source\ConstantEnabled[i] = 0
+  Next i
+  
   For i = 1 To NbLines
     index = FindString(ConfigLines$(i), "=", 1)
     If index = 0
@@ -1575,7 +1581,7 @@ EndProcedure
 Procedure AnalyzeProjectSettings(*Source.SourceFile, *Buffer, Length, IsTempFile)
   
   
-  If SaveProjectSettings = #SAVESETTINGS_DoNotSave ; don't save anything
+  If SaveProjectSettings = #SAVESETTINGS_DoNotSave And IsTempFile = 0 ; don't save anything
     ProcedureReturn Length
   EndIf
   


### PR DESCRIPTION
* Clear old list of constants before reloading
* Properly reload (and cut) settings from temp files in case of `#SAVESETTINGS_DoNotSave`

See https://www.purebasic.fr/english/viewtopic.php?t=78735