### PR TITLE
Add new options to Form Designer

### DIFF
--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -1010,10 +1010,10 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
             line + ", "
           EndIf
           
-          If Not FindString(FormWindows()\parent, "(")
+          If Asc(FormWindows()\parent) <> '=' 
             line + "WindowID(" + FormWindows()\parent + ")"
           Else
-            line + FormWindows()\parent
+            line + LTrim(FormWindows()\parent, "=") 
           EndIf
           
         EndIf

--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -966,6 +966,12 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
                 flags + Gadgets()\Flags()\name
               EndIf
             Next
+            ForEach Gadgets()\customFlags()
+                If flags <> ""
+                  flags + " | "
+                EndIf
+                flags + Gadgets()\customFlags()\name
+            Next
           EndIf
         Next
         

--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -480,6 +480,11 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
             If FormWindows()\FormGadgets()\type = #Form_Type_Container Or FormWindows()\FormGadgets()\type = #Form_Type_Panel Or FormWindows()\FormGadgets()\type = #Form_Type_ScrollArea
               AddElement(ContainerLevel())
               ContainerLevel() = ObjList()\level
+            ElseIf FormWindows()\FormGadgets()\type = #Form_Type_Frame3D
+              if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+                AddElement(ContainerLevel())
+                ContainerLevel() = ObjList()\level
+              Endif
             EndIf
             
             

--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -1010,7 +1010,12 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
             line + ", "
           EndIf
           
-          line + "WindowID(" + FormWindows()\parent + ")"
+          If Not FindString(FormWindows()\parent, "(")
+            line + "WindowID(" + FormWindows()\parent + ")"
+          Else
+            line + FormWindows()\parent
+          EndIf
+          
         EndIf
         
         line +  ")"

--- a/PureBasicIDE/FormDesigner/declare.pb
+++ b/PureBasicIDE/FormDesigner/declare.pb
@@ -456,6 +456,7 @@ Structure Gadgets
   icon.i
   node.b
   List Flags.Flags()
+  List customFlags.Flags()
   List Events.EventType()
 EndStructure
 

--- a/PureBasicIDE/FormDesigner/declare.pb
+++ b/PureBasicIDE/FormDesigner/declare.pb
@@ -716,6 +716,8 @@ AddElement(Gadgets()\Flags()) : Gadgets()\Flags()\name = "#PB_Frame_Double" : Ga
 Gadgets()\Flags()\ivalue = 1 << 1
 AddElement(Gadgets()\Flags()) : Gadgets()\Flags()\name = "#PB_Frame_Flat" : Gadgets()\Flags()\value = #PB_Frame_Flat
 Gadgets()\Flags()\ivalue = 1 << 2
+AddElement(Gadgets()\Flags()) : Gadgets()\Flags()\name = "#PB_Frame_Container" : Gadgets()\Flags()\value = #PB_Frame_Container
+Gadgets()\Flags()\ivalue = 1 << 3
 AddElement(Gadgets()) : Gadgets()\type = #Form_Type_HyperLink
 Gadgets()\node = 1
 Gadgets()\icon = #IMAGE_FormIcons_HyperLink

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -6430,6 +6430,17 @@ Procedure FD_InitSelectParent(parent_gadget)
           EndIf
           
           i + 1
