### PR TITLE
Resize #GADGET_ProjectInfo_FrameFiles following PR #341

### DIFF
--- a/PureBasicIDE/ProjectManagement.pb
+++ b/PureBasicIDE/ProjectManagement.pb
@@ -454,7 +454,7 @@ Procedure ResizeProjectInfo(Width, Height)
   ResizeGadget(#GADGET_ProjectInfo_OpenOptions, Width-30-ButtonWidth-BorderOffset, 25+ProjectInfoFrameHeight-BorderOffset, ButtonWidth, Button1Height)
   ResizeGadget(#GADGET_ProjectInfo_OpenCompilerOptions, Width-30-ButtonWidth-BorderOffset, 30+ProjectInfoFrameHeight+Button1Height-BorderOffset, ButtonWidth, Button1Height)
   
-  ResizeGadget(#GADGET_ProjectInfo_FrameFiles, 20-BorderOffset, InfoHeight+20-BorderOffset, Width-40, PartFilesHeight)
+  ResizeGadget(#GADGET_ProjectInfo_FrameFiles, 20-BorderOffset, InfoHeight+20-BorderOffset, Width-40, PartFilesHeight+Button1Height+5)
   ResizeGadget(#GADGET_ProjectInfo_FilterInput, 30-BorderOffset, InfoHeight+25+ProjectInfoFrameHeight-BorderOffset, 200, Button1Height)
   ResizeGadget(#GADGET_ProjectInfo_SortFiles, 240-BorderOffset, InfoHeight+25+ProjectInfoFrameHeight-BorderOffset, 200, Button1Height)
   ResizeGadget(#GADGET_ProjectInfo_Files, 30-BorderOffset, InfoHeight+30+ProjectInfoFrameHeight+Button1Height-BorderOffset, Width-60, PartFilesHeight-15-ProjectInfoFrameHeight)


### PR DESCRIPTION
Tiny update to resize #GADGET_ProjectInfo_FrameFiles height on ProjectManagement.pb, following PR [#341](https://github.com/fantaisie-software/purebasic/pull/341) "sort and Filter Project Files". 
The frame height wasn't adjusted to fit tits content with the new #GADGET_ProjectInfo_FilterInput,  my fault!