### PR TITLE
Fix macOS IDE crash on exit and Fix FormDesigner Custom Flags

### DIFF
--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -481,10 +481,10 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
               AddElement(ContainerLevel())
               ContainerLevel() = ObjList()\level
             ElseIf FormWindows()\FormGadgets()\type = #Form_Type_Frame3D
-              if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+              If FormWindows()\FormGadgets()\flags & #PB_Frame_Container
                 AddElement(ContainerLevel())
                 ContainerLevel() = ObjList()\level
-              Endif
+              EndIf
             EndIf
             
             
@@ -971,11 +971,11 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
                 flags + Gadgets()\Flags()\name
               EndIf
             Next
-            ForEach Gadgets()\customFlags()
+            ForEach FormWindows()\FormCustomFlags()
                 If flags <> ""
                   flags + " | "
                 EndIf
-                flags + Gadgets()\customFlags()\name
+                flags + FormWindows()\FormCustomFlags()
             Next
           EndIf
         Next

--- a/PureBasicIDE/FormDesigner/declare.pb
+++ b/PureBasicIDE/FormDesigner/declare.pb
@@ -215,6 +215,8 @@ Structure FormWindow
   event_file.s
   event_proc.s
   
+  List FormCustomFlags.s()
+  
   List FormImg.FormImg()
   List FormGadgets.FormGadget()
   List FormMenus.FormMenu()
@@ -456,7 +458,6 @@ Structure Gadgets
   icon.i
   node.b
   List Flags.Flags()
-  List customFlags.Flags()
   List Events.EventType()
 EndStructure
 

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -730,14 +730,14 @@ Procedure FD_SelectWindow(window)
           
           i+1
         Next
-        if ListSize(Gadgets()\Flags()) <= 0 : i + 1 : Endif
+        If ListSize(Gadgets()\Flags()) <= 0 : i + 1 : EndIf
         custFlags.s = ""
-        ForEach Gadgets()\customFlags()
-          if custFlags = ""
-            custFlags = Gadgets()\customFlags()\name
+        ForEach FormWindows()\FormCustomFlags()
+          If custFlags = ""
+            custFlags = FormWindows()\FormCustomFlags()
           Else
-            custFlags + "|" + Gadgets()\customFlags()\name
-          Endif  
+            custFlags + " | " + FormWindows()\FormCustomFlags()
+          EndIf  
         Next
         PropGridAddItem(propgrid, i, Language("Form", "customFlags"), custFlags)
         i + 1
@@ -6431,7 +6431,7 @@ Procedure FD_InitSelectParent(parent_gadget)
           
           i + 1
         Case #Form_Type_Frame3D
