### PR TITLE
Linux build target executables now lowercase "purebasic"

### DIFF
--- a/PureBasicIDE/PureBasicIDE.pbp
+++ b/PureBasicIDE/PureBasicIDE.pbp
@@ -411,9 +411,9 @@
     </target>
     <target name="Linux - x86" enabled="1" default="0">
       <inputfile value="PureBasic.pb"/>
-      <outputfile value="..\Build\x86\PureBasic"/>
+      <outputfile value="..\Build\x86\purebasic"/>
       <commandline value="/NOEXT"/>
-      <executable value="..\Build\x86\PureBasic"/>
+      <executable value="..\Build\x86\purebasic"/>
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1" optimizer="0"/>
       <icon enable="1">data\logo\PBLogoLinux.png</icon>
@@ -429,9 +429,9 @@
     </target>
     <target name="Linux - x64" enabled="1" default="0">
       <inputfile value="PureBasic.pb"/>
-      <outputfile value="..\Build\x64\PureBasic"/>
+      <outputfile value="..\Build\x64\purebasic"/>
       <commandline value="/NOEXT"/>
-      <executable value="..\Build\x64\PureBasic"/>
+      <executable value="..\Build\x64\purebasic"/>
       <directory value="data\"/>
       <options thread="1" xpskin="1" dpiaware="1" debug="1" optimizer="0"/>
       <icon enable="1">data\logo\PBLogoLinux.png</icon>


### PR DESCRIPTION
The PureBasicIDE project file has pre-defined build targets for Windows, Mac, and Linux. See #102 

Now that I'm using PB Linux, I realize the official packaged executables are all lowercase. The IDE is  `purebasic`, not `PureBasic`. Because Linux paths are case sensitive, I've corrected the two Linux build targets.