### PR TITLE
Form Designer Version Checking

### DIFF
--- a/PureBasicIDE/Common.pb
+++ b/PureBasicIDE/Common.pb
@@ -471,6 +471,12 @@ Runtime Enumeration 1 ; 0 is reserved for uninitialized #PB_Any
   #GADGET_Preferences_FormEventProcedure
   #GADGET_Preferences_FormGridSize
   #GADGET_Preferences_FormSkin
+  #GADGET_Preferences_FormNotRecognizedCaption
+  #GADGET_Preferences_FormNotRecognized
+  #GADGET_Preferences_FormDowngradeCaption
+  #GADGET_Preferences_FormDowngrade
+  #GADGET_Preferences_FormUpgradeCaption
+  #GADGET_Preferences_FormUpgrade
   #GADGET_Preferences_EnableHistory
   #GADGET_Preferences_HistoryTimer  ; first to auto disable
   #GADGET_Preferences_HistoryMaxFileSize
@@ -2618,7 +2624,7 @@ Global SaveProjectSettings
 Global EnableMenuIcons, AutoClearLog, DisplayFullPath, DisplayDarkMode, NoSplashScreen, DisplayProtoType, DisplayErrorWindow
 Global InitialSourceLine, MemorizeMarkers, LanguageFile$, ToolsPanelWidth_Hidden, ErrorLogHeight_Hidden
 Global EnableBraceMatch, EnableKeywordMatch, ShowWhiteSpace, ShowIndentGuides, MonitorFileChanges
-Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProcedure, FormSkin, FormSkinVersion
+Global FormVariable, FormVariableCaption, FormGrid, FormGridSize, FormEventProcedure, FormSkin, FormSkinVersion, FormVersionWarnings
 Global FilesPanelMultiline, FilesPanelCloseButtons, FilesPanelNewButton
 Global CurrentZoom, SynchronizingZoom
 Global ExtraWordChars$

--- a/PureBasicIDE/FormDesigner/declare.pb
+++ b/PureBasicIDE/FormDesigner/declare.pb
@@ -355,6 +355,14 @@ Declare FD_DuplicateGadget()
 Declare FD_Open(file.s,update = 0)
 Declare FD_PrepareTestCode(compile = 1)
 
+; Version Warnings Preference Items
+EnumerationBinary 
+  #FDI_Warn_NotRecognized
+  #FDI_Warn_DowngradeAlways
+  #FDI_Warn_UpgradeBreaking
+  #FDI_Warn_UpgradeAlways 
+EndEnumeration
+#FDI_Warn_Default = #FDI_Warn_NotRecognized | #FDI_Warn_DowngradeAlways | #FDI_Warn_UpgradeBreaking
 
 ; Gadget Types
 Enumeration

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -44,7 +44,6 @@ Procedure FD_NewWindow(x=0,y=0,width=600,height=400,file.s = "")
   ProcedureReturn FormWindows()
 EndProcedure
 
-
 Procedure FD_Save(Filename$)
   If FormWindows()\current_view = 1
     FD_SetDesignView()
@@ -84,7 +83,6 @@ Procedure FD_Save(Filename$)
   EndIf
 EndProcedure
 
-
 Procedure OpenReadNextParam(line.s,pos,includeequal = 0)
   If includeequal
     pos = FindString(line,"=",pos)
@@ -115,7 +113,6 @@ Procedure OpenReadNextParam(line.s,pos,includeequal = 0)
     EndIf
   ForEver
 EndProcedure
-
 
 Procedure OpenReadNextParamOld(line.s,pos,includeequal = 0)
   Repeat
@@ -162,6 +159,7 @@ Procedure OpenReadNextParamOld(line.s,pos,includeequal = 0)
   
   ProcedureReturn newpos
 EndProcedure
+
 Procedure OpenReadGadgetParams(line.s)
   FormWindows()\FormGadgets()\itemnumber = itemnumbers
   itemnumbers + 1
@@ -450,6 +448,7 @@ Procedure OpenReadGadgetParams(line.s)
   
   ProcedureReturn start
 EndProcedure
+
 Procedure OpenReadGadgetFlags(line.s, start)
   startnext = OpenReadNextParam(line,start)
   