-          if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+          If FormWindows()\FormGadgets()\flags & #PB_Frame_Container
             AddGadgetItem(#GADGET_Form_Parent_Select,i,FormWindows()\FormGadgets()\variable)
             SetGadgetItemData(#GADGET_Form_Parent_Select,i,FormWindows()\FormGadgets()\itemnumber)
             
@@ -6440,7 +6440,7 @@ Procedure FD_InitSelectParent(parent_gadget)
             EndIf
             
             i + 1
-          endif
+          EndIf
       EndSelect
     EndIf
   Next
@@ -6861,18 +6861,18 @@ Procedure FD_ProcessEventGridWindow(col,row)
           Next
           custFlags = Trim(grid_GetCellString(propgrid, 2, i))
           numflags = CountString(custFlags,"|")
-          ClearList(Gadgets()\customFlags())
-          if custFlags
+          ClearList(FormWindows()\FormCustomFlags())
+          If custFlags
             For k = 0 To numflags
               If numflags = 0
                 thisflags.s = custFlags
               Else
                 thisflags.s = Trim(StringField(custFlags,k+1,"|"))
               EndIf
-              AddElement(Gadgets()\customFlags())
-              Gadgets()\customFlags()\name = thisflags
+              AddElement(FormWindows()\FormCustomFlags())
+              FormWindows()\FormCustomFlags() = thisflags
             Next k
-          endif
+          EndIf
         EndIf
       Next
       FormWindows()\flags = flag
@@ -8325,10 +8325,10 @@ Procedure FD_Event(EventID, EventGadgetID, EventType)
                     parent = FormWindows()\FormGadgets()\itemnumber
                     Break
                   Case #Form_Type_Frame3D
-                    if FormWindows()\FormGadgets()\flags & #PB_Frame_Container
+                    If FormWindows()\FormGadgets()\flags & #PB_Frame_Container
                       parent = FormWindows()\FormGadgets()\itemnumber
                       Break
-                    Endif
+                    EndIf
                 EndSelect
               EndIf
             Until PreviousElement(FormWindows()\FormGadgets()) = 0

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -1225,33 +1225,37 @@ Procedure FD_Open(file.s,update = 0)
             
             ForEach Gadgets()
               If Gadgets()\type = #Form_Type_Window
+                flagsDone = #False
                 ForEach Gadgets()\Flags()
                   If thisflags = Gadgets()\Flags()\name
                     winflag = Gadgets()\Flags()\ivalue
-                  Elseif thisflags and thisflags <> "0"
-                    ;add custom flags to an extra list.
-                    ;custom flags have no effect on the display of the form in the Form Designer
-                    addCustomFlag = #True
-                    ForEach Gadgets()\customFlags()
-                      if Gadgets()\customFlags()\name = thisflags
-                        addCustomFlag = #False
-                        break
-                      Endif
-                    Next
-                    if addCustomFlag
-                      AddElement(Gadgets()\customFlags())
-                      Gadgets()\customFlags()\name = thisflags
-                    Endif
+                    flagsDone = #True
+                    Break
                   EndIf
                 Next
-              endif
+                If Not flagsDone And thisflags And thisflags <> "0"
+                  ;add custom flags to an extra list.
+                  ;custom flags have no effect on the display of the form in the Form Designer
+                  addCustomFlag = #True
+                  ForEach Gadgets()\customFlags()
+                    If Gadgets()\customFlags()\name = thisflags
+                      addCustomFlag = #False
+                      Break
+                    EndIf
+                  Next
+                  If addCustomFlag
+                    AddElement(Gadgets()\customFlags())
+                    Gadgets()\customFlags()\name = thisflags
+                  EndIf
+                EndIf
+              EndIf
             Next
           Else
             For i = 0 To numflags
               thisflags.s = Trim(StringField(flags,i+1,"|"))
-              
               ForEach Gadgets()
                 If Gadgets()\type = #Form_Type_Window
+                  flagsDone = #False
                   ForEach Gadgets()\Flags()
                     If thisflags = Gadgets()\Flags()\name
                       If winflag = 0
@@ -1259,23 +1263,26 @@ Procedure FD_Open(file.s,update = 0)
                       Else
                         winflag | Gadgets()\Flags()\ivalue
                       EndIf
-                    Elseif thisflags
-                      ;add custom flags to an extra list.
-                      ;custom flags have no effect on the display of the form in the Form Designer
-                      addCustomFlag = #True
-                      ForEach Gadgets()\customFlags()
-                        if Gadgets()\customFlags()\name = thisflags
-                          addCustomFlag = #False
-                          break
-                        Endif
-                      Next
-                      if addCustomFlag
-                        AddElement(Gadgets()\customFlags())
-                        Gadgets()\customFlags()\name = thisflags
-                      Endif
+                      flagsDone = #True
+                      Break
                     EndIf
                   Next
-                endif
+                  If Not flagsDone And thisflags
+                    ;add custom flags to an extra list.
+                    ;custom flags have no effect on the display of the form in the Form Designer
+                    addCustomFlag = #True
+                    ForEach Gadgets()\customFlags()
+                      If Gadgets()\customFlags()\name = thisflags
+                        addCustomFlag = #False
+                        Break
+                      EndIf
+                    Next
+                    If addCustomFlag
+                      AddElement(Gadgets()\customFlags())
+                      Gadgets()\customFlags()\name = thisflags
+                    EndIf
+                  EndIf
+                EndIf
               Next
             Next
           EndIf
@@ -1291,7 +1298,7 @@ Procedure FD_Open(file.s,update = 0)
             If FindString(parentwin, "WindowID(")
               parentwin = ReplaceString(parentwin, "WindowID(", "")
               parentwin = ReplaceString(parentwin, ")", "")
-            Elseif parentwin
+            ElseIf parentwin
               parentwin = "=" + parentwin
             EndIf
             FormWindows()\parent = parentwin
@@ -1456,7 +1463,7 @@ Procedure FD_Open(file.s,update = 0)
         If FormWindows()\FormGadgets()\flags & #PB_Frame_Container
           LastElement(GadgetList())
           AddElement(GadgetList()) : GadgetList()\a = FormWindows()\FormGadgets()\itemnumber : GadgetList()\b = -1
-        Endif
+        EndIf
         Continue
       EndIf ;}
       If procname = "IPAddressGadget" ;{

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -651,6 +651,7 @@ Procedure FD_Open(file.s,update = 0)
     ClearList(FormWindows()\FormMenus())
     ClearList(FormWindows()\FormStatusbars())
     ClearList(FormWindows()\FormToolbars())
+    ClearList(FormWindows()\FormCustomFlags())
     
     count = GetLinesCount(*ActiveSource)
     
@@ -1218,11 +1219,10 @@ Procedure FD_Open(file.s,update = 0)
           flags.s = Trim(Mid(line,start,startnext-start))
           winflag = 0
           numflags = CountString(flags,"|")
-          addCustomFlag.b = #False
+          addCustomFlag = #False
 
           If numflags = 0
             thisflags.s = Trim(flags)
-            
             ForEach Gadgets()
               If Gadgets()\type = #Form_Type_Window
                 flagsDone = #False
@@ -1237,15 +1237,16 @@ Procedure FD_Open(file.s,update = 0)
                   ;add custom flags to an extra list.
                   ;custom flags have no effect on the display of the form in the Form Designer
                   addCustomFlag = #True
-                  ForEach Gadgets()\customFlags()
-                    If Gadgets()\customFlags()\name = thisflags
+                  ForEach FormWindows()\FormCustomFlags()
+                    If FormWindows()\FormCustomFlags() = thisflags
                       addCustomFlag = #False
                       Break
                     EndIf
                   Next
                   If addCustomFlag
-                    AddElement(Gadgets()\customFlags())
-                    Gadgets()\customFlags()\name = thisflags
+                    LastElement(FormWindows()\FormCustomFlags())
+                    AddElement(FormWindows()\FormCustomFlags())
+                    FormWindows()\FormCustomFlags() = thisflags
                   EndIf
                 EndIf
               EndIf
@@ -1271,15 +1272,16 @@ Procedure FD_Open(file.s,update = 0)
                     ;add custom flags to an extra list.
                     ;custom flags have no effect on the display of the form in the Form Designer
                     addCustomFlag = #True
-                    ForEach Gadgets()\customFlags()
-                      If Gadgets()\customFlags()\name = thisflags
+                    ForEach FormWindows()\FormCustomFlags()
+                      If FormWindows()\FormCustomFlags() = thisflags
                         addCustomFlag = #False
                         Break
                       EndIf
                     Next
                     If addCustomFlag
-                      AddElement(Gadgets()\customFlags())
-                      Gadgets()\customFlags()\name = thisflags
+                      LastElement(FormWindows()\FormCustomFlags())
+                      AddElement(FormWindows()\FormCustomFlags())
+                      FormWindows()\FormCustomFlags() = thisflags
                     EndIf
                   EndIf
                 EndIf

--- a/PureBasicIDE/ProcedureBrowser.pb
+++ b/PureBasicIDE/ProcedureBrowser.pb
@@ -437,7 +437,7 @@ Procedure ProcedureBrowser_Highlight(ListIndex.i, ListType.i, EditorLine.i)
         EndWith
         Counter + 1
       Next
-      
+      PopListPosition(ProcedureList())
     Else
       Index = ListIndex
       Type = ListType
@@ -467,7 +467,6 @@ Procedure ProcedureBrowser_Highlight(ListIndex.i, ListType.i, EditorLine.i)
       ProcedureBrowser_DisableColorButtons(-1)
     EndIf
     
-    PopListPosition(ProcedureList())
   EndIf
   
 EndProcedure

--- a/PureBasicIDE/PureBasic.pb
+++ b/PureBasicIDE/PureBasic.pb
@@ -757,8 +757,12 @@ Procedure ShutdownIDE()
     ToolsPanelWidth = ToolsPanelWidth_Hidden
   EndIf
   
-  ; Close main window
-  CloseWindow(#WINDOW_Main)
+  ; Close main window, macOS hide window (Fix IDE Crash)
+  CompilerIf #CompileMac
+    HideWindow(#WINDOW_Main, #True)
+  CompilerElse
+    CloseWindow(#WINDOW_Main)
+  CompilerEndIf
   
   ; Fix IDE crash on macOS Big Sur
   CompilerIf #CompileMac

--- a/PureBasicIDE/UserInterface.pb
+++ b/PureBasicIDE/UserInterface.pb
@@ -2540,190 +2540,187 @@ Procedure DispatchEvent(EventID)
     ;
     If EventID = #PB_Event_Menu And EventMenu() = #MENU_Exit
       QuitIDE = MainWindowEvents(EventID)
-    Else
-    CompilerEndIf
-    
-    ;   If EventID <> 4 And EventID <> -1
-    ;   ;  Debug "Event: "+Str(EventID)+"   Window: " + Str(EventWindow())
-    ;   EndIf
-    
-    ; Form events - this is not in the main window event procedure as it handles the grid events as well
-    ; it also handles the specific menu events related to form popups
-    FD_Event(EventID, EventGadget(), EventType())
-    
-    Select EventWindow()
-        
-      Case #WINDOW_Main
-        QuitIDE = MainWindowEvents(EventID)
-        
-      Case #WINDOW_About
-        AboutWindowEvents(EventID)
-        
-      Case #WINDOW_Preferences
-        PreferencesWindowEvents(EventID)
-        
-      Case #WINDOW_FileViewer
-        FileViewerWindowEvents(EventID)
-        
-      Case #WINDOW_Goto
-        GotoWindowEvents(EventID)
-        
-      Case #WINDOW_Find
-        FindWindowEvents(EventID)
-        
-      Case #WINDOW_StructureViewer
-        StructureViewerWindowEvents(EventID)
-        
-      Case #WINDOW_Grep
-        GrepWindowEvents(EventID)
-        
-      Case #WINDOW_GrepOutput
-        GrepOutputWindowEvents(EventID)
-        
-      Case #WINDOW_Option
-        OptionWindowEvents(EventID)
-        
-        CompilerIf #SpiderBasic
-        Case #WINDOW_CreateApp
-          CreateAppWindowEvents(EventID)
-        CompilerEndIf
-        
-      Case #WINDOW_AddTools
-        AddTools_WindowEvents(EventID)
-        
-      Case #WINDOW_EditTools
-        AddTools_EditWindowEvents(EventID)
-        
-      Case #WINDOW_AutoComplete
-        AutoCompleteWindowEvents(EventID)
-        
-      Case #WINDOW_Template
-        TemplateWindowEvents(EventID)
-        
-      Case #WINDOW_MacroError
-        MacroErrorWindowEvents(EventID)
-        
-      Case #WINDOW_Warnings
-        WarningWindowEvents(EventID)
-        
-      Case #WINDOW_Compiler
-        CompilerWindowEvents(EventID)
-        
-      Case #WINDOW_ProjectOptions
-        ProjectOptionsEvents(EventID)
-        
-      Case #WINDOW_Build
-        BuildWindowEvents(EventID)
-        
-      Case #WINDOW_Diff
-        DiffWindowEvents(EventID)
-        
-      Case #WINDOW_DiffDialog
-        DiffDialogWindowEvents(EventID)
-        
-      Case #WINDOW_FileMonitor
-        FileMonitorWindowEvents(EventID)
-        
-      Case #Form_ImgList
-        FormImgListWindowEvents(EventID)
-        
-      Case #Form_Columns
-        FormColumnsWindowEvents(EventID)
-        
-      Case #Form_Items
-        FormItemsWindowEvents(EventID)
-        
-      Case #WINDOW_Form_Parent
-        FD_EventSelectParent(EventID)
-        
-      Case #WINDOW_EditHistory
-        EditHistoryWindowEvent(EventID)
-        
-      Case #WINDOW_Updates
-        UpdateWindowEvents(EventID)
-        
-        CompilerIf #CompileLinux | #CompileMac
-          
-        Case #WINDOW_Help
-          HelpWindowEvents(EventID)
-          
-        CompilerEndIf
-        
-        CompilerIf #DEBUG
-          
-        Case #WINDOW_Debugging
-          DebuggingWindowEvents(EventID)
-          
-        CompilerEndIf
-        
-      Default
-        ; check debugger events
-        ;
-        If Debugger_ProcessShortcuts(EventWindow(), EventID) = 0 ; ide debugger
-          If Debugger_ProcessEvents(EventWindow(), EventID) = 0  ; 0 means unhandled (debugger general function)
-            
-            ; check ToolsPanel tools in separate windows
-            ;
-            ForEach AvailablePanelTools()
-              If AvailablePanelTools()\IsSeparateWindow And AvailablePanelTools()\ToolWindowID = EventWindow()
-                If EventID = #PB_Event_CloseWindow
-                  
-                  If AvailablePanelTools()\NeedDestroyFunction
-                    Tool.ToolsPanelInterface = @AvailablePanelTools()
-                    Tool\DestroyFunction()
-                  EndIf
-                  
-                  If MemorizeWindow
-                    Window = AvailablePanelTools()\ToolWindowID
-                    If IsWindowMinimized(Window) = 0
-                      AvailablePanelTools()\ToolWindowX      = WindowX(Window)
-                      AvailablePanelTools()\ToolWindowY      = WindowY(Window)
-                      AvailablePanelTools()\ToolWindowWidth  = WindowWidth(Window)
-                      AvailablePanelTools()\ToolWindowHeight = WindowHeight(Window)
-                    EndIf
-                  EndIf
-                  CloseWindow(AvailablePanelTools()\ToolWindowID)
-                  AvailablePanelTools()\ToolWindowID = -1
-                  AvailablePanelTools()\IsSeparateWindow = 0
-                  
-                ElseIf EventID = #PB_Event_Gadget
-                  If #DEFAULT_CanWindowStayOnTop And EventGadget() = AvailablePanelTools()\ToolStayOnTop
-                    AvailablePanelTools()\IsToolStayOnTop = GetGadgetState(AvailablePanelTools()\ToolStayOnTop)
-                    SetWindowStayOnTop(AvailablePanelTools()\ToolWindowID, AvailablePanelTools()\IsToolStayOnTop)
-                  Else
-                    Tool.ToolsPanelInterface = @AvailablePanelTools()
-                    Tool\EventHandler(EventGadget())
-                  EndIf
-                  
-                  ; menu events in a separate toolspanel item are treated as main window events,
-                  ; same as when they are integrated in the sidepanel
-                  ; same for drag & drop events
-                ElseIf EventID = #PB_Event_Menu Or EventID = #PB_Event_GadgetDrop
-                  MainWindowEvents(EventID)
-                  
-                ElseIf EventID = #PB_Event_SizeWindow
-                  ResizeTools()
-                  
-                ElseIf EventID = #PB_Event_GadgetDrop
-                  ; special case for the Templates D+D
-                  If EventGadget() = #GADGET_Template_Tree
-                    Template_DropEvent()
-                  EndIf
-                  
-                EndIf
-                
-                Break
-              EndIf
-            Next AvailablePanelTools()
-            
-          EndIf
-        EndIf
-        
-    EndSelect
-    
-    CompilerIf #CompileMac
+      ProcedureReturn EventID
     EndIf
   CompilerEndIf
+  
+  ;   If EventID <> 4 And EventID <> -1
+  ;   ;  Debug "Event: "+Str(EventID)+"   Window: " + Str(EventWindow())
+  ;   EndIf
+  
+  ; Form events - this is not in the main window event procedure as it handles the grid events as well
+  ; it also handles the specific menu events related to form popups
+  FD_Event(EventID, EventGadget(), EventType())
+  
+  Select EventWindow()
+      
+    Case #WINDOW_Main
+      QuitIDE = MainWindowEvents(EventID)
+      
+    Case #WINDOW_About
+      AboutWindowEvents(EventID)
+      
+    Case #WINDOW_Preferences
+      PreferencesWindowEvents(EventID)
+      
+    Case #WINDOW_FileViewer
+      FileViewerWindowEvents(EventID)
+      
+    Case #WINDOW_Goto
+      GotoWindowEvents(EventID)
+      
+    Case #WINDOW_Find
+      FindWindowEvents(EventID)
+      
+    Case #WINDOW_StructureViewer
+      StructureViewerWindowEvents(EventID)
+      
+    Case #WINDOW_Grep
+      GrepWindowEvents(EventID)
+      
+    Case #WINDOW_GrepOutput
+      GrepOutputWindowEvents(EventID)
+      
+    Case #WINDOW_Option
+      OptionWindowEvents(EventID)
+      
+      CompilerIf #SpiderBasic
+      Case #WINDOW_CreateApp
+        CreateAppWindowEvents(EventID)
+      CompilerEndIf
+      
+    Case #WINDOW_AddTools
+      AddTools_WindowEvents(EventID)
+      
+    Case #WINDOW_EditTools
+      AddTools_EditWindowEvents(EventID)
+      
+    Case #WINDOW_AutoComplete
+      AutoCompleteWindowEvents(EventID)
+      
+    Case #WINDOW_Template
+      TemplateWindowEvents(EventID)
+      
+    Case #WINDOW_MacroError
+      MacroErrorWindowEvents(EventID)
+      
+    Case #WINDOW_Warnings
+      WarningWindowEvents(EventID)
+      
+    Case #WINDOW_Compiler
+      CompilerWindowEvents(EventID)
+      
+    Case #WINDOW_ProjectOptions
+      ProjectOptionsEvents(EventID)
+      
+    Case #WINDOW_Build
+      BuildWindowEvents(EventID)
+      
+    Case #WINDOW_Diff
+      DiffWindowEvents(EventID)
+      
+    Case #WINDOW_DiffDialog
+      DiffDialogWindowEvents(EventID)
+      
+    Case #WINDOW_FileMonitor
+      FileMonitorWindowEvents(EventID)
+      
+    Case #Form_ImgList
+      FormImgListWindowEvents(EventID)
+      
+    Case #Form_Columns
+      FormColumnsWindowEvents(EventID)
+      
+    Case #Form_Items
+      FormItemsWindowEvents(EventID)
+      
+    Case #WINDOW_Form_Parent
+      FD_EventSelectParent(EventID)
+      
+    Case #WINDOW_EditHistory
+      EditHistoryWindowEvent(EventID)
+      
+    Case #WINDOW_Updates
+      UpdateWindowEvents(EventID)
+      
+      CompilerIf #CompileLinux | #CompileMac
+        
+      Case #WINDOW_Help
+        HelpWindowEvents(EventID)
+        
+      CompilerEndIf
+      
+      CompilerIf #DEBUG
+        
+      Case #WINDOW_Debugging
+        DebuggingWindowEvents(EventID)
+        
+      CompilerEndIf
+      
+    Default
+      ; check debugger events
+      ;
+      If Debugger_ProcessShortcuts(EventWindow(), EventID) = 0 ; ide debugger
+        If Debugger_ProcessEvents(EventWindow(), EventID) = 0  ; 0 means unhandled (debugger general function)
+          
+          ; check ToolsPanel tools in separate windows
+          ;
+          ForEach AvailablePanelTools()
+            If AvailablePanelTools()\IsSeparateWindow And AvailablePanelTools()\ToolWindowID = EventWindow()
+              If EventID = #PB_Event_CloseWindow
+                
+                If AvailablePanelTools()\NeedDestroyFunction
+                  Tool.ToolsPanelInterface = @AvailablePanelTools()
+                  Tool\DestroyFunction()
+                EndIf
+                
+                If MemorizeWindow
+                  Window = AvailablePanelTools()\ToolWindowID
+                  If IsWindowMinimized(Window) = 0
+                    AvailablePanelTools()\ToolWindowX      = WindowX(Window)
+                    AvailablePanelTools()\ToolWindowY      = WindowY(Window)
+                    AvailablePanelTools()\ToolWindowWidth  = WindowWidth(Window)
+                    AvailablePanelTools()\ToolWindowHeight = WindowHeight(Window)
+                  EndIf
+                EndIf
+                CloseWindow(AvailablePanelTools()\ToolWindowID)
+                AvailablePanelTools()\ToolWindowID = -1
+                AvailablePanelTools()\IsSeparateWindow = 0
+                
+              ElseIf EventID = #PB_Event_Gadget
+                If #DEFAULT_CanWindowStayOnTop And EventGadget() = AvailablePanelTools()\ToolStayOnTop
+                  AvailablePanelTools()\IsToolStayOnTop = GetGadgetState(AvailablePanelTools()\ToolStayOnTop)
+                  SetWindowStayOnTop(AvailablePanelTools()\ToolWindowID, AvailablePanelTools()\IsToolStayOnTop)
+                Else
+                  Tool.ToolsPanelInterface = @AvailablePanelTools()
+                  Tool\EventHandler(EventGadget())
+                EndIf
+                
+                ; menu events in a separate toolspanel item are treated as main window events,
+                ; same as when they are integrated in the sidepanel
+                ; same for drag & drop events
+              ElseIf EventID = #PB_Event_Menu Or EventID = #PB_Event_GadgetDrop
+                MainWindowEvents(EventID)
+                
+              ElseIf EventID = #PB_Event_SizeWindow
+                ResizeTools()
+                
+              ElseIf EventID = #PB_Event_GadgetDrop
+                ; special case for the Templates D+D
+                If EventGadget() = #GADGET_Template_Tree
+                  Template_DropEvent()
+                EndIf
+                
+              EndIf
+              
+              Break
+            EndIf
+          Next AvailablePanelTools()
+          
+        EndIf
+      EndIf
+      
+  EndSelect
   
   ProcedureReturn EventID ; return the eventid still, to be able to check for 0 events (empty queue)
 EndProcedure


### PR DESCRIPTION
From the logic, the error should not occur. Guess it's because of the external scintilla library callback when the parent window is closed.