### PR TITLE
Documentation fix for GadgetType

### DIFF
--- a/Documentation/English/Gadget.txt
+++ b/Documentation/English/Gadget.txt
@@ -2298,6 +2298,7 @@
   @#PB_GadgetType_ListIcon      : @@ListIconGadget
   @#PB_GadgetType_ListView      : @@ListViewGadget
   @#PB_GadgetType_MDI           : @@MDIGadget
+  @#PB_GadgetType_OpenGL        : @@OpenGLGadget
   @#PB_GadgetType_Option        : @@OptionGadget
   @#PB_GadgetType_Panel         : @@PanelGadget
   @#PB_GadgetType_ProgressBar   : @@ProgressBarGadget

--- a/Documentation/German/Gadget.txt
+++ b/Documentation/German/Gadget.txt
@@ -2427,6 +2427,7 @@
   @#PB_GadgetType_ListIcon      : @@ListIconGadget
   @#PB_GadgetType_ListView      : @@ListViewGadget
   @#PB_GadgetType_MDI           : @@MDIGadget
+  @#PB_GadgetType_OpenGL        : @@OpenGLGadget
   @#PB_GadgetType_Option        : @@OptionGadget
   @#PB_GadgetType_Panel         : @@PanelGadget
   @#PB_GadgetType_ProgressBar   : @@ProgressBarGadget


### PR DESCRIPTION
Added missing #PB_GadgetType_OpenGL to GadgetType English and German. Fixes https://www.purebasic.fr/english/viewtopic.php?t=86297.