### PR TITLE
Use internal mkdir command on Windows

### DIFF
--- a/PureBasicDebugger/StandaloneDebugger.pb
+++ b/PureBasicDebugger/StandaloneDebugger.pb
@@ -1051,8 +1051,8 @@ Procedure DebuggerCallback(*Debugger.DebuggerData)
       
     Case #COMMAND_Error
       Standalone_AddLog(Language("Debugger","LogError")+" "+GetDebuggerRelativeFile(*Debugger, *Debugger\Command\Value1) + " ("+Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1)+")", *Debugger\Command\TimeStamp)
-      Standalone_AddLog(Language("Debugger","LogError")+" "+PeekAscii(*Debugger\CommandData), *Debugger\Command\TimeStamp)
-      StatusBarText(#STATUSBAR, 0, Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1) +" - " +  PeekAscii(*Debugger\CommandData))
+      Standalone_AddLog(Language("Debugger","LogError")+" "+PeekUTF8(*Debugger\CommandData), *Debugger\Command\TimeStamp)
+      StatusBarText(#STATUSBAR, 0, Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1) +" - " +  PeekUTF8(*Debugger\CommandData))
       UpdateGadgetStates()
       
       SetCurrentLine(*Debugger\Command\Value1)
@@ -1061,8 +1061,8 @@ Procedure DebuggerCallback(*Debugger.DebuggerData)
       
     Case #COMMAND_Warning
       Standalone_AddLog(Language("Debugger","LogWarning")+" "+GetDebuggerRelativeFile(*Debugger, *Debugger\Command\Value1) + " ("+Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1)+")", *Debugger\Command\TimeStamp)
-      Standalone_AddLog(Language("Debugger","LogWarning")+" "+PeekAscii(*Debugger\CommandData), *Debugger\Command\TimeStamp)
-      StatusBarText(#STATUSBAR, 0, Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1) +" - " +  PeekAscii(*Debugger\CommandData))
+      Standalone_AddLog(Language("Debugger","LogWarning")+" "+PeekUTF8(*Debugger\CommandData), *Debugger\Command\TimeStamp)
+      StatusBarText(#STATUSBAR, 0, Language("Misc","Line")+": " + Str(DebuggerLineGetLine(*Debugger\Command\Value1)+1) +" - " +  PeekUTF8(*Debugger\CommandData))
       UpdateGadgetStates()
       
       ; just mark, do not change current line or stop program

--- a/PureBasicIDE/CompilerInterface.pb
+++ b/PureBasicIDE/CompilerInterface.pb
@@ -77,7 +77,7 @@ CompilerIf #CompileWindows
     #COMPILER_UNICODE    = " /UNICODE" ; still needed to set in older compilers
   CompilerEndIf
   
-  #COMPILER_FileFormat = #PB_UTF8
+  #COMPILER_FileFormat = #PB_Ascii
 CompilerElse
   CompilerIf #CompileMac And Not #SpiderBasic
     #COMPILER_STANDBY    = " --standby -f -ibp" ; extra flags for osx only
@@ -95,7 +95,7 @@ CompilerElse
     #COMPILER_UNICODE    = " --unicode" ; still needed to set in older compilers
   CompilerEndIf
   
-  #COMPILER_FileFormat = #PB_UTF8
+  #COMPILER_FileFormat = #PB_Ascii
 CompilerEndIf
 
 

--- a/PureBasicIDE/IDEDebugger.pb
+++ b/PureBasicIDE/IDEDebugger.pb
@@ -875,9 +875,9 @@ Procedure DebuggerCallback(*Debugger.DebuggerData)
       Else
         Debugger_AddLog(*Debugger, Language("Debugger", "LogError") +" "+Language("Misc","Line")+": " + Str(LineNumber), *Debugger\Command\TimeStamp)
       EndIf
-      Debugger_AddLog(*Debugger, Language("Debugger", "LogError") +" " + PeekAscii(*Debugger\CommandData), *Debugger\Command\TimeStamp)
-      
-      ChangeStatus(Language("Misc","Line")+": " + Str(LineNumber) +" - " +  PeekAscii(*Debugger\CommandData), -1)
+      Debugger_AddLog(*Debugger, Language("Debugger", "LogError") +" " + PeekUTF8(*Debugger\CommandData), *Debugger\Command\TimeStamp)
+          
+      ChangeStatus(Language("Misc","Line")+": " + Str(LineNumber) +" - " +  PeekUTF8(*Debugger\CommandData), -1)
       
       If DebuggerKillOnError
         Debugger_Ended(*Debugger)
@@ -907,9 +907,9 @@ Procedure DebuggerCallback(*Debugger.DebuggerData)
       Else
         Debugger_AddLog(*Debugger, Language("Debugger", "LogWarning") +" "+Language("Misc","Line")+": " + Str(LineNumber), *Debugger\Command\TimeStamp)
       EndIf
-      Debugger_AddLog(*Debugger, Language("Debugger", "LogWarning") +" " + PeekAscii(*Debugger\CommandData), *Debugger\Command\TimeStamp)
+      Debugger_AddLog(*Debugger, Language("Debugger", "LogWarning") +" " + PeekUTF8(*Debugger\CommandData), *Debugger\Command\TimeStamp)
       
-      ChangeStatus(Language("Misc","Line")+": " + Str(LineNumber) +" - " +  PeekAscii(*Debugger\CommandData), -1)
+      ChangeStatus(Language("Misc","Line")+": " + Str(LineNumber) +" - " +  PeekUTF8(*Debugger\CommandData), -1)
       
       
     Case #COMMAND_Stopped
@@ -1050,7 +1050,7 @@ Procedure DebuggerCallback(*Debugger.DebuggerData)
         Select *Debugger\Command\Value2 ; result code
             
           Case 0 ; error
-            Message$ = "Debugger: " + PeekAscii(*Debugger\CommandData)
+            Message$ = "Debugger: " + PeekUTF8(*Debugger\CommandData)
             Debug Message$
             
             ; Variable not found is common (place the cursor on a keyword etc),

--- a/PureBasicIDE/Makefile
+++ b/PureBasicIDE/Makefile
@@ -188,13 +188,22 @@ Build/DefaultTheme.zip: data/DefaultTheme/*
 	rm -f Build/DefaultTheme.zip
 	zip -jq Build/DefaultTheme.zip data/DefaultTheme/*
 
-# Use "mkdir" instead on mkdir, so on Windows it search mkdir.exe on the PATH instead of using the internal CMD mkdir.
-# It works on Linux and OS X as well.
+# On Linux and OS X, use "mkdir" (mkdir.exe) instead of mkdir, to make it works
+# On Windows, use internal mkdir command, mkdir.exe does not exist and internal mkdir does not support -p switch
+# %OS% is the type of windows: Windows_NT
 #
+ifeq ($(OS),Windows_NT)
 $(THEMEFOLDER)/SilkTheme.zip: data/SilkTheme/*
-	"mkdir" -p "$(THEMEFOLDER)"
+	mkdir "$(THEMEFOLDER)"
 	rm -f "$(THEMEFOLDER)/SilkTheme.zip"
 	zip -jq "$(THEMEFOLDER)/SilkTheme.zip" data/SilkTheme/*
+
+else
+$(THEMEFOLDER)/SilkTheme.zip: data/SilkTheme/*
+	"mkdir.exe" -p "$(THEMEFOLDER)"
+	rm -f "$(THEMEFOLDER)/SilkTheme.zip"
+	zip -jq "$(THEMEFOLDER)/SilkTheme.zip" data/SilkTheme/*
+endif
 
 $(COLORTABLE): data/ColorTable.xml
 	cp -f data/ColorTable.xml "$(COLORTABLE)"


### PR DESCRIPTION
On Linux and OS X, use "mkdir" (mkdir.exe) instead of mkdir, to make it works, as it is currently.
On Windows, use internal mkdir command, mkdir.exe does not exist and internal mkdir does not support -p switch

Otherwise, on Windows we get this error:
`"mkdir.exe" -p "D:\PureBasic_Opensource\PureBasic_Windows_beta2_X64_6.10/Themes" - 
'"mkdir.exe"' n’est pas reconnu en tant que commande interne ou externe, un programme exécutable ou un fichier de commandes.`

Not verified on Linux and OS X that it continues to work as expected!