### PR TITLE
Linux: bring Help window to foreground after creating

### DIFF
--- a/PureBasicIDE/LinuxHelp.pb
+++ b/PureBasicIDE/LinuxHelp.pb
@@ -707,6 +707,7 @@ CompilerIf #CompileLinux
         
         ClearList(Help_History())
         
+        SetWindowForeground(#WINDOW_Help)
       EndIf
     Else
       SetWindowForeground(#WINDOW_Help)


### PR DESCRIPTION
On Linux*, it took two presses of `F1` to see the Help window. The first press created the Help window, but it always appears behind the IDE, subsequent presses brought it to the foreground. This Linux-only change brings `#WINDOW_Help` to the foreground immediately after creation.

* ElementaryOS 7.1 (Ubuntu 22.04 based)