### PR TITLE
Fix XML LibraryViewer crash on 64-bit

### DIFF
--- a/PureBasicDebugger/Plugin_Xml.pb
+++ b/PureBasicDebugger/Plugin_Xml.pb
@@ -15,15 +15,15 @@
 ;
 Structure Plugin_Xml
   ; Xml Object
-  XmlID.l
+  XmlID.i
   
   ; Gadgets
-  Tree.l
-  Panel.l
-  Splitter.l
-  Info.l
-  Attributes.l
-  Text.l
+  Tree.i
+  Panel.i
+  Splitter.i
+  Info.i
+  Attributes.i
+  Text.i
 EndStructure
 
 ; count children and grandchildren


### PR DESCRIPTION
See bug report here: www.purebasic.fr/english/viewtopic.php?t=87857

The XML LibraryViewer was crashing on 64-bit systems. (In my testing: Windows IDE crashed "silently", Mac crashed with Seg Fault message, Linux didn't crash but no XML tree was displayed)

The cause was an old structure that didn't get updated. :warning: Plugin_Xml was still using 32-bit .l to store dynamic XML and Gadget IDs, which were getting truncated and corrupted on 64-bit builds.

Now tests OK on Linux x64, XML tree and attribute panels display correctly.