### PR TITLE
Add option to add a custom parent to form in Form Designer

### DIFF
--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -1010,10 +1010,10 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
             line + ", "
           EndIf
           
-          If Not FindString(FormWindows()\parent, "(")
+          If Asc(FormWindows()\parent) <> '=' 
             line + "WindowID(" + FormWindows()\parent + ")"
           Else
-            line + FormWindows()\parent
+            line + LTrim(FormWindows()\parent, "=") 
           EndIf
           
         EndIf

--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -1010,7 +1010,12 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
             line + ", "
           EndIf
           
-          line + "WindowID(" + FormWindows()\parent + ")"
+          If Not FindString(FormWindows()\parent, "(")
+            line + "WindowID(" + FormWindows()\parent + ")"
+          Else
+            line + FormWindows()\parent
+          EndIf
+          
         EndIf
         
         line +  ")"


### PR DESCRIPTION
I have made a small change to 'codeviewer.pb' so that a custom 'parent' for the form can be passed using the suffix '='.
Now the following is possible

`Wnd = OpenWindow(#PB_Any, x, y, width, height, "", #PB_Window_BorderLess, GetWindow_(GadgetID(#ScrollArea),#GW_CHILD))`

in which the following is entered in **parent**:  `=GetWindow_(GadgetID(#ScrollArea),#GW_CHILD))`