### PR TITLE
Prevents the tab from moving when activated

### DIFF
--- a/PureBasicIDE/TabBarGadget.pbi
+++ b/PureBasicIDE/TabBarGadget.pbi
@@ -1957,6 +1957,8 @@ Procedure TabBarGadget_Examine(*TabBarGadget.TabBarGadget)
         UnlockMutex(TabBarGadgetInclude\Timer\Mutex)
       Case #PB_EventType_MouseLeave
         \HoverItem       = #Null
+        \MoveItem        = #Null
+        \ReadyToMoveItem = #Null
       Case #PB_EventType_LeftDoubleClick
         If TabBarGadgetInclude\EnableDoubleClickForNewTab And \HoverArrow = #Null And \HoverItem = #Null
           PostEvent(#PB_Event_Gadget, \Window, \Number, #TabBarGadget_EventType_NewItem, \EventTab)


### PR DESCRIPTION
PB v6.40b4, macOS Tahoe 26.3.2

When switching between tabs with a mouse click, a tab may sometimes move even after the mouse button has been released.
This happens when the tabs are sometimes displaying the ‘Error Log’ and sometimes not. In such cases, the ‘LeftButtonUp’ event is not triggered, or rather, it does not reach the TabBarGadget.

See the forum post:
IDE - Switching to a different code tab moves the tab
https://www.purebasic.fr/english/viewtopic.php?t=88543

Solution by STARGATE:
https://www.purebasic.fr/english/viewtopic.php?p=653197#p653197