### PR TITLE
Add ElementaryOS terminal support to LinuxMisc

### DIFF
--- a/PureBasicIDE/LinuxMisc.pb
+++ b/PureBasicIDE/LinuxMisc.pb
@@ -159,6 +159,9 @@ CompilerIf #CompileLinux
       
     ElseIf system_(ToAscii("which lxterminal > "+TempPath$+"PB_TerminalTest.txt 2>/dev/null")) = 0
       GUITerminalParameters$ = " -e "
+      
+    ElseIf system_(ToAscii("which io.elementary.terminal > "+TempPath$+"PB_TerminalTest.txt 2>/dev/null")) = 0
+      GUITerminalParameters$ = " -e "
     
     Else
       GUITerminalParameters$ = ""


### PR DESCRIPTION
This adds `io.elementary.terminal` to the searched terminals in `LinuxMisc.pb`, so the internal debugger can work in Console build mode.

See https://www.purebasic.fr/english/viewtopic.php?t=86701