### PR TITLE
Accessibility improvements for issues window.

### DIFF
--- a/PureBasicIDE/Issues.pb
+++ b/PureBasicIDE/Issues.pb
@@ -390,6 +390,8 @@ Procedure Issues_CreateFunction(*Entry.ToolsPanelEntry, PanelItemID)
   GadgetToolTip(#GADGET_Issues_Export,     Language("ToolsPanel", "Export"))
   
   If EnableAccessibility
+    ; Sets a label on the buttons for screen reader users.
+    ; This label is only ever seen by screen readers, and never visually shown.
     SetGadgetText(#GADGET_Issues_SingleFile, Language("ToolsPanel", "SingleFile"))
     SetGadgetText(#GADGET_Issues_MultiFile,  Language("ToolsPanel", "MultiFile"))
     SetGadgetText(#GADGET_Issues_Export,     Language("ToolsPanel", "Export"))


### PR DESCRIPTION
## Fixes

* Labeled a few unlabeled controls in the issues window.
	* I wanted to make the single file and multi-file toggles OptionGadgets, but I couldn't figure out how to make it so I could arrow between them. Any input on this would be appreciated.
* Made the issues list have the default keyboard focus in accessibility mode.
