### PR TITLE
Fix grammar and typos in SpiderBasic history file.

### DIFF
--- a/Documentation/SpiderBasic/English/MainGuide/history.txt
+++ b/Documentation/SpiderBasic/English/MainGuide/history.txt
@@ -5,7 +5,7 @@
 - Added: Android 34 ABI support to be able to publish on PlayStore @LineBreak
 - Added: Disabled code formatting in EnableJS/DisableJS block so JavaScript can be written directly in it @LineBreak
 - Added: Ubuntu 24.04 build @LineBreak
-- Added: Date library now support date between 1601 to 9999 @LineBreak
+- Added: Date library now supports dates between 1601 to 9999 @LineBreak
 - Added: Allowed wide date range for DateGadget() and CalendarGadget (from 1601 to 9999) @LineBreak
 
 
@@ -22,7 +22,7 @@
 - Added: AddTimer(), RemoveTimer() to have window independant timers. @LineBreak
 - Added: SplashScreenControl() to handle when closing the splashscreen. @LineBreak
  @LineBreak
-- Fixed: Some compiler and librarie bugs @LineBreak
+- Fixed: Some compiler and library bugs @LineBreak
 
 
 @Section 13th December 2023 : Version 2.51
@@ -42,12 +42,12 @@
 - Added: #PB_Compiler_App to detect the created app type: #PB_App_Android, #PB_App_IOS or #PB_App_Web @LineBreak
 - Added: --keepappdir on commandline and 'Create App' window to keep the cordova app directory @LineBreak
 @LineBreak
-- Updated: Cordova to lastest 11 version @LineBreak
+- Updated: Cordova to latest 11 version @LineBreak
 - Updated: Android API to 33 @LineBreak
 - Updated: PixiJS to 5.3.12 @LineBreak
 - Updated: InnoSetup on Windows to be able to install SpiderBasic without admin rights. @LineBreak
  @LineBreak
-- Fixed: Some compiler and librarie bugs @LineBreak
+- Fixed: Some compiler and library bugs @LineBreak
 
 
 @Section 28th November 2022 : Version 2.40
@@ -65,7 +65,7 @@
 - Added: #PB_ListIcon_GridLines support @LineBreak
 - Added: a timestamp to the index.html to avoid caching problem @LineBreak
 - Added: native OS X arm64 version @LineBreak
-- Added: all IDE improvement from PureBasic @LineBreak
+- Added: all IDE improvements from PureBasic @LineBreak
  @LineBreak
 - Updated: android framework to android-32 to be able to publish app on Google PlayStore @LineBreak
 - Updated: the application license file @LineBreak
@@ -85,7 +85,7 @@
 - Added: MessageRequester(), InputRequester() @LineBreak
 - Added: DeviceAlwaysOn(), DeviceBrightness() @LineBreak
 - Added: #PB_Window_AllowSelection flag to OpenWindow() to allow to select gadget text for copy/paste @LineBreak
-- Added: LoadScript() to load an external scripts for use in the program (JS, CSS) @LineBreak
+- Added: LoadScript() to load external scripts for use in the program (JS, CSS) @LineBreak
 - Added: #PB_Canvas_Container flag to CanvasGadget() @LineBreak
 - Added: CloseDebugOutput() to close the debug output window @LineBreak
 - Added: SDK example for LibraryMaker to create your own user libraries @LineBreak
@@ -98,7 +98,7 @@
 @Section 13th September 2019 : Version 2.22
 
 - Added: verbose (-vb, --verbose) switch to the commandline compiler to have all cordova outputs and help debugging @LineBreak
-- Added: new button in the iOS app window, to check if OS X is properly setuped (it will also update cordova if a new version is available) @LineBreak
+- Added: new button in the iOS app window, to check if OS X is properly set up (it will also update cordova if a new version is available) @LineBreak
 @LineBreak
 - Fixed: some compiler and library bugs
 
@@ -149,7 +149,7 @@
 - Added: app name field for WebApp @LineBreak
 - Added: default browser choice in Preferences -> Compiler @LineBreak
 - Added: too old browser detection when launching an app @LineBreak
-- Added: a lot of switch to the commandline compiler to support mobile app @LineBreak
+- Added: a lot of switches to the commandline compiler to support mobile app @LineBreak
 - Added: custom headers support to HttpRequest() @LineBreak
 - Added: #PB_Text_VerticalCenter flag to TextGadget() @LineBreak
 - Added: touch support to window dragging and resizing @LineBreak
@@ -158,7 +158,7 @@
 - Optimized: reduced greatly DOJO footprint for much faster app loading @LineBreak
 - Optimized: minified most of the spiderlibraries dependencies to reduce footprint @LineBreak
 @LineBreak
-- Updated: DOJO to lastest 1.11.2 version @LineBreak
+- Updated: DOJO to latest 1.11.2 version @LineBreak
 @LineBreak
 - Changed: Moved the old 'Export' panel to new 'Create App' window @LineBreak
 - Changed: OSX compiler is now bundled in the main SpiderBasic app for easier installation @LineBreak


### PR DESCRIPTION
I fixed a couple typos (e.g. librarie -> library) ,and fixed some grammar as well. (English docs only).