### PR TITLE
Not include opened project files in the ‘Recent files' menu

### DIFF
--- a/PureBasicIDE/Declarations.pb
+++ b/PureBasicIDE/Declarations.pb
@@ -601,7 +601,7 @@ Declare ChangeActiveSourcecode(*OldSource.SourceFile = 0) ; change the active so
 Declare NewSource(FileName$, ExecuteTool)                 ; create a new source (with optional name to load a file in)
 Declare SaveProjectSettings(*Target.CompileTarget, IsCodeFile, IsTempFile, ReportErrors) ; save the settings of *ActiveSource (a file must be open in write mode!)
 Declare AnalyzeProjectSettings(*Source.SourceFile, *Buffer, Length, IsTempFile)          ; fill the *Source structure with the project settings from *Buffer. (return new project length)
-Declare LoadSourceFile(FileName$, Activate = 1)                                          ; load the given file into a new source (if not already open)
+Declare LoadSourceFile(FileName$, Activate = 1, AddToRecentFiles = 1)                    ; load the given file into a new source (if not already open)
 Declare SaveSourceFile(FileName$)                                                        ; save the current source to the given name
 Declare LoadTempFile(FileName$)                                                          ; load the specified file over the current opened source
 Declare SaveTempFile(FileName$)                                                          ; save the current source to a temp name (no change of modified/unmodified by this!)

--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -1263,7 +1263,7 @@ Procedure LoadProject(Filename$)
             
             If ProjectOpenMode = #Project_Open_LoadAll Or (ProjectOpenMode = #Project_Open_LoadLast And ProjectFiles()\LastOpen) Or (ProjectOpenMode = #Project_Open_LoadDefault And ProjectFiles()\AutoLoad)
               PushListPosition(ProjectFiles())
-              LoadSourceFile(ProjectFiles()\FileName$) ; can change the ProjectFiles() index
+              LoadSourceFile(ProjectFiles()\FileName$, 1, 0) ; can change the ProjectFiles() index
               
               ; Flush events. So when many sources are opened at once, the User can see a bit the
               ; progress, instead of just an unresponsive window for quite a while.

--- a/PureBasicIDE/ProjectPanel.pb
+++ b/PureBasicIDE/ProjectPanel.pb
@@ -709,7 +709,7 @@ Procedure ProjectPanel_EventHandler(*Entry.ToolsPanelEntry, EventGadgetID)
         If Index <> -1
           *File.ProjectFile = GetGadgetItemData(#GADGET_ProjectPanel, Index)
           If ProjectPanel_IsFile(*File)
-            LoadSourceFile(*File\FileName$) ; will just switch if open
+            LoadSourceFile(*File\FileName$, 1, 0) ; will just switch if open
           EndIf
         EndIf
         

--- a/PureBasicIDE/SourceManagement.pb
+++ b/PureBasicIDE/SourceManagement.pb
@@ -1712,7 +1712,7 @@ Procedure FindSourceFile(FileName$)
   
 EndProcedure
 
-Procedure LoadSourceFile(FileName$, Activate = 1)
+Procedure LoadSourceFile(FileName$, Activate = 1, AddToRecentFiles = 1)
   success = 0
   
   ; Check if this is a project file
@@ -1840,7 +1840,9 @@ Procedure LoadSourceFile(FileName$, Activate = 1)
         *ActiveSource\DiskChecksum  = FileFingerprint(*ActiveSource\Filename$, #PB_Cipher_MD5)
       EnableDebugger
       
-      RecentFiles_AddFile(FileName$, #False)
+      If AddToRecentFiles
+        RecentFiles_AddFile(FileName$, #False)
+      EndIf
       AddTools_Execute(#TRIGGER_SourceLoad, *ActiveSource)
       FullSourceScan(*ActiveSource)
       UpdateFolding(*ActiveSource, 0, -1)


### PR DESCRIPTION
When opening a project, do not include the opened files in the ‘Recent Files’ menu.

Also, do not include project files opened from the ‘Project’ tool in the ‘Recent Files’ menu.