### PR TITLE
Improve array overview note text

### DIFF
--- a/Documentation/English/Array.txt
+++ b/Documentation/English/Array.txt
@@ -24,8 +24,8 @@
   be randomized using @@RandomizeArray.
 @LineBreak
 @LineBreak
-  Note: These arrays are dynamic because they can change size. In PureBasic, they exist
-  however arrays said static, not resizable and used only in the structures. These arrays 
+  Note: These arrays are called dynamic because they can change size. However, there are
+  also so-called static arrays, which can not be resized and are only used in structures. These arrays
   are written with square brackets. For example: ArrayStatic[2]. See @ReferenceLink "structures" "here". 
   The functions of this Array library can not be used with this type of array.
   

--- a/Documentation/German/Array.txt
+++ b/Documentation/German/Array.txt
@@ -25,8 +25,8 @@
   werden.
 @LineBreak
 @LineBreak
-  Hinweis: Diese Arrays sind dynamisch, da sich ihre Größe ändern kann. In PureBasic
-  existieren dagegen auch sogenannte statische Arrays, die nicht in ihrer Größe verändert
+  Hinweis: Diese Arrays werden als dynamisch bezeichnet, weil sie ihre Größe ändern
+  können. Es gibt jedoch auch sogenannte statische Arrays, die nicht in ihrer Größe verändert
   und nur innerhalb von Strukturen verwendet werden können. Diese Arrays werden mit
   eckigen Klammern geschrieben. Zum Beispiel: ArrayStatic[2]. Siehe @ReferenceLink "structures" "hier".
   Die Funktionen dieser Array-Bibliothek können mit diesem Typ von Arrays nicht verwendet werden.


### PR DESCRIPTION
- "In PureBasic" removed from the English and German versions because it was not worded that way in the French version either.

- English sentence corrected.

- English and German version better adapted to the French version.