### PR TITLE
Fixed a typo in the English and German docs causing CreateMutex() to not show a parameter list.

### DIFF
--- a/Documentation/English/Thread.txt
+++ b/Documentation/English/Thread.txt
@@ -105,7 +105,7 @@
 @Linebreak
   See @@LockMutex and @@UnlockMutex for locking/unlocking a mutex.
 
-@NoParameter
+@NoParameters
 
 @ReturnValue
   The new mutext object, or zero if the mutex creation has failed.

--- a/Documentation/German/Thread.txt
+++ b/Documentation/German/Thread.txt
@@ -112,7 +112,7 @@
   Siehe @@LockMutex und @@UnlockMutex für
   das Sperren/Entsperren eines Mutex.
 
-@NoParameter
+@NoParameters
 
 @ReturnValue
   Das neue Mutex-Objekt - oder Null, wenn die Mutex-Erstellung fehlgeschlagen ist.


### PR DESCRIPTION
`@NoParameters` was written as `@NoParameter` in the English and German docs for CreateMutex(). French was uneffected.