### PR TITLE
Add missing autocomplete data for Base64Encoder and Base64EncoderBuffer.

### DIFF
--- a/PureBasicIDE/ConstantsData.pbi
+++ b/PureBasicIDE/ConstantsData.pbi
@@ -48,6 +48,8 @@ DataSection
   Data$ "ApplyEntityTorqueImpulse,5,#PB_Local,#PB_Parent,#PB_World"
   
   ;- B
+  Data$ "Base64Encoder,3,#PB_Cipher_NoPadding,#PB_Cipher_URL"
+  Data$ "Base64EncoderBuffer,5,#PB_Cipher_NoPadding,#PB_Cipher_URL"
   Data$ "BillboardGroupX,2,#PB_Absolute,#PB_Relative"
   Data$ "BillboardGroupY,2,#PB_Absolute,#PB_Relative"
   Data$ "BillboardGroupZ,2,#PB_Absolute,#PB_Relative"

--- a/PureBasicIDE/ConstantsDataSpiderBasic.pbi
+++ b/PureBasicIDE/ConstantsDataSpiderBasic.pbi
@@ -33,6 +33,8 @@ DataSection
   Data$ "AllocateMemory,2,#PB_Memory_NoClear"
   
   ;- B
+  Data$ "Base64Encoder,4,#PB_Cipher_NoPadding,#PB_Cipher_URL"
+  Data$ "Base64EncoderBuffer,7,#PB_Cipher_NoPadding,#PB_Cipher_URL"
   Data$ "Bin,2,#PB_Quad,#PB_Byte,#PB_Ascii,#PB_Word,#PB_Unicode,#PB_Long"
   Data$ "BindEvent,1,#PB_Event_*"
   Data$ "BindEvent,3,#PB_All"


### PR DESCRIPTION
Fixes reported bug [no context-sensitive autocomplete for Base64Encoder and Base64EncoderBuffer flags] (https://www.purebasic.fr/english/viewtopic.php?t=82202)