### PR TITLE
Remove an old Linux fix that causes problems when switching sources while loading a file

### DIFF
--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -130,6 +130,9 @@ Procedure UpdateSourceStatus(Modified)
   
 EndProcedure
 
+; Note: Do not call FlushEvents() in here as this procedure is called during file loading and processing
+;       events could change the active source again and really mess things up!
+;
 Procedure ChangeActiveSourcecode(*OldSource.SourceFile = 0)
   
   If *OldSource = 0
@@ -268,19 +271,6 @@ Procedure ChangeActiveSourcecode(*OldSource.SourceFile = 0)
       HideGadget(#GADGET_Form, 1)
     EndIf
   EndIf
-  
-  ; Note:
-  ;   For some odd reason, the ResizeMainWindow() above has no effect as long as the ScintillaGadget
-  ;   is not the topmost visible one on Linux. The result is that when you close all tabs, you end up
-  ;   with a newly created '<New>' source that is not visible (because its still sized 0,0)
-  ;
-  ;   This is a Linux only problem and i have no idea why, but just trying another
-  ;   resize after the proper gadget is visible and events are flushed fixes the trouble.
-  ;
-  CompilerIf #CompileLinux
-    FlushEvents() ; this still dispatches all events, so its not problematic
-    ResizeMainWindow()
-  CompilerEndIf
   
   UpdateCursorPosition()
   


### PR DESCRIPTION
Removed a `FlushEvents()` call that messes up the file contents when switching tabs while loading many sources (for example on startup).

Note: The removed "fix" is very old and I cannot reproduce the behavior described in the old comments. So it probably does not apply anymore to the current version of Scintilla and other components. If the described behavior comes back we have to find a different solution for this.

See:
* https://www.purebasic.fr/english/viewtopic.php?t=76168
* https://www.purebasic.fr/english/viewtopic.php?f=18&t=71194
* https://www.purebasic.fr/english/viewtopic.php?f=23&t=69839
