### PR TITLE
Documentation grammar correction for 'Bound'

### DIFF
--- a/Documentation/English/CGI.txt
+++ b/Documentation/English/CGI.txt
@@ -665,7 +665,7 @@
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function Result = InitFastCGI(LocalPort [, BindedIP$])
+@Function Result = InitFastCGI(LocalPort [, BoundIP$])
 
 @Description
   Initializes FastCGI support. Once called, all the CGI commands switch automatically to FastCGI support.
@@ -681,7 +681,7 @@
 @Parameter "LocalPort"
   The local port to bind the FastCGI application. The web-server needs to be configured to use this port.
 
-@OptionalParameter "BindedIP$"
+@OptionalParameter "BoundIP$"
   The IP address to bind the FastCGI application. For now, only "localhost" or "127.0.0.1" is accepted.
 
 @ReturnValue
@@ -696,7 +696,7 @@
 @FixedFont  
   ProxyPass /myfastcgiapp/ fcgi://localhost:5600/
 @EndFixedFont  
-  Here, the url '/myfastcgiapp' will redirect to the FastCGI program binded on the port 5600. It's also possible to
+  Here, the url '/myfastcgiapp' will redirect to the FastCGI program bound on the port 5600. It's also possible to
   run the FastCGI program on distant server.
 @Example
 @Code

--- a/Documentation/English/Network.txt
+++ b/Documentation/English/Network.txt
@@ -110,7 +110,7 @@ ftp clients, etc) or even multiplayer games.
 
 ;--------------------------------------------------------------------------------------------------------
 
-@Function Result = CreateNetworkServer(#Server, Port [, Mode [, BindedIP$]])
+@Function Result = CreateNetworkServer(#Server, Port [, Mode [, BoundIP$]])
 
 @Description
   Create a new network server on the local computer using the specified port. 
@@ -136,7 +136,7 @@ ftp clients, etc) or even multiplayer games.
   @#PB_Network_IPv6: create a server using IPv6
 @EndFixedFont
 
-@OptionalParameter "BindedIP$"
+@OptionalParameter "BoundIP$"
   The local IP address to bind the server. By default, the server is created on all available local interfaces, and accept
   connections from them. It can be useful to restrict the server to only one interface (for example "127.0.0.1")
   to avoid connection attempt from other interfaces. On Windows, binding only to the localhost avoid to trigger the

--- a/Documentation/English/WebView.txt
+++ b/Documentation/English/WebView.txt
@@ -254,7 +254,7 @@
 @Function UnbindWebViewCallback(#Gadget, JavaScriptFunction$)
 
 @Description
-  Unbind a JavaScript function previously binded with @@BindWebViewCallback. The JavaScript function will be automatically removed from the web view and won't be be available anymore in the JavaScript code.
+  Unbind a JavaScript function previously bound with @@BindWebViewCallback. The JavaScript function will be automatically removed from the web view and won't be be available anymore in the JavaScript code.
   
 @Parameter "#Gadget"
   The web view gadget to use.

--- a/Documentation/English/Window.txt
+++ b/Documentation/English/Window.txt
@@ -330,7 +330,7 @@
   Note: The following items created for a window are also automatically freed when the window
   is closed: @LibraryLink "gadget" "Gadgets", @Link "AddKeyboardShortcut" "Keyboard shortcuts",
   @LibraryLink "menu" "Menus", @LibraryLink "statusbar" "StatusBars", @Link "AddWindowTimer" "Timers",
-  @LibraryLink "toolbar" "Toolbars" and binded events (with @@BindEvent).
+  @LibraryLink "toolbar" "Toolbars" and bound events (with @@BindEvent).
 
 @SeeAlso
   @@OpenWindow


### PR DESCRIPTION
The past tense of 'bind' is 'bound' not 'binded'.