### PR TITLE
Linux: handle LeftTab event to allow tabbing backward through ProjectInfo

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -626,6 +626,20 @@ CompilerIf #CompileLinux
     Debug "Key event: " + *Event\keyval
     If *Event\keyval = #GDK_Return
       PostEvent(#PB_Event_Gadget, #WINDOW_Main, Gadget, #PB_EventType_LeftDoubleClick)
+      
+    ElseIf *Event\keyval = $FE20 ; #GDK_LeftTab
+      If (*Event\state & (1 << 2)) ; Ctrl
+        If (*Event\state & 1) ; Shift
+          If KeyboardShortcuts(#MENU_NextOpenedFile) = #PB_Shortcut_Control|#PB_Shortcut_Shift|#PB_Shortcut_Tab
+            ;ChangeCurrentFile(0)
+            PostEvent(#PB_Event_Menu, #WINDOW_Main, #MENU_NextOpenedFile)
+          ElseIf KeyboardShortcuts(#MENU_PreviousOpenedFile) = #PB_Shortcut_Control|#PB_Shortcut_Shift|#PB_Shortcut_Tab
+            ;ChangeCurrentFile(1)
+            PostEvent(#PB_Event_Menu, #WINDOW_Main, #MENU_PreviousOpenedFile)
+          EndIf
+        EndIf
+      EndIf
+      
     EndIf
   EndProcedure
 CompilerEndIf


### PR DESCRIPTION
On Linux*, with a project open in the IDE, I can `Ctrl+Tab` forward through all open tabs with no problem, but `Ctrl+Shift+Tab` backward gets "stuck" on the ProjectInfo tab.

It seems `Ctrl+Shift+Tab` throws a GDK key value `$FE20` (`LeftTab`) plus `Ctrl` and `Shift` modifiers. This patch handles those events, similar to how `ScintillaShortcutHandler()` handles `$FF09`, and posts the appropriate `#MENU` response.

⚠️ _Can others with more PB Linux and GDK experience confirm this bug, and review this bugfix? Thanks!_

* ElementaryOS 7.1 (Ubuntu 22.04 based)