### PR TITLE
Improve interface parser to deal with module prefixes and line continuations

### DIFF
--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -629,6 +629,7 @@ Declare.s ResolveItemType(*InputItem.SourceItem, InputLine, *OutType.INTEGER)
 Declare LocateStructureBaseItem(Line$, Position, *pItem.INTEGER, *pLine.INTEGER, List StructureStack.s())
 Declare IsLineContinuation(*Buffer, *Pointer.PTR) ; returns true if *Pointer is the end of a line with continuation
 Declare IsContinuedLineStart(Line$)               ; returns true if Line$ is the beginning of a line with line continuation at the end
+Declare.s Parser_Cleanup(Input$)                  ; cleanup a prototype string (remove newlines, line continutaions and extra whitespace)
 Declare CharsToBytes(Line$, Start, Encoding, Chars)   ; Convert a char offset (0-based) to a byte offset in the specified encoding
 Declare BytesToChars(Line$, Start, Encoding, Bytes)   ; Convert a byte offset (0-based) to a char offset in the specified encoding
 


### PR DESCRIPTION
Bugfix for: https://www.purebasic.fr/english/viewtopic.php?t=61676

In addition to module prefixes, also improved handling of line continuations within a method prototype, e.g.:
```
Interface foo
  bar(a, ; comment
      b, ; comment
      c) ; comment
EndInterface
```