### PR TITLE
Fix typo in SpiderBasic docs

### DIFF
--- a/Documentation/SpiderBasic/English/System.txt
+++ b/Documentation/SpiderBasic/English/System.txt
@@ -127,7 +127,7 @@ The system library offers access to specialized commands.
   @#PB_Device_Platform: The underlying platform ("Android" or "iOS").
   @#PB_Device_UUID    : The unique ID identifier of the device
   @#PB_Device_Version : The OS version (ie: "4" for iOS 4, "4.1" for Android 4.1 etc.)
-  @#PB_Device_Manufacturer: The manufcaturer ("Apple", "Motorola" etc.)
+  @#PB_Device_Manufacturer: The manufacturer ("Apple", "Motorola" etc.)
   @#PB_Device_Serial  : The device hardware serial number
 @EndFixedFont  
     


### PR DESCRIPTION
In Reference manual -> System -> DeviceInfo, "manufacturer" was written as "manufcaturer".