### PR TITLE
Feature/form editor explicit gadget

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run MakeWindows.cmd",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-ExecutionPolicy", "Bypass",
+                "-NoProfile",
+                "-Command",
+                "$config = Get-Content ..\\config.json | ConvertFrom-Json; cmd /c MakeWindows.cmd $config.PureBasicPath"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}\\PureBasicIDE"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/PureBasicIDE/FormDesigner/codeviewer.pb
+++ b/PureBasicIDE/FormDesigner/codeviewer.pb
@@ -41,7 +41,11 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
     
     windowvar + FormWindows()\variable
   Else
-    windowenum + "  #" + FormWindows()\variable + #Endline
+    If FormWindows()\explicitId
+      windowenum + "  #" + FormWindows()\variable + "=" + Str(FormWindows()\explicitId) + #Endline
+    Else
+      windowenum + "  #" + FormWindows()\variable + #Endline
+    EndIf
   EndIf
   
   ForEach FormWindows()\FormMenus()
@@ -65,7 +69,11 @@ Procedure.s FD_SelectCode(contentonly = 0, testcode = 0)
       
       gadgetvar + FormWindows()\FormGadgets()\variable
     Else
-      gadgetenum + "  #" + FormWindows()\FormGadgets()\variable + #Endline
+      If FormWindows()\FormGadgets()\explicitId
+        gadgetenum + "  #" + FormWindows()\FormGadgets()\variable + "=" + Str(FormWindows()\FormGadgets()\explicitId) + #Endline
+      Else
+        gadgetenum + "  #" + FormWindows()\FormGadgets()\variable + #Endline
+      EndIf
     EndIf
     
     If FormWindows()\FormGadgets()\cust_init <> ""

--- a/PureBasicIDE/FormDesigner/declare.pb
+++ b/PureBasicIDE/FormDesigner/declare.pb
@@ -109,6 +109,7 @@ Structure FormGadget
   tooltip.s
   tooltipvariable.b
   variable.s
+  explicitId.i
   image.q
   imageid.s ; for parsing when loading
 
@@ -206,6 +207,7 @@ Structure FormWindow
   width.i
   height.i
   variable.s
+  explicitId.i
   caption.s
   captionvariable.b
   flags.i

--- a/PureBasicIDE/FormDesigner/mainevents.pb
+++ b/PureBasicIDE/FormDesigner/mainevents.pb
@@ -397,7 +397,15 @@ Procedure FD_SelectGadget(gadget)
     EndSelect
     
     grid_SetCellState(propgrid,2,1,FormWindows()\FormGadgets()\pbany)
-    grid_SetCellString(propgrid,2,2,FormWindows()\FormGadgets()\variable)
+    If FormWindows()\FormGadgets()\pbany
+      grid_SetCellString(propgrid, 2, 2, FormWindows()\FormGadgets()\variable)
+    Else
+      If FormWindows()\FormGadgets()\explicitId
+        grid_SetCellString(propgrid, 2, 2, FormWindows()\FormGadgets()\variable + "=" + Str(FormWindows()\FormGadgets()\explicitId))
+      Else
+        grid_SetCellString(propgrid, 2, 2, FormWindows()\FormGadgets()\variable)
+      EndIf
+    EndIf
     grid_SetCellState(propgrid,2,3,FormWindows()\FormGadgets()\captionvariable)
     
     Select FormWindows()\FormGadgets()\type
@@ -656,7 +664,15 @@ Procedure FD_SelectWindow(window)
     
     ChangeCurrentElement(FormWindows(),window)
     grid_SetCellState(propgrid, 2, 1, FormWindows()\pbany)
-    grid_SetCellString(propgrid, 2, 2, FormWindows()\variable)
+    If FormWindows()\pbany
+      grid_SetCellString(propgrid, 2, 2, FormWindows()\variable)
+    Else
+      If FormWindows()\explicitId
+        grid_SetCellString(propgrid, 2, 2, FormWindows()\variable + "=" + Str(FormWindows()\explicitId))
+      Else
+        grid_SetCellString(propgrid, 2, 2, FormWindows()\variable)
+      EndIf
+    EndIf
     grid_SetCellState(propgrid, 2, 3, FormWindows()\captionvariable)
     grid_SetCellString(propgrid, 2, 4, FormWindows()\caption)
     
@@ -4693,6 +4709,7 @@ Procedure FD_LeftUp(x,y)
       FormWindows()\FormGadgets()\frontcolor = -1
       FormWindows()\FormGadgets()\backcolor = -1
       FormWindows()\FormGadgets()\variable = var
