### PR TITLE
Fix IDE keyword-match underlining at end-of-line and on multi-byte lines

### DIFF
--- a/PureBasicDebugger/Standalone_ScintillaStuff.pb
+++ b/PureBasicDebugger/Standalone_ScintillaStuff.pb
@@ -16,7 +16,7 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
     *WordStart.Character = *Buffer
     *WordEnd.Character   = *Buffer + BufferLength
     
-    If Position >= 0 And Position < BufferLength+#CharSize And (Mode = 1 Or Position < BufferLength)
+    If Position >= 0 And Position < BufferLength+#CharSize And (Mode = 1 Or Position <= BufferLength)
       *Cursor.Character = *Buffer + Position*#CharSize
       
       If Mode = 1 ; Needed for Auto-complete

--- a/PureBasicIDE/HighlightingFunctions.pb
+++ b/PureBasicIDE/HighlightingFunctions.pb
@@ -35,7 +35,7 @@ Procedure GetWordBoundary(*Buffer, BufferLength, Position, *StartIndex.INTEGER, 
   *WordStart.Character = *Buffer
   *WordEnd.Character   = *Buffer + BufferLength * #CharSize
   
-  If Position >= 0 And Position < BufferLength+#CharSize And (Mode = 1 Or Position < BufferLength)
+  If Position >= 0 And Position < BufferLength+#CharSize And (Mode = 1 Or Position <= BufferLength)
     *Cursor.Character = *Buffer + Position*#CharSize
     
     If Mode = 1 ; Needed for Auto-complete

--- a/PureBasicIDE/ScintillaHighlighting.pb
+++ b/PureBasicIDE/ScintillaHighlighting.pb
@@ -2502,11 +2502,13 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
               EndIf
               
               ; Mark the original item
+              ; (use *OriginalItem's byte-based Position/Length, not the char-based StartIndex/EndIndex from
+              ; GetWordBoundary(), which would misplace the indicator on lines with multi-byte UTF-8 characters)
               If IsMatch
                 If Colors(#COLOR_GoodBrace)\Enabled
                   SendEditorMessage(#SCI_SETINDICATORCURRENT, #INDICATOR_KeywordMatch)
-                  SendEditorMessage(#SCI_INDICATORFILLRANGE, SendEditorMessage(#SCI_POSITIONFROMLINE, OriginalLine)+StartIndex, EndIndex-StartIndex+1)
-                  
+                  SendEditorMessage(#SCI_INDICATORFILLRANGE, SendEditorMessage(#SCI_POSITIONFROMLINE, OriginalLine)+*OriginalItem\Position, *OriginalItem\Length)
+
                   ; Unfortunately, this does not seem to work. Would have been cool to highlight the matching indent guide,
                   ; but it just never changes the color. Dunno what to do about it.
                   ;                 If ShowIndentGuides And FirstMatchColumn = LastMatchColumn
@@ -2515,11 +2517,11 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
                   ;                   SendEditorMessage(#SCI_SETHIGHLIGHTGUIDE, Column)
                   ;                 EndIf
                 EndIf
-                
+
               ElseIf IsMismatch
                 If Colors(#COLOR_BadBrace)\Enabled
                   SendEditorMessage(#SCI_SETINDICATORCURRENT, #INDICATOR_KeywordMismatch)
-                  SendEditorMessage(#SCI_INDICATORFILLRANGE, SendEditorMessage(#SCI_POSITIONFROMLINE, OriginalLine)+StartIndex, EndIndex-StartIndex+1)
+                  SendEditorMessage(#SCI_INDICATORFILLRANGE, SendEditorMessage(#SCI_POSITIONFROMLINE, OriginalLine)+*OriginalItem\Position, *OriginalItem\Length)
                 EndIf
                 
               EndIf
@@ -2680,8 +2682,9 @@ CompilerIf #CompileWindows | #CompileLinux | #CompileMac
                     *Item = 0
                     
                     If FindBreakKeywords(@*ActiveSource\Parser, *OriginalItem, OriginalLine, Items())
+                      EndBytePosition = CharsToBytes(Line$, 0, *ActiveSource\Parser\Encoding, EndIndex)
                       ForEach Items()
-                        If Items()\Line > *ActiveSource\CurrentLine-1 Or (Items()\Line = *ActiveSource\CurrentLine-1 And Items()\Item\Position > EndIndex)
+                        If Items()\Line > *ActiveSource\CurrentLine-1 Or (Items()\Line = *ActiveSource\CurrentLine-1 And Items()\Item\Position > EndBytePosition)
                           *Item = Items()\Item
                           Line  = Items()\Line
                           Break


### PR DESCRIPTION
## Summary

Fixes two related bugs in the IDE editor's matching-keyword underlining, reported at https://www.purebasic.fr/english/viewtopic.php?t=82666 ("PB 6.03 - not work marking of matching keywords"):

- The underline failed to appear when the caret sat right after the last character of a line (e.g. right after `EndIf` at the very end of a line/file).
- The underline was misplaced on lines containing multi-byte UTF-8 characters (e.g. non-Latin text), because a character offset was used directly as a Scintilla byte offset without conversion.

## Changes

- **`GetWordBoundary()`** (`HighlightingFunctions.pb`, and its duplicate in `PureBasicDebugger/Standalone_ScintillaStuff.pb`, kept in sync per the existing "report to the IDE/standalone debugger" comment on both copies): relaxed the `Mode=0` guard from `Position < BufferLength` to `Position <= BufferLength`, matching the leniency already given to `Mode=1` (autocomplete). The character-scanning logic below the guard already handles running off the end of the line correctly; it just wasn't being allowed to run for this caret position.
- **`UpdateKeywordHighlight()`** (`ScintillaHighlighting.pb`): the "mark the original item" step used `StartIndex`/`EndIndex` — character offsets from `GetWordBoundary()` — directly as Scintilla byte offsets, instead of converting them like every other lookup in the function does. Now uses `*OriginalItem`'s already-correct byte-based `Position`/`Length`, consistent with how every other matched/mismatched item is highlighted in the same function.
- **`JumpToMatchingKeyword()`** (`ScintillaHighlighting.pb`): same byte/char mismatch, comparing a parser item's byte `Position` against a char-based `EndIndex`. Fixed by converting `EndIndex` to a byte offset via `CharsToBytes()` first.

## Test plan

- [x] `pbcompiler /CHECK /THREAD` on `PureBasicIDE/PureBasic.pb` — clean.
- [x] Full `/EXE` build of the IDE succeeds.
- [x] Manually verified in the built IDE: placing the caret immediately after the last character of a line (e.g. after `EndIf` at EOL) now underlines the matching keyword, matching the behavior when the caret is one position earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
