### PR TITLE
fix(ToolsPanel): avoid flicker when hiding panel

### DIFF
--- a/PureBasicIDE/ToolsPanel.pb
+++ b/PureBasicIDE/ToolsPanel.pb
@@ -467,6 +467,11 @@ Procedure ToolsPanel_Hide()
       State = GetGadgetState(#GADGET_LogSplitter) ; somehow the reparenting makes the slider jump in the second splitter on linux, so only reset it after ResizeWindow()
     EndIf
     
+    CompilerIf #CompileWindows
+      ; Temporarily disable painting to avoid flickering while reparenting.
+      SendMessage_(WindowID(#WINDOW_Main), #WM_SETREDRAW, #False, 0)
+    CompilerEndIf
+    
     If ToolsPanelSide = 0
       ToolsPanelWidth_Hidden = GadgetWidth(#GADGET_ToolsSplitter) - GetGadgetState(#GADGET_ToolsSplitter)
       SetGadgetAttribute(#GADGET_ToolsSplitter, #PB_Splitter_FirstGadget, #GADGET_ToolsDummy)
@@ -476,9 +481,13 @@ Procedure ToolsPanel_Hide()
     EndIf
     
     ToolsPanelVisible = 0
-    HideGadget(#GADGET_ToolsSplitter, 1)
     HideGadget(#GADGET_ToolsPanelFake, 0)
     ResizeMainWindow()
+    CompilerIf #CompileWindows
+      ; Restore painting to have updated visuals reflected.
+      SendMessage_(WindowID(#WINDOW_Main), #WM_SETREDRAW, #True, 0)
+    CompilerEndIf
+    HideGadget(#GADGET_ToolsSplitter, 1)
     
     If ErrorLogVisible
       SetGadgetState(#GADGET_LogSplitter, State)


### PR DESCRIPTION
This PR resolves a flickering issue mentioned in the conversation at https://github.com/fantaisie-software/purebasic/issues/252#issuecomment-1751737019, where the editing area and toolbar tends to flicker when hiding the ToolsPanel.

I tried a few approaches to avoid the flickering here, but temporarily pausing main-window painting with WM_SETREDRAW seemed to be the solution with least flickering. (Pausing just the editor area works, but then the toolbar flickers, so would have to be separately paused as well)

I have to admit I'm unfamiliar with the `SplitterGadget`, so there might be a better way to deal with the reparenting here without relying on WM_SETREDRAW.