### PR TITLE
Replaced 'brackets' with 'parentheses' in english documentation.

### DIFF
--- a/Documentation/English/List.txt
+++ b/Documentation/English/List.txt
@@ -59,7 +59,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns non-zero if the new element was created and zero otherwise. The value returned is
@@ -118,7 +118,7 @@
 
 @Parameter "List()"
   The name of the list, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @Parameter "*NewElement"
   The new element to set as the current element for the list.
@@ -182,7 +182,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @NoReturnValue
 
@@ -336,7 +336,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   The total number of elements in the list. If the list is not initialized, it returns -1 (for example after @@FreeList).
@@ -374,7 +374,7 @@
 
 @Parameter "List()"
   List() - The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @OptionalParameter "Flags"
   If this parameter is set to 1 and the first element is deleted, the new current element will be the second one. This flag
@@ -417,7 +417,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns the address of the data in the first list element if successful and zero
@@ -491,7 +491,7 @@
   
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns non-zero if the new element was created and zero otherwise. The value returned is
@@ -548,7 +548,7 @@
   
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns the address of the data in the last list element if successful and zero
@@ -622,7 +622,7 @@
   
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   A number containing the position of the current element within the list. The first
@@ -666,7 +666,7 @@
   
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns the address of the data in the next list element if successful and zero
@@ -704,7 +704,7 @@
   
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @ReturnValue
   Returns the address of the data in the previous list element if successful and zero
@@ -742,7 +742,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @NoReturnValue
 
@@ -777,7 +777,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @Parameter "Position"
   The position to move to in the list, considering that the first item in the list
@@ -830,7 +830,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @Parameter "*FirstElement"
   Address of the first element to swap. You can get this address by using the @ operator on the list name.
@@ -882,7 +882,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @Parameter "Location"
   Location where to move the current element. This can be one of the following values:
@@ -940,7 +940,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @NoReturnValue
 
@@ -998,7 +998,7 @@
 
 @Parameter "List()"
   The name of your list variable, created with the @ReferenceLink "newlist" "NewList" function.
-  You must include the brackets after the list name.
+  You must include the parentheses after the list name.
 
 @NoReturnValue
 

--- a/Documentation/English/Reference/variables.txt
+++ b/Documentation/English/Reference/variables.txt
@@ -346,7 +346,7 @@
 
 <tr>
     <td><div align="center">()</div></td>
-    <td><font face="Arial" size="2">Brackets. You can use sets of brackets to force part of an expression to be evaluated first, or in a certain order.<br>
+    <td><font face="Arial" size="2">Parentheses. You can use sets of brackets to force part of an expression to be evaluated first, or in a certain order.<br>
     <br><i><b>Example:</b></i><br>
     <font face="Courier New, Courier, mono">
     a = (5 + 6) * 3 <font color="#006666">; Result will be 33 since the 5+6 is evaluated first</font><br>
@@ -684,9 +684,9 @@ RHS | Result
 @EndCode  
 
 
-@Section Operator () (Brackets)
+@Section Operator () (Parentheses)
 
-  You can use sets of brackets to force part of an expression to be evaluated 
+  You can use sets of parentheses to force part of an expression to be evaluated 
   first, or in a certain order.
 
   @Example


### PR DESCRIPTION
The correct word (where replaced) is parentheses, not brackets. :)