### PR TITLE
Sort arrays, lists, and maps in variableViewer!

### DIFF
--- a/PureBasicDebugger/VariableDebug.pb
+++ b/PureBasicDebugger/VariableDebug.pb
@@ -930,14 +930,18 @@ Procedure OpenVariableWindow(*Debugger.DebuggerData)
       
       ; Set default sorting values (name column, ascending)
       ;
-      *Debugger\ArraySortColumn         = 0
+      *Debugger\ArraySortColumn         = 1
       *Debugger\ArraySortDirection      = 1
       *Debugger\LocalArraySortColumn    = 1
       *Debugger\LocalArraySortDirection = 1
-      *Debugger\ListSortColumn          = 0
+      *Debugger\ListSortColumn          = 1
       *Debugger\ListSortDirection       = 1
       *Debugger\LocalListSortColumn     = 1
       *Debugger\LocalListSortDirection  = 1
+      *Debugger\MapSortColumn           = 1
+      *Debugger\MapSortDirection        = 1
+      *Debugger\LocalMapSortColumn      = 1
+      *Debugger\LocalMapSortDirection   = 1
       
       CompilerIf #CompileWindows
         ; watch column clicks


### PR DESCRIPTION
In variableViewer, sorts arrays, lists, and maps by their names by default.
Unless there is a reason that I am not seeing
