### PR TITLE
Fix for single-line "Remove Comments" when caret is at start of line

### DIFF
--- a/PureBasicIDE/HighlightingFunctions.pb
+++ b/PureBasicIDE/HighlightingFunctions.pb
@@ -399,7 +399,7 @@ Procedure RemoveComments()
   
   GetSelection(@LineStart, 0, @LineEnd, @RowEnd)
   
-  If RowEnd <= 1 ; when selecting a full line, it actually selects the newline too, this results in one extra line
+  If RowEnd <= 1 And LineEnd > LineStart ; when selecting a full line, it actually selects the newline too, this results in one extra line
     LineEnd - 1
   EndIf
   


### PR DESCRIPTION
Fix for "Remove Comments". It now does the expected uncomment behavior if the caret is at the very start of a line (column 1) with no text selection.

See https://www.purebasic.fr/english/viewtopic.php?t=84667