+      FormWindows()\FormGadgets()\explicitId = 0
       FormWindows()\FormGadgets()\pbany = FormVariable
       FormWindows()\FormGadgets()\captionvariable = FormVariableCaption
       FormWindows()\FormGadgets()\tooltipvariable = FormVariableCaption
@@ -6541,10 +6558,70 @@ Procedure FD_ProcessEventGridGadget(col,row)
       FormWindows()\FormGadgets()\pbany = grid_GetCellState(propgrid, 2, row)
       
     Case 2 ; Variable
-      If grid_GetCellString(propgrid, 2, row) = ""
-        grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+      Protected input.s, name.s, rhs.s
+      Protected eqPos.i, id.i
+    
+      input = Trim(grid_GetCellString(propgrid, 2, row))
+    
+      If input = ""
+        ; revert to current model value
+        If FormWindows()\FormGadgets()\pbany
+          grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+        Else
+          If FormWindows()\FormGadgets()\explicitId
+            grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable + "=" + Str(FormWindows()\FormGadgets()\explicitId))
+          Else
+            grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+          EndIf
+        EndIf
+    
       Else
-        FormWindows()\FormGadgets()\variable = grid_GetCellString(propgrid, 2, row)
+        ; parse "NAME" or "NAME=123"
+        eqPos = FindString(input, "=")
+    
+        If eqPos
+          name = Trim(Left(input, eqPos - 1))
+          rhs  = Trim(Mid(input, eqPos + 1))
+          id   = Val(rhs)
+        Else
+          name = input
+          id   = 0
+        EndIf
+    
+        ; validate NAME using existing validator 
+        If FD_CheckVariable(name)
+          FormWindows()\FormGadgets()\variable = name
+    
+          If FormWindows()\FormGadgets()\pbany
+            ; PB_Any gadgets must not use explicit IDs
+            FormWindows()\FormGadgets()\explicitId = 0
+          Else
+            FormWindows()\FormGadgets()\explicitId = id
+          EndIf
+    
+          ; normalize display text
+          If FormWindows()\FormGadgets()\pbany
+            grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+          Else
+            If FormWindows()\FormGadgets()\explicitId
+              grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable + "=" + Str(FormWindows()\FormGadgets()\explicitId))
+            Else
+              grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+            EndIf
+          EndIf
+    
+        Else
+          ; invalid -> revert
+          If FormWindows()\FormGadgets()\pbany
+            grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+          Else
+            If FormWindows()\FormGadgets()\explicitId
+              grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable + "=" + Str(FormWindows()\FormGadgets()\explicitId))
+            Else
+              grid_SetCellString(propgrid, 2, row, FormWindows()\FormGadgets()\variable)
+            EndIf
+          EndIf
+        EndIf
       EndIf
       
       FD_UpdateObjList()
@@ -6741,10 +6818,70 @@ Procedure FD_ProcessEventGridWindow(col,row)
       FormWindows()\pbany = grid_GetCellState(propgrid, 2,row)
       
     Case 2 ; Variable
-      If grid_GetCellString(propgrid, 2, row) = ""
-        grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+      Protected input.s, name.s, rhs.s
+      Protected eqPos.i, id.i
+    
+      input = Trim(grid_GetCellString(propgrid, 2, row))
+    
+      If input = ""
+        ; revert to current model value
+        If FormWindows()\pbany
+          grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+        Else
+          If FormWindows()\explicitId
+            grid_SetCellString(propgrid, 2, row, FormWindows()\variable + "=" + Str(FormWindows()\explicitId))
+          Else
+            grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+          EndIf
+        EndIf
+    
       Else
