### PR TITLE
Add/Remove Scintilla shortcuts for MacOS too

### DIFF
--- a/PureBasicIDE/Commandline.pb
+++ b/PureBasicIDE/Commandline.pb
@@ -415,21 +415,22 @@ Procedure ParseCommandline()
           DontCreateExtensions = 1
           
         Case "/LOCAL"
+          ; Keep PreferencesFile$, TemplatesFile$,... if already defined using -p “PreferenceFile”, -t “TemplatesFile”,... before /PORTABLE switch
           Directory$ = GetPathPart(ProgramFilename())
-          PreferencesFile$ = Directory$ + #PreferenceFileName$
-          TemplatesFile$   = Directory$ + "Templates.prefs"
-          AddToolsFile$    = Directory$ + "Tools.prefs"
-          HistoryDatabaseFile$ = Directory$ + "History.db"
+          If PreferencesFile$     = "" : PreferencesFile$ = Directory$ + #PreferenceFileName$ : EndIf
+          If TemplatesFile$       = "" : TemplatesFile$   = Directory$ + "Templates.prefs"    : EndIf
+          If AddToolsFile$        = "" : AddToolsFile$    = Directory$ + "Tools.prefs"        : EndIf
+          If HistoryDatabaseFile$ = "" : HistoryDatabaseFile$ = Directory$ + "History.db"     : EndIf
           UpdateCheckFile$ = Directory$+ "UpdateCheck.xml"
           
         Case "/PORTABLE"
           DontCreateExtensions = 1  ; implies /NOEXT as well
-          
+          ; Keep PreferencesFile$, TemplatesFile$,... if already defined using -p “PreferenceFile”, -t “TemplatesFile”,... before /PORTABLE switch
           Directory$ = GetPathPart(ProgramFilename())
-          PreferencesFile$ = Directory$ + #PreferenceFileName$
-          TemplatesFile$   = Directory$ + "Templates.prefs"
-          AddToolsFile$    = Directory$ + "Tools.prefs"
-          HistoryDatabaseFile$ = Directory$ + "History.db"
+          If PreferencesFile$     = "" : PreferencesFile$ = Directory$ + #PreferenceFileName$ : EndIf
+          If TemplatesFile$       = "" : TemplatesFile$   = Directory$ + "Templates.prefs"    : EndIf
+          If AddToolsFile$        = "" : AddToolsFile$    = Directory$ + "Tools.prefs"        : EndIf
+          If HistoryDatabaseFile$ = "" : HistoryDatabaseFile$ = Directory$ + "History.db"     : EndIf
           UpdateCheckFile$ = Directory$+ "UpdateCheck.xml"
           
         CompilerEndIf

--- a/PureBasicIDE/Commandline.pb
+++ b/PureBasicIDE/Commandline.pb
@@ -415,22 +415,21 @@ Procedure ParseCommandline()
           DontCreateExtensions = 1
           
         Case "/LOCAL"
-          ; Keep PreferencesFile$, TemplatesFile$,... if already defined using -p “PreferenceFile”, -t “TemplatesFile”,... before /PORTABLE switch
           Directory$ = GetPathPart(ProgramFilename())
-          If PreferencesFile$     = "" : PreferencesFile$ = Directory$ + #PreferenceFileName$ : EndIf
-          If TemplatesFile$       = "" : TemplatesFile$   = Directory$ + "Templates.prefs"    : EndIf
-          If AddToolsFile$        = "" : AddToolsFile$    = Directory$ + "Tools.prefs"        : EndIf
-          If HistoryDatabaseFile$ = "" : HistoryDatabaseFile$ = Directory$ + "History.db"     : EndIf
+          PreferencesFile$ = Directory$ + #PreferenceFileName$
+          TemplatesFile$   = Directory$ + "Templates.prefs"
+          AddToolsFile$    = Directory$ + "Tools.prefs"
+          HistoryDatabaseFile$ = Directory$ + "History.db"
           UpdateCheckFile$ = Directory$+ "UpdateCheck.xml"
           
         Case "/PORTABLE"
           DontCreateExtensions = 1  ; implies /NOEXT as well
-          ; Keep PreferencesFile$, TemplatesFile$,... if already defined using -p “PreferenceFile”, -t “TemplatesFile”,... before /PORTABLE switch
+          
           Directory$ = GetPathPart(ProgramFilename())
-          If PreferencesFile$     = "" : PreferencesFile$ = Directory$ + #PreferenceFileName$ : EndIf
-          If TemplatesFile$       = "" : TemplatesFile$   = Directory$ + "Templates.prefs"    : EndIf
-          If AddToolsFile$        = "" : AddToolsFile$    = Directory$ + "Tools.prefs"        : EndIf
-          If HistoryDatabaseFile$ = "" : HistoryDatabaseFile$ = Directory$ + "History.db"     : EndIf
+          PreferencesFile$ = Directory$ + #PreferenceFileName$
+          TemplatesFile$   = Directory$ + "Templates.prefs"
+          AddToolsFile$    = Directory$ + "Tools.prefs"
+          HistoryDatabaseFile$ = Directory$ + "History.db"
           UpdateCheckFile$ = Directory$+ "UpdateCheck.xml"
           
         CompilerEndIf

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -2758,32 +2758,22 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     Select *scinotify\nmhdr\code
         
       Case #SCN_FOCUSIN
