### PR TITLE
Fix IDE crash on extreme rapid Undo (out-of-bounds SourceLineCorrection)

### DIFF
--- a/PureBasicIDE/SourceParser.pb
+++ b/PureBasicIDE/SourceParser.pb
@@ -2034,16 +2034,25 @@ EndProcedure
 
 
 Procedure SourceLineCorrection(*Source.SourceFile, Line, LinesAdded)
-  If *Source\Parser\SourceItemArray And *Source\IsCode
+  If *Source\Parser\SourceItemArray And *Source\IsCode And LinesAdded <> 0
     *Array.ParsedLines = *Source\Parser\SourceItemArray
     Count              = *Source\Parser\SourceItemCount
-    
+    LastLine           = Line+Abs(LinesAdded) ; the range [Line, LastLine) is inserted/removed
+
+    ; Sanity check: the affected range must stay inside the currently tracked line count.
+    ; If the array and the real document line count ever drifted apart (which can happen
+    ; after a burst of rapid edits, e.g. holding down Ctrl+Z), blindly trusting Line/LastLine
+    ; below would let MoveMemory()/FreeSourceItems() walk past the allocated buffer and crash.
+    ; Rebuild the whole array from the live document instead - slower, but always safe.
+    If Line < 0 Or (LinesAdded < 0 And LastLine > Count) Or (LinesAdded > 0 And Line > Count)
+      FullSourceScan(*Source)
+      ProcedureReturn
+    EndIf
+
     ; Any parsing makes the sorted data invalid (as old items get freed)
     *Source\Parser\SortedValid = #False
-    
+
     If LinesAdded > 0
-      LastLine = Line+LinesAdded
-      
       ; need to realloc the buffer. Allocate some extra so there is no realloc for every newline
       If Count+LinesAdded > *Source\Parser\SourceItemSize
         *Array = ReAllocateMemory(*Array, (Count+LinesAdded+20) * SizeOf(ParsedLine))
@@ -2051,32 +2060,30 @@ Procedure SourceLineCorrection(*Source.SourceFile, Line, LinesAdded)
           *Source\Parser\SourceItemSize = Count+LinesAdded+20
         EndIf
       EndIf
-      
+
       If *Array
         MoveMemory(*Array + Line*SizeOf(ParsedLine), *Array + LastLine*SizeOf(ParsedLine), (Count-Line)*SizeOf(ParsedLine))
-        
+
         ; need to zero out the new entries, else we get a double free later!
         For i = Line To LastLine-1
           *Array\Line[i]\First = 0
           *Array\Line[i]\Last  = 0
         Next i
-        
+
         *Source\Parser\SourceItemArray = *Array
         *Source\Parser\SourceItemCount + LinesAdded
       EndIf
     Else
-      LastLine = Line-LinesAdded ; LinesAdded is negative here, so this is right!
-      
       ; free all entries of the gone lines
       For i = Line To LastLine-1
         FreeSourceItems(*Array\Line[i]\First)
         *Array\Line[i]\First = 0 ; just to be sure!
         *Array\Line[i]\Last  = 0
       Next i
-      
+
       ; no realloc needed here
       MoveMemory(*Array + LastLine*SizeOf(ParsedLine), *Array + Line*SizeOf(ParsedLine), (Count-LastLine)*SizeOf(ParsedLine))
-      
+
       *Source\Parser\SourceItemCount + LinesAdded
     EndIf
   EndIf


### PR DESCRIPTION
## Summary

Fixes a reported IDE crash when holding Ctrl+Z (rapid, extreme Undo):
https://www.purebasic.fr/english/viewtopic.php?t=88518

`SourceLineCorrection()` (in `PureBasicIDE/SourceParser.pb`), called from
the `#SCN_MODIFIED` handler on every Undo/Redo step, shifted the parser's
per-line array (a raw flexible-array struct with no bounds checking) using
`Line`/`LastLine` values derived from the current Scintilla notification,
without ever validating them against the array's own tracked line count.

If those two ever drifted apart, the delete branch could compute a
negative `(Count-LastLine)` byte count, which `MoveMemory()` reads as a
huge unsigned length, causing an out-of-bounds copy, or the free-loop
could walk past the end of the allocation freeing garbage pointers.
Either way: a hard crash. A long, rapid burst of Undo steps (holding
Ctrl+Z down) exercises this path far more than ordinary typing ever does.

- Add a bounds check that detects when the affected range would exceed
  the tracked line count and falls back to a full, safe rescan
  (`FullSourceScan()`) instead of performing the unsafe partial shift.

## Test plan

- [x] `make` builds the IDE cleanly with no errors/warnings from this change
- [x] Launched the built IDE, typed a batch of procedures, then fired
      ~9200 rapid Ctrl+Z presses (well past exhausting the real undo
      history, mirroring "holding it down past the beginning") — no
      crash, document correctly unwound back to its original content,
      Procedure list stayed accurate throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
