### PR TITLE
(Preferences) If a shortcut is already used, ask if user wants to reassign it, instead of rejecting the change

### DIFF
--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -1667,6 +1667,7 @@ DataSection
   Data$ "ProceduresUpdate", "Trigger Update of Procedure & Variable Viewer"
   
   Data$ "AllreadyUsed",     "The shortcut you specified is already used by" ; DO NOT FIX TYPO: AllreadyUsed
+  Data$ "ReassignPrompt",   "Should the shortcut be reassigned?"
   Data$ "ExternalTool",     "External Tool"
   Data$ "Menu",             "Menu"
   Data$ "TabIntend",        "Indent/Unindent code Selection"

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -4973,7 +4973,18 @@ Procedure PreferencesWindowEvents(EventID)
         index = GetGadgetState(#GADGET_Preferences_ShortcutList)
         If index >= 0
           If IsShortcutUsed(Shortcut, index, 0)
-            MessageRequester(#ProductName$, Language("Shortcuts","AllreadyUsed")+#NewLine+Chr(34)+GetShortcutOwner(Shortcut)+Chr(34), #FLAG_Info) ; DO NOT FIX TYPO: AllreadyUsed
+            ; Shortcut is already used... ask if user would like to reassign it now
+            Text$ = Language("Shortcuts","AllreadyUsed")+#NewLine+Chr(34)+GetShortcutOwner(Shortcut)+Chr(34)+#NewLine+#NewLine+Language("Shortcuts","ReassignPrompt")
+            If MessageRequester(#ProductName$, Text$, #FLAG_Question | #PB_MessageRequester_YesNo) = #PB_MessageRequester_Yes ; DO NOT FIX TYPO: AllreadyUsed
+              For i = 0 To #MENU_LastShortcutItem
+                If Prefs_KeyboardShortcuts(i) = Shortcut
+                  Prefs_KeyboardShortcuts(i) = 0
+                  SetGadgetItemText(#GADGET_Preferences_ShortcutList, i, "", 1)
+                EndIf
+              Next i
+              Prefs_KeyboardShortcuts(index) = Shortcut ; must be before the SetText for OSX (see ShortcutManagement.pb)
+              SetGadgetItemText(#GADGET_Preferences_ShortcutList, index, GetShortcutText(Shortcut), 1)
+            EndIf
           Else
             Prefs_KeyboardShortcuts(index) = Shortcut ; must be before the SetText for OSX (see ShortcutManagement.pb)
             SetGadgetItemText(#GADGET_Preferences_ShortcutList, index, GetShortcutText(Shortcut), 1)


### PR DESCRIPTION
Just a small change to make the Shortcut Preferences more user-friendly.

If the user tries to assign a shortcut which is already used, instead of rejecting it with a "Shortcut is already used..." dialog, change that to a "Shortcut is already used... Reassign it?" Yes/No requester, allowing them to accept it immediately.

This saves the user some clicks and scrolling and keypresses... You don't need to find the conflicting shortcut in the list, unassign it, return to original shortcut, assign that again.