### PR TITLE
Linux/Mac: Normalize keyboard shortcuts to uppercase values

### DIFF
--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -471,6 +471,7 @@ Procedure LoadPreferences()
     Read.s MenuItem$
     Read.l DefaultShortcut
     KeyboardShortcuts(i) = ReadPreferenceLong(MenuItem$, DefaultShortcut)
+    KeyboardShortcuts(i) = NormalizeShortcut(KeyboardShortcuts(i))
   Next i
   
   ; a little fix to not have a shortcut twice, since i switched two shortcut values in the defaults
@@ -4905,6 +4906,7 @@ Procedure PreferencesWindowEvents(EventID)
         
       Case #GADGET_Preferences_ShortcutSet
         Shortcut = GetGadgetState(#GADGET_Preferences_SelectShortcut)
+        Shortcut = NormalizeShortcut(Shortcut)
         ;         Shortcut = ShortcutValues(GetGadgetState(#GADGET_Preferences_ShortcutKey))
         ;         If GetGadgetState(#GADGET_Preferences_ShortcutControl)
         ;           Shortcut | #PB_Shortcut_Control

--- a/PureBasicIDE/ShortcutManagement.pb
+++ b/PureBasicIDE/ShortcutManagement.pb
@@ -70,6 +70,31 @@ Procedure CreateKeyboardShortcuts(Window)
   
 EndProcedure
 
+Procedure NormalizeShortcut(Shortcut)
+  
+  ; On Linux/Mac, ShortcutGadget may return a lowercase base key value which does not match a #PB_Shortcut_* value, so remap to uppercase
+  CompilerIf (#CompileMac Or #CompileLinux)
+    Modifiers = Shortcut & (#PB_Shortcut_Control | #PB_Shortcut_Alt | #PB_Shortcut_Shift | #PB_Shortcut_Command)
+    BaseKey = Shortcut & (~Modifiers)
+    
+    Select (BaseKey)
+      Case 'a' To 'z'
+        CompilerIf (#PB_Shortcut_A = 'A')
+          Shortcut = #PB_Shortcut_A + (BaseKey - 'a')
+        CompilerEndIf
+      Case 'A' To 'Z'
+        CompilerIf (#PB_Shortcut_A = 'a')
+          Shortcut = #PB_Shortcut_A + (BaseKey - 'A')
+        CompilerEndIf
+    EndSelect
+    
+    ; Preserve original modifiers, even if Shortcut value was changed above
+    Shortcut = Shortcut | Modifiers
+  CompilerEndIf
+  
+  ProcedureReturn Shortcut
+EndProcedure
+
 Procedure GetBaseKeyIndex(Shortcut)
   
   If Shortcut


### PR DESCRIPTION
Problem: (Linux/Mac, not Windows) The **ShortcutGadget** used to assign keyboard shortcuts can return uppercase or lowercase values depending on whether `Shift` or `CapsLock` was active. For example `Alt+'A'` or `Alt+'a'`. Only the uppercase matches a `#PB_Shortcut_*` constant. This causes (at least) two problems:

1. When converting value to string (see shortcut table in IDE preferences), lowercase-valued shortcuts will be missing the letter. For example `Alt+'a'` will show as just `Alt+`.
2. Since you can generate two different shortcut values (try it with `CapsLock` on or off), you can assign the same key combination twice in the IDE table, without warning. Then it seems only the uppercase-value shortcut with work!

Ideal solution: It would probably be best to solve this in the ShortcutGadget library. Could it always return a consistent value regardless of `Shift` and `CapsLock` state?

**Simple IDE fix for now**: This patch adds `NormalizeShortcut()` which remaps lowercase values to uppercase. It can be expanded to more cases. Currently, it only has an effect on Linux/Mac, and it only has an effect on alphabet letter shortcuts.

Forum thread about this: https://www.purebasic.fr/english/viewtopic.php?t=85404