@@ -480,6 +479,7 @@ Procedure OpenReadGadgetFlags(line.s, start)
   EndIf
   FormWindows()\FormGadgets()\flags = winflag
 EndProcedure
+
 Procedure OpenReadGadgetCaption(line.s, start)
   startnext = OpenReadNextParam(line,start)
   
@@ -493,6 +493,7 @@ Procedure OpenReadGadgetCaption(line.s, start)
   EndIf
   ProcedureReturn startnext + 1
 EndProcedure
+
 Procedure OpenReadGadgetImageID(line.s, start)
   oldstart = start
   start = FindString(line,"(",start) + 1 ; searching for ImageID(
@@ -520,6 +521,7 @@ Procedure OpenReadGadgetImageID(line.s, start)
   
   ProcedureReturn startnext + 1
 EndProcedure
+
 Procedure OpenReadGadgetMinMax(line.s, start)
   startnext = OpenReadNextParam(line,start)
   
@@ -536,12 +538,14 @@ Procedure OpenReadGadgetMinMax(line.s, start)
   
   ProcedureReturn startnext + 1
 EndProcedure
+
 Macro OpenReadGadgetParent()
   If LastElement(GadgetList())
     FormWindows()\FormGadgets()\parent = GadgetList()\a
     FormWindows()\FormGadgets()\parent_item = GadgetList()\b
   EndIf
 EndMacro
+
 Procedure OpenReadStatusFlags(line.s, start)
   startnext = OpenReadNextParam(line,start)
   
@@ -574,6 +578,7 @@ Procedure OpenReadStatusFlags(line.s, start)
   EndIf
   FormWindows()\FormStatusbars()\flags = winflag
 EndProcedure
+
 Procedure OpenReadStatusFlagsImageID(line.s, start)
   start = FindString(line,"(",start) + 1 ; searching for ImageID(
   startnext = FindString(line,")",start)
@@ -593,6 +598,7 @@ Procedure OpenReadStatusFlagsImageID(line.s, start)
   
   ProcedureReturn startnext + 1
 EndProcedure
+
 Procedure.s OpenReadProcName(line.s)
   pos = FindString(line,"(")
   
@@ -607,7 +613,13 @@ Procedure.s OpenReadProcName(line.s)
   
   ProcedureReturn proc
 EndProcedure
+
 Procedure FD_Open(file.s,update = 0)
+  
+  ; If any changes or new features in this procedure would break backward compatibility with earlier form designer versions,
+  ; for example, implementing a new gadget or including a new command in the output code,
+  ; please update FD_VersionCheck so that the IDE will be aware of this and can warn properly.
+  
   If Not update
     PushListPosition(FormWindows())
     found = 0
@@ -1220,7 +1232,7 @@ Procedure FD_Open(file.s,update = 0)
           winflag = 0
           numflags = CountString(flags,"|")
           addCustomFlag = #False
-
+          
           If numflags = 0
             thisflags.s = Trim(flags)
             ForEach Gadgets()
@@ -2562,6 +2574,122 @@ Procedure FD_Open(file.s,update = 0)
     EndIf
   EndIf
 EndProcedure
+
 Procedure FD_UpdateCode()
   FD_Open(FormWindows()\current_file,1)
+EndProcedure
+
+Procedure.b FD_VersionCheck(FileName.s)
+  ; Check the designer statement for compatibility problems.
+  ; Returns a #PB_MessageRequester_* value from the message requester. 
+  ; (#PB_MessageRequester_Yes if no problems found or preferences prohibit a warning).
+  
+  Define.i File, Format, TagPosition, VerPosition, DotPosition, FileVersion, Loop, Max, MayBreak, Icon, Warn, Result
+  Define VerString$, Message$
+  
+  ; List of compatibility breaking version numbers.
+  ; If any form designer code changes or new features will break backward compatibility with earlier versions, add the version number to this Array.
+  Static Dim Breaks(2)
+  If Breaks(0) = 0
+    Breaks(0) = 610 ; WebViewGadget support.
+    Breaks(1) = 621 ; Custom Flags for OpenWindow and other new flags.
+  EndIf
+  
+  If FileSize(FileName) <= 0
+    ProcedureReturn #PB_MessageRequester_Yes
+  EndIf
+  
+  ; Extract the version content from the first non blank line of the source file.
+  File = OpenFile(#PB_Any, FileName)
+  Format = ReadStringFormat(File)
+  Repeat 
+    VerString$ = ReadString(File, Format)
+  Until VerString$ <> #Empty$
+  CloseFile(File)
+  
+  TagPosition = FindString(VerString$, "; Form Designer")
+  VerPosition = FindString(VerString$, "- ")
+  
+  ; Check for problems and warnings.
+  If TagPosition And VerPosition
+    
+    ; Reformat so that it matches the compiler and version constants.
+    VerString$ = Mid(VerString$, VerPosition + 2)
+    FileVersion = Int(ValD(VerString$) * 100.0)
+    
+    ; Check for a backward compatibility issue.
+    MayBreak = #False
+    Max = ArraySize(Breaks())
+    For Index = 0 To Max
+      If FileVersion < Breaks(Index)
+        MayBreak = #True
+        Break
+      EndIf
+    Next Index
+    
+    If FileVersion = #PB_Compiler_Version
+      ; Matching version, no need to prompt.
+      Warn = #False
+      Result = #PB_MessageRequester_Yes
+      
+    ElseIf FileVersion > #PB_Compiler_Version 
+      ; This is a downgrade.
+      
+      If (FormVersionWarnings & #FDI_Warn_DowngradeAlways) = 0
+        ; Downgrade warnings are off.
+        Warn = #False
+        Result = #PB_MessageRequester_Yes
+        
+      Else
+        ; Downgrade warnings are on.
+        Warn = #True
+        Icon = #FLAG_Warning
+        Message$ = ReplaceString(ReplaceString(Language("Form", "MessageNewer"), "%newline%",  #LF$), "%s%", VerString$)
+        
+      EndIf
+      
+    ElseIf FileVersion < #PB_Compiler_Version 
+      ; This is an upgrade.
+      
+      If FormVersionWarnings & (#FDI_Warn_UpgradeBreaking | #FDI_Warn_UpgradeAlways) = 0
+        ; Upgrade warnings are off.
+        Warn = #False
+        Result = #PB_MessageRequester_Yes
+            
+      ElseIf (FormVersionWarnings & #FDI_Warn_UpgradeBreaking) = #FDI_Warn_UpgradeBreaking And MayBreak = #False
+        ; Non-breaking warnings are off.
+        Warn = #False
+        Result = #PB_MessageRequester_Yes
+        
+      ElseIf (FormVersionWarnings & (#FDI_Warn_UpgradeBreaking | #FDI_Warn_UpgradeAlways)) > 0 And MayBreak = #True
+        ; Breaking warnings are on and a break is possible.
+        Warn = #True
+        Icon = #FLAG_Warning
+        Message$ = ReplaceString(ReplaceString(Language("Form", "MessageBackward"), "%newline%",  #LF$), "%s%", VerString$)
+      
+      ElseIf (FormVersionWarnings & #FDI_Warn_UpgradeAlways) = #FDI_Warn_UpgradeAlways
+        ; Upgrade warnings are always on.
+        Warn = #True
+        Icon = #FLAG_Warning
+        Message$ = ReplaceString(ReplaceString(Language("Form", "MessageOlder"), "%newline%",  #LF$), "%s%", VerString$)
+        
+      EndIf
+      
+    EndIf
+    
+  ElseIf (FormVersionWarnings & #FDI_Warn_NotRecognized) = #FDI_Warn_NotRecognized
+    ; The form designer version line wasn't found, probably not a designer file.
+    Warn = #True
+    Icon = #FLAG_Warning
+    Message$ = ReplaceString(Language("Form", "MessageNotDesign"), "%newline%",  #LF$)
+    
+  EndIf
+  
+  If Warn
+    Message$ + #LF$ + Language("Misc", "MessageContinue")
+    Result = MessageRequester(#ProductName$, Message$, Icon | #PB_MessageRequester_YesNo)
+  EndIf
+  
+  ProcedureReturn Result
+  
 EndProcedure

--- a/PureBasicIDE/Language.pb
+++ b/PureBasicIDE/Language.pb
@@ -1091,26 +1091,33 @@ DataSection
   Data$ "CustomFont",       "Use a custom font"
   Data$ "CustomColors",     "Use custom colors"
   
-  Data$ "Form",             "Form"
-  Data$ "FormVariable",     "New gadgets use #PB_Any by default"
-  Data$ "FormVariableCaption","New gadgets use a variable as caption"
-  Data$ "FormGrid",         "Grid Visible"
-  Data$ "FormEventProcedure","Generate event procedure"
-  Data$ "FormGridSize",     "Grid Size"
-  Data$ "FormSkin",         "OS Skin"
+  Data$ "Form",                "Form"
+  Data$ "FormVariable",        "New gadgets use #PB_Any by default"
+  Data$ "FormVariableCaption", "New gadgets use a variable as caption"
+  Data$ "FormGrid",            "Grid Visible"
+  Data$ "FormEventProcedure",  "Generate event procedure"
+  Data$ "FormGridSize",        "Grid Size"
+  Data$ "FormSkin",            "OS Skin"
+  Data$ "FormWarnings",        "Warnings"
+  Data$ "WarnNotRecognized",   "For an unrecognised file"
+  Data$ "WarnDowngrade",       "For a version downgrade"
+  Data$ "WarnUpgrade",         "For a version upgrade"
+  Data$ "Option_Always",       "Always warn"
+  Data$ "Option_Backward",     "Warn if backward compatibility is affected"
+  Data$ "Option_Never",        "Never warn"
   
-  Data$ "Issues",           "Issues"
-  Data$ "IssueNameShort",   "Name"
-  Data$ "IssueExprShort",   "Expression"
-  Data$ "IssueName",        "Issue name"
-  Data$ "IssueExpr",        "Regular expression"
-  Data$ "IssueCodeNoColor", "No code color"
-  Data$ "IssueCodeBack",    "Change issue background"
-  Data$ "IssueCodeLine",    "Change line background"
-  Data$ "IssueCodeLineLimit","Only up to %limit% issues that change the line background can be defined."
-  Data$ "IssueInTool",      "Show in issue tool"
-  Data$ "IssueInBrowser",   "Show in procedure browser"
-  Data$ "InvalidExpr",      "Invalid regular expression"
+  Data$ "Issues",             "Issues"
+  Data$ "IssueNameShort",     "Name"
+  Data$ "IssueExprShort",     "Expression"
+  Data$ "IssueName",          "Issue name"
+  Data$ "IssueExpr",          "Regular expression"
+  Data$ "IssueCodeNoColor",   "No code color"
+  Data$ "IssueCodeBack",      "Change issue background"
+  Data$ "IssueCodeLine",      "Change line background"
+  Data$ "IssueCodeLineLimit", "Only up to %limit% issues that change the line background can be defined."
+  Data$ "IssueInTool",        "Show in issue tool"
+  Data$ "IssueInBrowser",     "Show in procedure browser"
+  Data$ "InvalidExpr",        "Invalid regular expression"
   
   CompilerIf #SpiderBasic
     Data$ "WebBrowser",  "Web browser"
@@ -2087,7 +2094,8 @@ DataSection
   Data$ "AskScreenReader",  "A Screen Reader software was detected. Do you wish to enable accessibility features?%newline%%newline%(You can change this option later under File - Preferences - General)"
   
   Data$ "ImageManagerTitle","Image Manager"
-  
+  Data$ "MessageContinue",   "Do you want to continue?"
+
   
   ; ===================================================
   ;- Group - Form
@@ -2105,7 +2113,15 @@ DataSection
   Data$ "Separator",          "Separator"
   Data$ "Shortcut",           "Shortcut"
   Data$ "OutOfMemoryError",   "Can't render gadget of %size% pixels (out of memory)."
-  Data$ "N/A",                 "N/A"
+  Data$ "N/A",                "N/A"
+  
+  Data$ "MessageNewer",       "This file was created with a newer version of the designer (%s%).%newline%Any unsupported features may be lost."
+  Data$ "MessageOlder",       "This file was created with an older version of the designer (%s%) and will be upgraded to the current version."
+  Data$ "MessageBackward",    "This file was created with an older version of the designer (%s%).%newline%Backward compatibility may be affected if upgraded."
+  Data$ "MessageNotDesign",   "This file does not appear to contain a form design.%newline%The content may not be imported properly."
+  Data$ "Option_Always",      "Always"
+  Data$ "Option_Backward",    "If backward compatibility is affected"
+  Data$ "Option_Never",       "Never"
   
   ;Data$ "_GROUP_",            "StatusWindow"
   ; ===================================================
@@ -2292,7 +2308,7 @@ DataSection
   Data$ "Remove",               "Remove"
   Data$ "Parent",               "Parent"
   Data$ "ParentItem",           "Parent Item"
-  Data$ "customFlags",          "Custom Flags"
+  Data$ "CustomFlags",          "Custom Flags"
   
  
   ; ===================================================

--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -4,8 +4,6 @@
 ;  See LICENSE and LICENSE-FANTAISIE in the project root for license information.
 ; --------------------------------------------------------------------------------------------
 
-
-
 Global SelectedLanguage, PreferenceFontName$, PreferenceFontSize, PreferenceFontStyle
 Global PreferenceToolsPanelFrontColor, PreferenceToolsPanelBackColor, PreferenceToolsPanelFont$
 Global PreferenceToolsPanelFontSize, PreferenceToolsPanelFontStyle
@@ -410,6 +408,8 @@ Procedure LoadPreferences()
       FormSkinVersion = ReadPreferenceLong("FormSkinVersion", 7)
   EndSelect
   
+  FormVersionWarnings = ReadPreferenceLong("VersionWarnings",  #FDI_Warn_Default)
+    
   ;- - EditHistory
   PreferenceGroup("EditHistory")
   EnableHistory      = ReadPreferenceLong("Enable", 1)
@@ -1092,12 +1092,10 @@ Procedure LoadPreferences()
   PurifierWindowY            = ReadPreferenceLong("PurifierWindowY", 50)
   
   ClosePreferences()
+  
 EndProcedure
 
-
-
 Procedure SavePreferences()
-  
   
   If CreatePreferences(PreferencesFile$)
     PreferenceComment(" PureBasic IDE Preference File")
@@ -1245,6 +1243,7 @@ Procedure SavePreferences()
     WritePreferenceLong("EventProcedure",   FormEventProcedure)
     WritePreferenceLong("FormSkin",         FormSkin)
     WritePreferenceLong("FormSkinVersion",  FormSkinVersion)
+    WritePreferenceLong("VersionWarnings",  FormVersionWarnings)
     
     ;- - EditHistory
     PreferenceGroup("EditHistory")
@@ -1937,6 +1936,18 @@ Procedure IsPreferenceChanged()
   If FormSkin <> TempFormSkin: ProcedureReturn 1: EndIf
   If FormSkinVersion <> TempFormSkinVersion: ProcedureReturn 1: EndIf
   
+  TempFormNotRecognized = FormVersionWarnings & #FDI_Warn_NotRecognized
+  If GetGadgetState(#GADGET_Preferences_FormNotRecognized) <> TempFormNotRecognized : ProcedureReturn 1: EndIf
+  TempFormDowngrade = FormVersionWarnings & #FDI_Warn_DowngradeAlways
+  ; If GetGadgetState(#)
+  
+  If (FormVersionWarnings & #FDI_Warn_UpgradeBreaking) = #FDI_Warn_UpgradeBreaking And GetGadgetState(#GADGET_Preferences_FormUpgrade) <> 1
+    ProcedureReturn 1
+  EndIf
+  If (FormVersionWarnings & #FDI_Warn_UpgradeAlways) = #FDI_Warn_UpgradeAlways And GetGadgetState(#GADGET_Preferences_FormUpgrade) <> 2
+    ProcedureReturn 1
+  EndIf
+  
   If GetGadgetState(#GADGET_Preferences_HistoryPurgeNever)
     TempPurgeMode = 0
   ElseIf GetGadgetState(#GADGET_Preferences_HistoryPurgeByCount)
@@ -2311,6 +2322,36 @@ Procedure ApplyPreferences()
       
     Case 3 ; Linux
       FormSkin = #PB_OS_Linux
+  EndSelect
+  
+  CallDebugger
+  Debug GetGadgetState(#GADGET_Preferences_FormNotRecognized)
+  Select GetGadgetState(#GADGET_Preferences_FormNotRecognized)
+    Case 0
+      FormVersionWarnings & ~#FDI_Warn_NotRecognized
+    Case 1
+      FormVersionWarnings | #FDI_Warn_NotRecognized
+  EndSelect
+  
+  Debug GetGadgetState(#GADGET_Preferences_FormDowngrade)
+  Select GetGadgetState(#GADGET_Preferences_FormDowngrade)
+    Case 0
+      FormVersionWarnings & ~#FDI_Warn_DowngradeAlways 
+    Case 1
+      FormVersionWarnings | #FDI_Warn_DowngradeAlways
+  EndSelect
+  
+  Debug GetGadgetState(#GADGET_Preferences_FormUpgrade)
+  Select GetGadgetState(#GADGET_Preferences_FormUpgrade)
+    Case 0
+      FormVersionWarnings & ~#FDI_Warn_UpgradeBreaking 
+      FormVersionWarnings & ~#FDI_Warn_UpgradeAlways
+    Case 1
+      FormVersionWarnings | #FDI_Warn_UpgradeBreaking
+      FormVersionWarnings & ~#FDI_Warn_UpgradeAlways
+    Case 2
+      FormVersionWarnings & ~#FDI_Warn_UpgradeBreaking
+      FormVersionWarnings | #FDI_Warn_UpgradeAlways
   EndSelect
   
   ; Reload specific form skin variables and fonts
@@ -3521,6 +3562,26 @@ Procedure OpenPreferencesWindow()
           SetGadgetState(#GADGET_Preferences_FormSkin,2)
       EndSelect
   EndSelect
+  
+  If (FormVersionWarnings & #FDI_Warn_NotRecognized) = #FDI_Warn_NotRecognized
+    SetGadgetState(#GADGET_Preferences_FormNotRecognized, 1)
+  Else
+    SetGadgetState(#GADGET_Preferences_FormNotRecognized, 0)
+  EndIf
+  
+  If (FormVersionWarnings & #FDI_Warn_DowngradeAlways) = #FDI_Warn_DowngradeAlways
+    SetGadgetState(#GADGET_Preferences_FormDowngrade, 1)
+  Else
+    SetGadgetState(#GADGET_Preferences_FormDowngrade, 0)
+  EndIf
+  
+  If (FormVersionWarnings & (#FDI_Warn_UpgradeBreaking | #FDI_Warn_UpgradeAlways)) = 0
+    SetGadgetState(#GADGET_Preferences_FormUpgrade, 0)
+  ElseIf (FormVersionWarnings & #FDI_Warn_UpgradeBreaking) = #FDI_Warn_UpgradeBreaking
+    SetGadgetState(#GADGET_Preferences_FormUpgrade, 1)
+  ElseIf (FormVersionWarnings & #FDI_Warn_UpgradeAlways) = #FDI_Warn_UpgradeAlways
+    SetGadgetState(#GADGET_Preferences_FormUpgrade, 2)
+  EndIf
   
   PreferenceCurrentPage = 0
   For i = 0 To CountGadgetItems(#GADGET_Preferences_Tree) - 1

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -1735,11 +1735,17 @@ Procedure LoadSourceFile(FileName$, Activate = 1)
   ; Check if this is a form (file extension only for now)
   ; NOTE: it needs to be after the already opened check !
   If LCase(GetExtensionPart(FileName$)) = "pbf"
+    
+    If FD_VersionCheck(FileName$) = #PB_MessageRequester_No
+      ProcedureReturn 0
+    EndIf
+
     OpenForm(FileName$)
     RecentFiles_AddFile(FileName$, #False)
     AddTools_Execute(#TRIGGER_SourceLoad, *ActiveSource)
     LinkSourceToProject(*ActiveSource) ; Link To project (If any)
     ProcedureReturn 1
+    
   EndIf
   
   ; reset the current source

--- a/PureBasicIDE/dialogs/Preferences.xml
+++ b/PureBasicIDE/dialogs/Preferences.xml
@@ -886,36 +886,58 @@
           </frame>
         </container>
 
-          <!-- Form -->
-          <container margin="0" expand="horizontal" invisible="yes" id="#GADGET_Preferences_FirstContainer+20">
-              <frame lang="Preferences:Form" margin="5">
-                  <vbox spacing="20">
-                      <vbox>
-                          <checkbox id="#GADGET_Preferences_FormVariable"              lang="Preferences:FormVariable" />
-                          <checkbox id="#GADGET_Preferences_FormVariableCaption"       lang="Preferences:FormVariableCaption" />
-                          <checkbox id="#GADGET_Preferences_FormGrid"       lang="Preferences:FormGrid" />
-                          <checkbox id="#GADGET_Preferences_FormEventProcedure"     lang="Preferences:FormEventProcedure" />
-                      </vbox>
-                      
-                      <gridbox colspacing="10" colexpand="item:2">
-                          <text lang="Preferences:FormGridSize" text=": " />
-                          <singlebox expand="no" margin="0">
-                              <string id="#GADGET_Preferences_FormGridSize" flags="#PB_String_Numeric" width="80" />
-                          </singlebox>
+        <!-- Form -->
+        <container margin="0" expand="horizontal" invisible="yes" id="#GADGET_Preferences_FirstContainer+20">
+          <vbox>
+            <frame lang="Preferences:Form" margin="5">
+              <vbox spacing="20">
+                <vbox>
+                  <checkbox id="#GADGET_Preferences_FormVariable"              lang="Preferences:FormVariable" />
+                  <checkbox id="#GADGET_Preferences_FormVariableCaption"       lang="Preferences:FormVariableCaption" />
+                  <checkbox id="#GADGET_Preferences_FormGrid"       lang="Preferences:FormGrid" />
+                  <checkbox id="#GADGET_Preferences_FormEventProcedure"     lang="Preferences:FormEventProcedure" />
+                </vbox>
+                
+                <gridbox colspacing="10" colexpand="item:2">
+                  <text lang="Preferences:FormGridSize" text=": " />
+                  <singlebox expand="no" margin="0">
+                    <string id="#GADGET_Preferences_FormGridSize" flags="#PB_String_Numeric" width="80" />
+                  </singlebox>
 
-                          <text lang="Preferences:FormSkin" text=": " />
-                          <combobox id="#GADGET_Preferences_FormSkin">
-                              <item text="OS X" />
-                              <item text="Windows 7" />
-                              <item text="Windows 8" />
-                              <item text="Linux Ubuntu" />
-                          </combobox>
-
-                      </gridbox>
-
-                  </vbox>
-              </frame>
-          </container>
+                  <text lang="Preferences:FormSkin" text=": " />
+                  <combobox id="#GADGET_Preferences_FormSkin">
+                    <item text="OS X" />
+                    <item text="Windows 7" />
+                    <item text="Windows 8" />
+                    <item text="Linux Ubuntu" />
+                  </combobox>
+                </gridbox>
+              </vbox>
+            </frame>
+            <frame lang="Preferences:FormWarnings" margin="5">
+              <vbox spacing="20">
+                <gridbox colspacing="10" colexpand="item:2">
+                  <text lang="Preferences:WarnNotRecognized" text=": " />
+                  <combobox id="#GADGET_Preferences_FormNotRecognized">
+                    <item lang="Form:Option_Never" />
+                    <item lang="Form:Option_Always" />
+                  </combobox>
+                  <text lang="Preferences:WarnUpgrade" text=": " />
+                  <combobox id="#GADGET_Preferences_FormUpgrade">
+                      <item lang="Form:Option_Never" />
+                      <item lang="Form:Option_Backward" />
+                      <item lang="Form:Option_Always" />
+                  </combobox>
+                  <text lang="Preferences:WarnDowngrade" text=": " />
+                  <combobox id="#GADGET_Preferences_FormDowngrade">
+                      <item lang="Form:Option_Never" />
+                      <item lang="Form:Option_Always" />
+                  </combobox>
+                </gridbox>
+              </vbox>
+            </frame>
+          </vbox>
+        </container>
 
         <!-- Toolspanel -->
         <container margin="0" invisible="yes" id="#GADGET_Preferences_FirstContainer+21">


### PR DESCRIPTION
- Warn if an opened pbf file doesn't contain the form designer title line.

- Warn about a version upgrade and compatibility issues when opening a file from an older version.

- Warn about a downgrade when opening a file from a newer version.

- Added a new section to the preference dialog to control these warnings.