+        Case #Form_Type_Frame3D
+          if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+            AddGadgetItem(#GADGET_Form_Parent_Select,i,FormWindows()\FormGadgets()\variable)
+            SetGadgetItemData(#GADGET_Form_Parent_Select,i,FormWindows()\FormGadgets()\itemnumber)
+            
+            If FormWindows()\FormGadgets()\itemnumber = parent_gadget
+              selected = i
+            EndIf
+            
+            i + 1
+          endif
       EndSelect
     EndIf
   Next

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -730,6 +730,17 @@ Procedure FD_SelectWindow(window)
           
           i+1
         Next
+        if ListSize(Gadgets()\Flags()) <= 0 : i + 1 : Endif
+        custFlags.s = ""
+        ForEach Gadgets()\customFlags()
+          if custFlags = ""
+            custFlags = Gadgets()\customFlags()\name
+          Else
+            custFlags + "|" + Gadgets()\customFlags()\name
+          Endif  
+        Next
+        PropGridAddItem(propgrid, i, Language("Form", "customFlags"), custFlags)
+        i + 1
       EndIf
     Next
     
@@ -6822,6 +6833,8 @@ Procedure FD_ProcessEventGridWindow(col,row)
     Default
       i = 17
       flag = 0
+      custFlags.s = ""
+      
       ForEach Gadgets()
         If Gadgets()\type = #Form_Type_Window
           ForEach Gadgets()\Flags()
@@ -6835,6 +6848,18 @@ Procedure FD_ProcessEventGridWindow(col,row)
             EndIf
             i+1
           Next
+          custFlags = grid_GetCellString(propgrid, 2, i)
+          numflags = CountString(custFlags,"|")
+          ClearList(Gadgets()\customFlags())
+          For k = 0 To numflags
+            If numflags = 0
+              thisflags.s = Trim(custFlags)
+            Else
+              thisflags.s = Trim(StringField(custFlags,k+1,"|"))
+            EndIf
+            AddElement(Gadgets()\customFlags())
+            Gadgets()\customFlags()\name = thisflags
+          Next k
         EndIf
       Next
       FormWindows()\flags = flag

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -6848,18 +6848,20 @@ Procedure FD_ProcessEventGridWindow(col,row)
             EndIf
             i+1
           Next
-          custFlags = grid_GetCellString(propgrid, 2, i)
+          custFlags = Trim(grid_GetCellString(propgrid, 2, i))
           numflags = CountString(custFlags,"|")
           ClearList(Gadgets()\customFlags())
-          For k = 0 To numflags
-            If numflags = 0
-              thisflags.s = Trim(custFlags)
-            Else
-              thisflags.s = Trim(StringField(custFlags,k+1,"|"))
-            EndIf
-            AddElement(Gadgets()\customFlags())
-            Gadgets()\customFlags()\name = thisflags
-          Next k
+          if custFlags
+            For k = 0 To numflags
+              If numflags = 0
+                thisflags.s = custFlags
+              Else
+                thisflags.s = Trim(StringField(custFlags,k+1,"|"))
+              EndIf
+              AddElement(Gadgets()\customFlags())
+              Gadgets()\customFlags()\name = thisflags
+            Next k
+          endif
         EndIf
       Next
       FormWindows()\flags = flag

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -8313,6 +8313,11 @@ Procedure FD_Event(EventID, EventGadgetID, EventType)
                   Case #Form_Type_Container, #Form_Type_Panel, #Form_Type_ScrollArea
                     parent = FormWindows()\FormGadgets()\itemnumber
                     Break
+                  Case #Form_Type_Frame3D
+                    if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+                      parent = FormWindows()\FormGadgets()\itemnumber
+                      Break
+                    Endif
                 EndSelect
               EndIf
             Until PreviousElement(FormWindows()\FormGadgets()) = 0

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1218,31 +1218,64 @@ Procedure FD_Open(file.s,update = 0)
           flags.s = Trim(Mid(line,start,startnext-start))
           winflag = 0
           numflags = CountString(flags,"|")
-          
+          addCustomFlag.b = #False
+
           If numflags = 0
             thisflags.s = Trim(flags)
             
             ForEach Gadgets()
-              ForEach Gadgets()\Flags()
-                If thisflags = Gadgets()\Flags()\name
-                  winflag = Gadgets()\Flags()\ivalue
-                EndIf
-              Next
+              If Gadgets()\type = #Form_Type_Window
+                ForEach Gadgets()\Flags()
+                  If thisflags = Gadgets()\Flags()\name
+                    winflag = Gadgets()\Flags()\ivalue
+                  Else
+                    ;add custom flags to an extra list.
+                    ;custom flags have no effect on the display of the form in the Form Designer
+                    addCustomFlag = #True
+                    ForEach Gadgets()\customFlags()
+                      if Gadgets()\customFlags()\name = thisflags
+                        addCustomFlag = #False
+                        break
+                      Endif
+                    Next
+                    if addCustomFlag
+                      AddElement(Gadgets()\customFlags())
+                      Gadgets()\customFlags()\name = thisflags
+                    Endif
+                  EndIf
+                Next
+              endif
             Next
           Else
             For i = 0 To numflags
               thisflags.s = Trim(StringField(flags,i+1,"|"))
               
               ForEach Gadgets()
-                ForEach Gadgets()\Flags()
-                  If thisflags = Gadgets()\Flags()\name
-                    If winflag = 0
-                      winflag = Gadgets()\Flags()\ivalue
+                If Gadgets()\type = #Form_Type_Window
+                  ForEach Gadgets()\Flags()
+                    If thisflags = Gadgets()\Flags()\name
+                      If winflag = 0
+                        winflag = Gadgets()\Flags()\ivalue
+                      Else
+                        winflag | Gadgets()\Flags()\ivalue
+                      EndIf
                     Else
-                      winflag | Gadgets()\Flags()\ivalue
+                      ;add custom flags to an extra list.
+                      ;custom flags have no effect on the display of the form in the Form Designer
+                      addCustomFlag = #True
+                      ForEach Gadgets()\customFlags()
+                        if Gadgets()\customFlags()\name = thisflags
+                          addCustomFlag = #False
+                          break
+                        Endif
+                      Next
+                      if addCustomFlag
+                        AddElement(Gadgets()\customFlags())
+                        Gadgets()\customFlags()\name = thisflags
+                      Endif
                     EndIf
-                  EndIf
-                Next
+                  Next
+                endif
               Next
             Next
           EndIf

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1291,7 +1291,7 @@ Procedure FD_Open(file.s,update = 0)
             If FindString(parentwin, "WindowID(")
               parentwin = ReplaceString(parentwin, "WindowID(", "")
               parentwin = ReplaceString(parentwin, ")", "")
-            Else
+            Elseif parentwin
               parentwin = "=" + parentwin
             EndIf
             FormWindows()\parent = parentwin

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1228,7 +1228,7 @@ Procedure FD_Open(file.s,update = 0)
                 ForEach Gadgets()\Flags()
                   If thisflags = Gadgets()\Flags()\name
                     winflag = Gadgets()\Flags()\ivalue
-                  Else
+                  Elseif thisflags and thisflags <> "0"
                     ;add custom flags to an extra list.
                     ;custom flags have no effect on the display of the form in the Form Designer
                     addCustomFlag = #True
@@ -1259,7 +1259,7 @@ Procedure FD_Open(file.s,update = 0)
                       Else
                         winflag | Gadgets()\Flags()\ivalue
                       EndIf
-                    Else
+                    Elseif thisflags
                       ;add custom flags to an extra list.
                       ;custom flags have no effect on the display of the form in the Form Designer
                       addCustomFlag = #True

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1255,9 +1255,12 @@ Procedure FD_Open(file.s,update = 0)
           
           If startnext
             parentwin.s = Trim(Mid(line,start,startnext-start))
-            
-            parentwin = ReplaceString(parentwin, "WindowID(", "")
-            parentwin = ReplaceString(parentwin, ")", "")
+            If FindString(parentwin, "WindowID(")
+              parentwin = ReplaceString(parentwin, "WindowID(", "")
+              parentwin = ReplaceString(parentwin, ")", "")
+            Else
+              parentwin = "=" + parentwin
+            EndIf
             FormWindows()\parent = parentwin
           EndIf
         EndIf

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1453,6 +1453,10 @@ Procedure FD_Open(file.s,update = 0)
         FormWindows()\FormGadgets()\backcolor = -1
         FormWindows()\FormGadgets()\frontcolor = -1
         OpenReadGadgetParent()
+        If FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+          LastElement(GadgetList())
+          AddElement(GadgetList()) : GadgetList()\a = FormWindows()\FormGadgets()\itemnumber : GadgetList()\b = -1
+        Endif
         Continue
       EndIf ;}
       If procname = "IPAddressGadget" ;{

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -2268,6 +2268,7 @@ DataSection
   Data$ "Remove",               "Remove"
   Data$ "Parent",               "Parent"
   Data$ "ParentItem",           "Parent Item"
+  Data$ "customFlags",          "Custom Flags"
   
  
   ; ===================================================


### PR DESCRIPTION
I have made a small change to 'codeviewer.pb' and 'opensave.pb' so that a custom 'parent' for the form can be passed using the suffix '='.
Now the following is possible

```Wnd = OpenWindow(#PB_Any, x, y, width, height, "", #PB_Window_BorderLess, customHwnd)```

in which the following is entered in **parent**:  `=customHwnd`

Then `customHwnd` can be defined elsewhere in the code, e.g. as follows.

`customHwnd = GetWindow_(GadgetID(#ScrollArea),#GW_CHILD))`

I have also added the possibility to set custom flags for the forms.

With these two options, it is now possible to display a form in a ScrollAreaGadget, for example, without having to modify the form designer code every time.