### PR TITLE
Debugging IDE Drag-and-drop

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -2898,6 +2898,10 @@ CompilerIf #PB_Compiler_Debugger
   ; (new debugger event is processed While being in a debugger event. It is wrong, As it can changes the display order, and creates weird bug).
   ;
   Global InDebuggerCallback = #False
+  ; Useful to ensures WindowEvent() is NEVER called in the MainWindowCallback WM_DropFiles event when débugging as it crash
+  ; (WindowEvent() can Not be called from a 'binded' event callback) 
+  ; 
+  Global InDragDropCallback = #False
 CompilerEndIf
 
 UseMD5Fingerprint()

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -2718,9 +2718,18 @@ EndProcedure
 ;
 Procedure FlushEvents()
   
-  While DispatchEvent(WindowEvent()) ; returns the eventid
-    EventLoopCallback()
-  Wend
+  CompilerIf #PB_Compiler_Debugger
+    ; When debugging the IDE with a new tab then drag and drop a project, it crashes with: [ERROR] WindowEvent() can Not be called from a 'binded' event callback.
+    If InDragDropCallback = #False
+      While DispatchEvent(WindowEvent()) ; returns the eventid
+        EventLoopCallback()
+      Wend
+    EndIf
+  CompilerElse
+    While DispatchEvent(WindowEvent()) ; returns the eventid
+      EventLoopCallback()
+    Wend
+  CompilerEndIf        
   
 EndProcedure
 

--- a/PureBasicIDE/WindowsMisc.pb
+++ b/PureBasicIDE/WindowsMisc.pb
@@ -288,6 +288,11 @@ CompilerIf #CompileWindows
     Result = #PB_ProcessPureBasicEvents
     
     If Message = #WM_DROPFILES ; drag and drop stuff
+      
+      CompilerIf #PB_Compiler_Debugger
+        InDragDropCallback = #True
+      CompilerEndIf
+      
       *hdrop = wParam
       
       count = DragQueryFile_(*hdrop, $FFFFFFFF, 0, 0)
@@ -307,6 +312,10 @@ CompilerIf #CompileWindows
       Next i
       
       DragFinish_(*hdrop)
+      
+      CompilerIf #PB_Compiler_Debugger
+        InDragDropCallback = #False
+      CompilerEndIf
       
     ElseIf Message = #WM_SYSCOMMAND
       wParam & $FFF0    ; mask out the windows internal 4 bits


### PR DESCRIPTION
When debugging the IDE with a new tab then drag and drop a project, it crashes with: 
[ERROR] WindowEvent() can Not be called from a 'binded' event callback.