-        ; Restore the 4 keyboard shortcuts previously removed on #SCN_KILLFOCUS event. It is used in this ScintillaGadget
+        ; Restore the 4 keyboard shortcuts previously removed on #SCN_KILLFOCUS event. They are used in this ScintillaGadget
+        ; #PB_Shortcut_Command will act like #PB_Shortcut_Control on non-macOS 
         For item = 0 To #MENU_LastShortcutItem
           Select KeyboardShortcuts(item)
-            CompilerIf #CompileLinux | #CompileWindows
-              Case #PB_Shortcut_Control | #PB_Shortcut_C, #PB_Shortcut_Control | #PB_Shortcut_X, #PB_Shortcut_Control | #PB_Shortcut_V, #PB_Shortcut_Control | #PB_Shortcut_A
-                AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
-            CompilerElse ; MacOS
-              Case #PB_Shortcut_Command | #PB_Shortcut_C, #PB_Shortcut_Command | #PB_Shortcut_X, #PB_Shortcut_Command | #PB_Shortcut_V, #PB_Shortcut_Command | #PB_Shortcut_A
-                AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
-            CompilerEndIf
+            Case #PB_Shortcut_Command | #PB_Shortcut_C, #PB_Shortcut_Command | #PB_Shortcut_X, #PB_Shortcut_Command | #PB_Shortcut_V, #PB_Shortcut_Command | #PB_Shortcut_A
+              AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
           EndSelect
         Next
         
       Case #SCN_FOCUSOUT
         ; Remove the 4 main keyboard shortcuts to restore the standard behavior for StringGadget text
-        CompilerIf #CompileLinux | #CompileWindows
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_C)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_X)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_V)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_A)
-        CompilerElse ; MacOS
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_C)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_X)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_V)
-          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_A)
-        CompilerEndIf
+        ; #PB_Shortcut_Command will act like #PB_Shortcut_Control on non-macOS 
+        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_C)
+        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_X)
+        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_V)
+        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_A)
         
       Case #SCN_MODIFYATTEMPTRO
         ChangeStatus(Language("Debugger","EditError"), -1)

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -2761,18 +2761,30 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
         ; Restore the 4 keyboard shortcuts previously removed on #SCN_KILLFOCUS event. It is used in this ScintillaGadget
         For item = 0 To #MENU_LastShortcutItem
           Select KeyboardShortcuts(item)
-            Case #PB_Shortcut_Control | #PB_Shortcut_C, #PB_Shortcut_Control | #PB_Shortcut_X, #PB_Shortcut_Control | #PB_Shortcut_V, #PB_Shortcut_Control | #PB_Shortcut_A
-              AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
+            CompilerIf #CompileLinux | #CompileWindows
+              Case #PB_Shortcut_Control | #PB_Shortcut_C, #PB_Shortcut_Control | #PB_Shortcut_X, #PB_Shortcut_Control | #PB_Shortcut_V, #PB_Shortcut_Control | #PB_Shortcut_A
+                AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
+            CompilerElse ; MacOS
+              Case #PB_Shortcut_Command | #PB_Shortcut_C, #PB_Shortcut_Command | #PB_Shortcut_X, #PB_Shortcut_Command | #PB_Shortcut_V, #PB_Shortcut_Command | #PB_Shortcut_A
+                AddKeyboardShortcut(#WINDOW_Main, KeyboardShortcuts(item), item)
+            CompilerEndIf
           EndSelect
         Next
         
       Case #SCN_FOCUSOUT
         ; Remove the 4 main keyboard shortcuts to restore the standard behavior for StringGadget text
-        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_C)
-        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_X)
-        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_V)
-        RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_A)
-      
+        CompilerIf #CompileLinux | #CompileWindows
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_C)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_X)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_V)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Control | #PB_Shortcut_A)
+        CompilerElse ; MacOS
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_C)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_X)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_V)
+          RemoveKeyboardShortcut(#WINDOW_Main, #PB_Shortcut_Command | #PB_Shortcut_A)
+        CompilerEndIf
+        
       Case #SCN_MODIFYATTEMPTRO
         ChangeStatus(Language("Debugger","EditError"), -1)
         CompilerIf #CompileWindows
@@ -2784,7 +2796,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
         
       Case #SCN_SAVEPOINTREACHED
         UpdateSourceStatus(-1)
-                
+        
         ; Note: This check is done in a separate event callback for linux,
         ;   as we have no way of knowing the modifier keys here in the
         ;   scintilla callback


### PR DESCRIPTION
Add/Remove Scintilla shortcuts on #SCN_FOCUSIN, #SCN_FOCUSOUT for MacOS too, using #PB_Shortcut_Command (rather than #PB_Shortcut_Control for windows and Linux).

It should be good, but I don't have a Mac to test it!