### PR TITLE
Russian-Catalog-Encoding

### DIFF
--- a/Documentation/Catalogs/Russian/compiler.catalog
+++ b/Documentation/Catalogs/Russian/compiler.catalog
@@ -1,4 +1,4 @@
-﻿[LanguageInfo]
+[LanguageInfo]
 Application = PB_Compiler
 Language = Russian
 LastUpdated = 20/04/2022

--- a/Documentation/Catalogs/Russian/debugger.catalog
+++ b/Documentation/Catalogs/Russian/debugger.catalog
@@ -1,4 +1,4 @@
-﻿[LanguageInfo]
+[LanguageInfo]
 Application = PB_Debugger
 Language = Russian
 Creator = purebasic.mybb.ru

--- a/Documentation/Catalogs/Russian/libraries.catalog
+++ b/Documentation/Catalogs/Russian/libraries.catalog
@@ -1,4 +1,4 @@
-﻿[LanguageInfo]
+[LanguageInfo]
 Application = PB_Libraries
 Language = Russian
 Creator = purebasic.mybb.ru


### PR DESCRIPTION
Message from AZJIO who seems not to have access
The Russian compiler.catalog, debugger.catalog and libraries.catalog files must be in utf-8 without BOM. Now with BOM and because of this the text is in English.

My fault, when I converted, I probably only looked at editor.catalog to find out the encoding for the other languages, UTF8+Bom for this one.