### PR TITLE
Recursively create target folder before attempting to compile there

### DIFF
--- a/PureBasicIDE/CompilerInterface.pb
+++ b/PureBasicIDE/CompilerInterface.pb
@@ -2500,6 +2500,10 @@ Procedure Compiler_BuildTarget(SourceFileName$, TargetFileName$, *Target.Compile
     Command$ + Chr(9) + "DLL"
   EndIf
   
+  CompilerIf Not #SpiderBasic
+    CreateDirectoryRecursive(GetPathPart(TargetFileName$))
+  CompilerEndIf
+  
   CompilerWrite(Command$)
   
   ; We need the *ActiveSource for HandleCompilerResponse if the mainfile option is set

--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -366,6 +366,7 @@ Declare.s UniqueFilename(File$)                     ; return a unique representa
 Declare   IsEqualFile(File1$, File2$)               ; returns true if the 2 filenames identify the same file
 Declare.s CreateRelativePath(BasePath$, FileName$)  ; turn the full path FileName$ into a relative one to BasePath$
 Declare.s ResolveRelativePath(BasePath$, FileName$) ; merge a base path and a relative path to a full path
+Declare   CreateDirectoryRecursive(Directory$)      ; create a directory and its parent directories, recursively if necessary
 
 ;- GotoWindow.pb
 ;

--- a/PureBasicIDE/FileSystem.pb
+++ b/PureBasicIDE/FileSystem.pb
@@ -275,3 +275,26 @@ Procedure.s ResolveRelativePath(BasePath$, FileName$)
   ProcedureReturn UniqueFilename(FileName$)
 EndProcedure
 
+Procedure CreateDirectoryRecursive(Directory$)
+  If Directory$ <> ""
+    Select FileSize(Directory$)
+      Case -2 ; already exists - OK!
+        ProcedureReturn #True
+        
+      Case -1 ; does not exist - create it
+        Parent$ = UniqueFilename(Directory$ + #Separator + ".." + #Separator)
+        If Parent$ <> ""
+          CreateDirectoryRecursive(Parent$)
+        EndIf
+        CreateDirectory(Directory$)
+        If FileSize(Directory$) = -2
+          ProcedureReturn #True
+        EndIf
+        
+      Default ; it's a file!
+        ProcedureReturn #False
+    EndSelect
+  EndIf
+  ProcedureReturn #False
+EndProcedure
+


### PR DESCRIPTION
**Minor Issue**: Compiling will fail with an unintuitive error (linker error) if the destination folder does not exist. This is more common an issue when using a Project and **Build All Targets** rather than **Create Executable** and manually browsing to a destination.

**Proposed Solution**: Right before compiling, automatically create the destination folder, including its parent folders, recursively if necessary. I think this is a reasonable expected behavior.

**More Context**: When working on a large cross-platform project, you might organize your build targets into nested subfolders, for example `<project>/build/demo/windows/x86/MyApp.exe` or `<project>/build/full/linux/x64/MyApp`. **Build All** will fail if these subfolders don't exist. Manually preparing the output folder structures on several systems can be annoying... Before you ask "Why can't you just copy the folder structure around?" If you're working with Git, *Git does not preserve folders which contain no files or nested files!* So any time you `git clone` or `git pull` or even `git archive --format zip`, it does not carry along empty folder structures. (Also, it's common to `.gitignore` your `build` output folder anyway.)

Thanks for considering.