-        FormWindows()\variable = grid_GetCellString(propgrid, 2, row)
+        ; parse "NAME" or "NAME=123"
+        eqPos = FindString(input, "=")
+    
+        If eqPos
+          name = Trim(Left(input, eqPos - 1))
+          rhs  = Trim(Mid(input, eqPos + 1))
+          id   = Val(rhs)
+        Else
+          name = input
+          id   = 0
+        EndIf
+    
+        ; validate NAME using existing validator 
+        If FD_CheckVariable(name)
+          FormWindows()\variable = name
+    
+          If FormWindows()\pbany
+            ; PB_Any gadgets must not use explicit IDs
+            FormWindows()\explicitId = 0
+          Else
+            FormWindows()\explicitId = id
+          EndIf
+    
+          ; normalize display text
+          If FormWindows()\pbany
+            grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+          Else
+            If FormWindows()\explicitId
+              grid_SetCellString(propgrid, 2, row, FormWindows()\variable + "=" + Str(FormWindows()\explicitId))
+            Else
+              grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+            EndIf
+          EndIf
+    
+        Else
+          ; invalid -> revert
+          If FormWindows()\pbany
+            grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+          Else
+            If FormWindows()\explicitId
+              grid_SetCellString(propgrid, 2, row, FormWindows()\variable + "=" + Str(FormWindows()\explicitId))
+            Else
+              grid_SetCellString(propgrid, 2, row, FormWindows()\variable)
+            EndIf
+          EndIf
+        EndIf
       EndIf
       
       FD_UpdateObjList()
@@ -8406,6 +8543,7 @@ Procedure FD_Event(EventID, EventGadgetID, EventType)
           FormWindows()\FormGadgets()\frontcolor = -1
           FormWindows()\FormGadgets()\backcolor = -1
           FormWindows()\FormGadgets()\variable = var
+          FormWindows()\FormGadgets()\explicitId = 0
           FormWindows()\FormGadgets()\pbany = FormVariable
           FormWindows()\FormGadgets()\captionvariable = FormVariableCaption
           FormWindows()\FormGadgets()\tooltipvariable = FormVariableCaption

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -24,6 +24,7 @@ Procedure FD_NewWindow(x=0,y=0,width=600,height=400,file.s = "")
   FormWindows()\width = width
   FormWindows()\height = height
   FormWindows()\variable = "Window_"+Str(c_window)
+  FormWindows()\explicitId = 0
   FormWindows()\pbany = FormVariable
   FormWindows()\captionvariable = FormVariableCaption
   FormWindows()\color = -1
@@ -160,14 +161,26 @@ Procedure OpenReadGadgetParams(line.s)
   
   pbany = FindString(line, "=")
   start = FindString(line, "(") + 1
-  If pbany
+  
+  ; only treat as "var = Proc(...)" if '=' is before '('
+  If pbany And pbany < start
     FormWindows()\FormGadgets()\variable = Trim(Left(line,pbany - 1))
     FormWindows()\FormGadgets()\pbany = 1
     start = OpenReadNextParam(line,start) + 1
   Else
     startnext = OpenReadNextParam(line,start)
-    FormWindows()\FormGadgets()\variable = Trim(Mid(line,start,startnext-start))
-    FormWindows()\FormGadgets()\variable = Right(FormWindows()\FormGadgets()\variable,Len(FormWindows()\FormGadgets()\variable) -1)
+    
+    tmp.s = Trim(Mid(line, start, startnext - start)) ; e.g. "#ID13310" or "#ID13310=13310"
+    tmp = Right(tmp, Len(tmp) - 1)                    ; remove '#'
+
+    eq = FindString(tmp, "=")
+    If eq
+      FormWindows()\FormGadgets()\variable   = Trim(Left(tmp, eq - 1))
+      FormWindows()\FormGadgets()\explicitId = Val(Trim(Mid(tmp, eq + 1)))
+    Else
+      FormWindows()\FormGadgets()\variable = tmp
+    EndIf
+
     start = startnext + 1
   EndIf
   
@@ -748,14 +761,54 @@ Procedure FD_Open(file.s,update = 0)
         Continue
       EndIf
       
+      NewMap enumGadgetIds.i()
+      NewMap enumWindowIds.i()
+      enumMode.i = 0 ; 0=none, 1=FormGadget, 2=FormWindow
+      
       If Left(line,11) = "Enumeration" Or Left(line,17) = "EnumerationBinary"
         loop_enumeration = 1
+        enumMode = 0
+      
+        ; detect "Enumeration FormGadget"
+        If FindString(line, "FormGadget")
+          enumMode = 1
+        EndIf
+        
+        ; detect "Enumeration FormWindow"
+        If FindString(line, "FormWindow")
+          enumMode = 2
+        EndIf
+      
+        Continue
       EndIf
+      
       If Left(line,14) = "EndEnumeration"
         loop_enumeration = 0
+        enumMode = 0
+        Continue
       EndIf
       
       If loop_enumeration
