### PR TITLE
Show file name instead of full path, in "Modified on Disk" and "Deleted on Disk" dialogs

### DIFF
--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -2859,7 +2859,7 @@ Procedure FileMonitorEvent()
           ChangeActiveSourceCode()  ; show the file to the user
           FlushEvents()
           
-          If MessageRequester(#ProductName$, LanguagePattern("FileStuff","DeletedOnDisk", "%filename%", FileList()\FileName$), #PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
+          If MessageRequester(#ProductName$, LanguagePattern("FileStuff","DeletedOnDisk", "%filename%", GetFilePart(FileList()\FileName$)), #PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes
             SaveSourceFile(*ActiveSource\Filename$)
             HistoryEvent(*ActiveSource, #HISTORY_Save)
           Else
@@ -2884,9 +2884,9 @@ Procedure FileMonitorEvent()
           FlushEvents()
           
           If GetSourceModified() ; different message if the file is modified
-            Message$ = LanguagePattern("FileStuff","ModifiedOnDisk2", "%filename%", FileList()\Filename$)
+            Message$ = LanguagePattern("FileStuff","ModifiedOnDisk2", "%filename%", GetFilePart(FileList()\Filename$))
           Else
-            Message$ = LanguagePattern("FileStuff","ModifiedOnDisk1", "%filename%", FileList()\Filename$)
+            Message$ = LanguagePattern("FileStuff","ModifiedOnDisk1", "%filename%", GetFilePart(FileList()\Filename$))
           EndIf
           
           FileMonitorWindowDialog = OpenDialog(?Dialog_FileMonitor, WindowID(#WINDOW_Main))


### PR DESCRIPTION
Sometimes a file's full path overflows the "Modified on Disk" dialogs.

This patch only shows the file's name, not the full path, in the `ModifiedOnDisk1` and `ModifiedOnDisk2` and `DeletedOnDisk` dialogs. In 99% of cases, this is probably enough info. In fact the `Modified` dialog when closing already does this.

Other suggestions in the forum are compacting the file path to the available width, or dynamically growing the window size.

See https://www.purebasic.fr/english/viewtopic.php?t=60349