+        ; Parse only gadget and window enum lines, ignore others
+        If enumMode > 0
+          If Left(line, 1) = "#"
+            tmp.s = Trim(Mid(line, 2)) ; remove leading '#'
+      
+            eq = FindString(tmp, "=")
+            If eq
+              name.s = Trim(Left(tmp, eq - 1))
+              enumVal.i = Val(Trim(Mid(tmp, eq + 1)))
+              If name <> "" And enumVal <> 0
+                If enumMode = 1 
+                  enumGadgetIds(name) = enumVal 
+                ElseIf enumMode = 2
+                  enumWindowIds(name) = enumVal
+                EndIf
+              EndIf
+            EndIf
+          EndIf         
+        EndIf
+      
         Continue
       EndIf
       
@@ -2563,6 +2616,24 @@ Procedure FD_Open(file.s,update = 0)
       EndIf
     Next
     
+    ForEach FormWindows()\FormGadgets()
+      If FormWindows()\FormGadgets()\pbany = 0
+        If FormWindows()\FormGadgets()\explicitId = 0
+          If FindMapElement(enumGadgetIds(), FormWindows()\FormGadgets()\variable)
+            FormWindows()\FormGadgets()\explicitId = enumGadgetIds()
+          EndIf
+        EndIf
+      EndIf
+    Next
+    
+    If FormWindows()\pbany = 0
+        If FormWindows()\explicitId = 0
+          If FindMapElement(enumWindowIds(), FormWindows()\variable)
+            FormWindows()\explicitId = enumWindowIds()
+          EndIf
+        EndIf
+    EndIf
+
     FD_UpdateObjList()
     FD_UpdateScrollbars()
     FD_SelectWindow(currentwindow)

--- a/PureBasicIDE/FormDesigner/opensave.pb
+++ b/PureBasicIDE/FormDesigner/opensave.pb
@@ -172,7 +172,7 @@ Procedure OpenReadGadgetParams(line.s)
     
     tmp.s = Trim(Mid(line, start, startnext - start)) ; e.g. "#ID13310" or "#ID13310=13310"
     tmp = Right(tmp, Len(tmp) - 1)                    ; remove '#'
-
+    
     eq = FindString(tmp, "=")
     If eq
       FormWindows()\FormGadgets()\variable   = Trim(Left(tmp, eq - 1))
@@ -707,6 +707,10 @@ Procedure FD_Open(file.s,update = 0)
     custgadgetnb = -1
     event_file.s = ""
     
+    NewMap enumGadgetIds.i()
+    NewMap enumWindowIds.i()
+    enumMode.i = 0 ; 0=none, 1=FormGadget, 2=FormWindow
+
     Repeat
       If update
         line.s = Trim(StringField(content, line_num, #LF$))
@@ -760,11 +764,7 @@ Procedure FD_Open(file.s,update = 0)
         EndIf
         Continue
       EndIf
-      
-      NewMap enumGadgetIds.i()
-      NewMap enumWindowIds.i()
-      enumMode.i = 0 ; 0=none, 1=FormGadget, 2=FormWindow
-      
+            
       If Left(line,11) = "Enumeration" Or Left(line,17) = "EnumerationBinary"
         loop_enumeration = 1
         enumMode = 0
@@ -793,7 +793,6 @@ Procedure FD_Open(file.s,update = 0)
         If enumMode > 0
           If Left(line, 1) = "#"
             tmp.s = Trim(Mid(line, 2)) ; remove leading '#'
-      
             eq = FindString(tmp, "=")
             If eq
               name.s = Trim(Left(tmp, eq - 1))

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "PureBasicPath": "C:\\PureBasic"
+}


### PR DESCRIPTION
## Summary

This PR adds support for **explicit gadget IDs** & **explicit window IDs** in the PureBasic Form Designer property field, using the syntax:

- `ID13310=13310` or `Gadget1=1008` (variable=explicit numeric ID)

The generated code will keep the **variable name** as-is, while the **enumeration constant** gets the explicit assignment:

```purebasic
Enumeration FormGadget
  #ID13310=13310
EndEnumeration
```

## Motivation

Some projects require stable, predefined numeric IDs (e.g. compatibility with existing code, external bindings etc.). Until now, the Form Designer only supported automatic IDs (#PB_Any) or non-explicit enumeration constants, making it hard to keep IDs deterministic across edits/saves.

## Behavior / Rules

The property field `variable` may contain `Name=Number` to define an explicit mapping.
Code generation outputs `#Name=Number` in Enumeration FormGadget / FormWindow.
Gadget/window creation uses `#Name` or `Name` for Procedure Open...
**Backward compatible / non-breaking:** If a property value contains no `=`, the Form Designer behaves **exactly as before** (same parsing, same code generation).